### PR TITLE
[codex] add reproducible instantiation params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-22
+
+### Added
+- `instantiate_with_params()` and `InstantiationOutput` for returning both the config value and replayable selected params.
+- `allow_none=True` for scalar params and `select`/`multi_select` choices.
+- Documentation for reproducible logging, replay, nullable params, and dict-backed select values.
+
+### Breaking Changes
+- `instantiate()`, `instantiate_with_params()`, and `explore()` now raise on unknown or unreachable `values` by default. Pass `on_unknown="warn"` or `on_unknown="ignore"` for softer behavior.
+- `hp.*` and `hp.nest` names must be valid Python identifiers. Replace literal dots, spaces, and hyphens with underscores, and let Hypster compose dotted paths from nesting.
+- Scalar parameters now require `allow_none=True` when `default=None` or a `None` override is valid.
+- `select` and `multi_select` choices must be logging-safe scalar values. Use dictionary-backed select to map simple keys to complex runtime objects.
+- Complex dictionary values in `values=` are interpreted as nested parameter paths, not as custom select values.
+
+### Changed
+- Nested dict `values` are normalized into dotted parameter paths for duplicate and unknown-value checks.
+- Nested dict keys must be valid identifier segments; use top-level dotted keys to spell full parameter paths.
+
+### Fixed
+- Unknown/unreachable value errors now guide users to run `explore(config, values=...)` to inspect the active branch.
+- Duplicate dotted and nested entries for the same parameter path now fail instead of silently choosing one value.
+- Invalid `on_unknown` policies are rejected before user config code executes.
+
 ## [0.3.10] - 2026-03-14
 
 ### Fixed

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,112 @@
+# Hypster
+
+Hypster is a Python configuration context for defining parameterized config functions, instantiating them into arbitrary Python values, and recording the parameter choices that make a run reproducible.
+
+## Language
+
+**Configuration Function**:
+A Python function that receives `hp` and returns the configured object or data for a run.
+_Avoid_: config space when referring to the executable function itself
+
+**Values**:
+User-provided parameter overrides passed into a configuration function.
+_Avoid_: params, selected params
+
+**Selected Params**:
+The complete, flat, dotted-path record of reachable `hp` parameter selections for one run, including defaults and using logging-friendly values that can be replayed through `values`.
+_Avoid_: input values, return value, logged objects
+
+**Select Choice**:
+A logging-friendly scalar value chosen directly from list-backed select options or used as the key for dictionary-backed select options.
+_Avoid_: mapped select value, returned option value
+
+**Explicit None**:
+`None` used intentionally as a selected parameter value.
+_Avoid_: missing default, not selected
+
+**Nullable Parameter**:
+A parameter whose domain explicitly includes **Explicit None** through `allow_none=True`.
+_Avoid_: optional when it means an omitted argument
+
+**Logging-Safe Value**:
+A value that can be logged and replayed directly: `None`, `bool`, `int`, `float`, `str`, or a list containing only those types.
+_Avoid_: arbitrary object, tuple, nested dict
+
+**Parameter Path**:
+A dotted name formed by Hypster from nested scopes and Python-identifier parameter names.
+_Avoid_: literal dots or path syntax inside parameter names
+
+**Instantiation Value**:
+The arbitrary Python value returned by a configuration function.
+_Avoid_: values, params
+
+**Instantiation Output**:
+The result of an execution that exposes both the **Instantiation Value** and its **Selected Params**.
+_Avoid_: replacing the raw return value of `instantiate`
+
+**Explore Schema**:
+Structured metadata describing the reachable parameters, defaults, bounds, options, and nesting for a configuration function branch.
+_Avoid_: selected params
+
+## Relationships
+
+- A **Configuration Function** can be executed with **Values**.
+- A **Configuration Function** produces one **Instantiation Value** per execution.
+- `instantiate` returns only the **Instantiation Value**; `instantiate_with_params` returns an **Instantiation Output**.
+- An **Instantiation Output** is a lightweight container with `value` and `params` attributes; `params` is a caller-owned plain dictionary copy.
+- `instantiate_with_params` accepts the same execution arguments and unknown-parameter policy as `instantiate`.
+- There is no params-only public API; selected params are exposed through `instantiate_with_params`.
+- Flat dotted **Selected Params** are the canonical replay/logging shape; no nested params helper is included in the first API.
+- **Selected Params** are derived from the reachable parameter calls in one execution, not from only the provided **Values**.
+- **Selected Params** exclude parameters from branches that were not reached in that execution.
+- **Selected Params** include only leaf `hp` parameter calls; `hp.nest` group names are namespaces, not selected parameters.
+- **Selected Params** use the same dotted names as **Values** so they can be replayed.
+- **Selected Params** are exposed as a plain flat dictionary.
+- **Selected Params** are collected from the same parameter-recording event that powers the **Explore Schema**.
+- Replaying an **Instantiation Output** through `instantiate(config, values=output.params)` must follow the same reachable parameter choices, but does not guarantee object identity or deterministic side effects outside the selected parameters.
+- HPO-generated **Values** use the same **Parameter Path** and **Select Choice** rules as execution-generated **Selected Params**.
+- Individual `hp` parameter names and `hp.nest` names must be valid Python identifiers and cannot be Python keywords.
+- **Values** keys must be valid **Parameter Paths**, where each dotted segment or nested-dict segment is a valid Python identifier and not a Python keyword.
+- `instantiate`, `instantiate_with_params`, and `explore` all use `on_unknown="raise"` by default.
+- Nested-dict **Values** participate in unknown/unreachable checking as their equivalent dotted **Parameter Paths**.
+- The `on_unknown` policy applies consistently after nested-dict **Values** are interpreted as dotted **Parameter Paths**.
+- **Values** must not specify the same **Parameter Path** through both dotted keys and nested dictionaries, even when both entries have the same value; duplicates always raise as malformed input and are not controlled by `on_unknown`.
+- Unknown/unreachable **Values** errors should guide users to `explore(config, values=...)` to inspect the active branch, but `instantiate` must not run extra branch exploration automatically.
+- List-backed `select` and `multi_select` parameters record their **Select Choices** in **Selected Params**.
+- Dictionary-backed `select` and `multi_select` parameters record **Select Choices** in **Selected Params**, even when the **Instantiation Value** uses mapped primitive or complex objects.
+- **Select Choices** must be logging-safe scalar values at parameter execution time, regardless of whether **Selected Params** are requested.
+- `options_only=False` permits custom **Select Choices** outside the declared options, but those choices must still be **Logging-Safe Values** and may only be `None` for a **Nullable Parameter**.
+- Dictionary-backed `select` and `multi_select` should be used when a logging-safe **Select Choice** needs to produce a complex mapped object in the **Instantiation Value**.
+- **Explicit None** is distinct from the absence of a default and requires an internal sentinel when an API parameter may omit `default`.
+- **Explicit None** is valid only for a **Nullable Parameter**.
+- `allow_none=True` is required when `default=None`, when a `None` override is accepted, and when `None` appears among `select` or `multi_select` choices.
+- `allow_none=True` applies to scalar parameters and select choices, including `multi_select`; nullable elements for `multi_int`, `multi_float`, `multi_text`, and `multi_bool` are not supported yet and must fail with clear guidance.
+- **Selected Params** contain only **Logging-Safe Values**.
+- An **Explore Schema** describes parameter metadata; it is not the run's **Selected Params**.
+
+## Documentation requirements
+
+- Show `instantiate_with_params` for logging all selected params, including defaults.
+- Show replaying `result.params` through `instantiate(..., values=result.params)`.
+- Show dictionary-backed `select` with logging-safe choices mapped to complex values.
+- Show `allow_none=True` examples for scalar params and select choices.
+- Document that `allow_none=True` supports `multi_select` choices but not nullable elements for `multi_int`, `multi_float`, `multi_text`, or `multi_bool`; include the error guidance.
+- Show that `instantiate_with_params` accepts the same execution arguments as `instantiate`, including `args`, `kwargs`, and `on_unknown`.
+- Replace the old "nested dict wins" docs with guidance that dotted and nested forms are both supported, but duplicate **Parameter Paths** fail.
+- Document that unknown/unreachable errors are based on the current execution path and that users should run `explore(config, values=...)` to inspect branches.
+
+## Example dialogue
+
+> **Dev:** "If the user only overrides `provider`, do we log only that value?"
+> **Domain expert:** "No. **Selected Params** must include defaults too, so the run can be reproduced and logged to tools like MLflow."
+
+## Flagged ambiguities
+
+- "params" was used to mean both user-provided **Values** and run-derived **Selected Params**; resolved: **Values** are inputs, **Selected Params** are the replayable output sidecar.
+- `select` was ambiguous between logging the returned mapped value and logging the user-facing choice; resolved: **Selected Params** record the **Select Choice** because it is replayable and logging-friendly.
+- `None` was ambiguous between **Explicit None** and missing default; resolved: these must be separate states internally.
+- Nullability was ambiguous when inferred from defaults or select options; resolved: `allow_none=True` explicitly marks a **Nullable Parameter**.
+- The result shape was ambiguous between changing `instantiate` and adding a sibling API; resolved: `instantiate` keeps returning the **Instantiation Value**, while `instantiate_with_params` returns an **Instantiation Output**.
+- A params-only shortcut was considered; resolved: skip it until there is a separate execution mode that can avoid constructing the **Instantiation Value**.
+- A nested params helper was considered; resolved: skip it because flat dotted **Selected Params** are the canonical replay/logging shape.
+- Literal dotted names and other path-like names were ambiguous with nested paths; resolved: individual names must be Python identifiers, while Hypster generates dotted **Parameter Paths**.

--- a/docs/adr/0001-strict-unknown-values.md
+++ b/docs/adr/0001-strict-unknown-values.md
@@ -1,0 +1,10 @@
+# Strict Unknown Values
+
+Hypster treats `values` as a reproducibility surface, so unknown or unreachable overrides should fail loudly by default instead of being silently logged or replayed incorrectly. We changed the default unknown-parameter policy for `instantiate`, `instantiate_with_params`, and `explore` to `raise`, while keeping `warn` and `ignore` available for callers who intentionally want softer behavior.
+
+## Consequences
+
+- Nested-dict `values` must participate in unknown/unreachable checking as their equivalent dotted parameter paths.
+- A parameter path specified more than once through mixed dotted and nested forms always raises as malformed input, even when the duplicate values are equal.
+- Unknown/unreachable errors should guide users to `explore(config, values=...)` to inspect the active branch, but `instantiate` must not execute extra branch exploration automatically.
+- This is stricter than the previous default, but it better matches logging and replay workflows where ignored overrides are usually bugs.

--- a/docs/getting-started/defining-a-configuration-space.md
+++ b/docs/getting-started/defining-a-configuration-space.md
@@ -86,7 +86,7 @@ This prints the reachable parameters, defaults, options, and nested scopes for t
 {% step %}
 #### Instantiation
 
-Execute your configuration and override parameters using `values=`. See "Values & Overrides" for dotted vs nested overrides and precedence.
+Execute your configuration and override parameters using `values=`. See "Values & Overrides" for dotted paths, nested dictionaries, and duplicate-key validation.
 
 ```python
 from hypster import instantiate
@@ -102,6 +102,6 @@ cfg = instantiate(
 # cfg -> {"model_name": "gpt-5", "temperature": 0.5, "max_tokens": 1024}
 ```
 
-Control unknown or unreachable values via `on_unknown`: `"warn"` (default), `"raise"`, or `"ignore"`.
+Unknown or unreachable values raise by default. Use `on_unknown="warn"` or `on_unknown="ignore"` only when you intentionally want softer handling.
 {% endstep %}
 {% endstepper %}

--- a/docs/getting-started/exploring-a-configuration-space.md
+++ b/docs/getting-started/exploring-a-configuration-space.md
@@ -25,6 +25,7 @@ def gemini(hp: HP):
         [None, "minimal", "elevated"],
         name="thinking_level",
         default=None,
+        allow_none=True,
     )
     return {"model": model, "thinking_level": thinking_level}
 
@@ -125,7 +126,7 @@ info.to_dict()
 # JSON-serializable nested structure
 ```
 
-By default, `explore()` also warns when `values=` contains unknown names or overrides for a branch that was not reached. Pass `on_unknown="raise"` to make that strict, or `on_unknown="ignore"` to silence it.
+By default, `explore()` raises when `values=` contains unknown names or overrides for a branch that was not reached. Pass `on_unknown="warn"` to inspect while warning, or `on_unknown="ignore"` to silence it.
 
 ## When to use `explore()` vs `instantiate()`
 

--- a/docs/getting-started/instantiating-a-configuration-space.md
+++ b/docs/getting-started/instantiating-a-configuration-space.md
@@ -1,8 +1,8 @@
 # ⚡ Instantiating a Config Function
 
-Use `instantiate(func, values=...)` to execute your configuration function with optional overrides.
+Use `instantiate(func, values=...)` to execute a configuration function with optional overrides.
 
-If you want to inspect the available parameters first, use [`explore()`](exploring-a-configuration-space.md) before instantiating.
+If you want to inspect the active parameters first, use [`explore()`](exploring-a-configuration-space.md).
 
 ```python
 from hypster import instantiate
@@ -15,12 +15,46 @@ result = instantiate(model_cfg, values={
 # => {"model": ("rf", 200, 12.5)}
 ```
 
+## Logging selected params
+
+Use `instantiate_with_params()` when you need a replayable record for experiment tracking tools such as MLflow. The returned `params` dictionary includes every reachable `hp.*` parameter on that run, including defaults the user did not override.
+
+```python
+from hypster import HP, instantiate, instantiate_with_params
+
+def llm_config(hp: HP):
+    provider = hp.select(["gemini", "openai"], name="provider", default="gemini")
+    temperature = hp.float(0.2, name="temperature", min=0.0, max=2.0)
+    return {"provider": provider, "temperature": temperature}
+
+run = instantiate_with_params(llm_config, values={"provider": "openai"})
+
+run.value
+# => {"provider": "openai", "temperature": 0.2}
+
+run.params
+# => {"provider": "openai", "temperature": 0.2}
+
+replayed = instantiate(llm_config, values=run.params)
+assert replayed == run.value
+```
+
+`instantiate_with_params()` accepts the same `values`, `args`, `kwargs`, and `on_unknown` arguments as `instantiate()`. It does not change what your config returns; it adds a sidecar for logging and replay.
+
 ## Unknown parameters
 
-Control how unknown or conditionally unreachable values are handled via `on_unknown`:
-- `on_unknown="warn"` (default): issue a warning and continue
-- `on_unknown="raise"`: raise a `ValueError`
-- `on_unknown="ignore"`: silently ignore
+Unknown or conditionally unreachable values raise by default:
+
+```python
+instantiate(model_cfg, values={"n_trees": 200})
+# ValueError: Unknown or unreachable parameters:
+#   - 'n_trees': Unknown parameter
+#
+# Run explore(config, values=...) to inspect the active branch.
+# Nested dict values are interpreted as parameter paths; use dict-backed select keys for objects.
+```
+
+Use `on_unknown="warn"` or `on_unknown="ignore"` only when you intentionally want softer handling:
 
 ```python
 instantiate(model_cfg, values={"n_trees": 200}, on_unknown="warn")
@@ -28,9 +62,27 @@ instantiate(model_cfg, values={"n_trees": 200}, on_unknown="warn")
 
 ## Dotted keys vs nested dicts
 
-See In Depth → Values & Overrides for how to pass nested overrides and precedence.
+See [Values & Overrides](../in-depth/values-and-overrides.md) for dotted paths, nested dicts, and duplicate-key validation.
 
 The same `values=` format also works with `explore()` when you want to inspect a specific conditional branch.
+
+## Nullable parameters
+
+`None` is an explicit value in Hypster, not a marker for "not selected". Use `allow_none=True` when `None` is part of a parameter's domain:
+
+```python
+def config(hp: HP):
+    max_depth = hp.int(None, name="max_depth", allow_none=True)
+    thinking_level = hp.select(
+        [None, "low", "medium", "high"],
+        name="thinking_level",
+        default=None,
+        allow_none=True,
+    )
+    return {"max_depth": max_depth, "thinking_level": thinking_level}
+```
+
+Nullable elements are supported for `multi_select(..., allow_none=True)`. They are not supported for `multi_int`, `multi_float`, `multi_text`, or `multi_bool`; those calls raise with guidance if `allow_none=True` is passed.
 
 ## Passing args/kwargs to nested configs
 
@@ -47,3 +99,4 @@ def parent(hp: HP):
     calc1 = hp.nest(child, name="calc1", args=(2,))
     calc2 = hp.nest(child, name="calc2", args=(3,), kwargs={"offset": 10})
     return {"calc1": calc1, "calc2": calc2}
+```

--- a/docs/in-depth/hp-call-types/bool-and-multi-bool.md
+++ b/docs/in-depth/hp-call-types/bool-and-multi-bool.md
@@ -6,10 +6,11 @@ Hypster provides boolean parameter configuration through `bool` and `multi_bool`
 
 ```python
 def bool(
-    default: bool,
+    default: Optional[bool],
     *,
-    name: str
-) -> bool
+    name: str,
+    allow_none: bool = False
+) -> Optional[bool]
 
 def multi_bool(
     default: List[bool] = [],
@@ -17,6 +18,18 @@ def multi_bool(
     name: str
 ) -> List[bool]
 ```
+
+## Nullable boolean values
+
+Use `allow_none=True` when `None` is an intentional tri-state value:
+
+```python
+def stream_config(hp: HP):
+    stream = hp.bool(None, name="stream", allow_none=True)
+    return {"stream": stream}
+```
+
+Nullable elements are not supported for `multi_bool`; use `multi_select(..., allow_none=True)` for nullable categorical lists.
 
 ## Usage Examples
 

--- a/docs/in-depth/hp-call-types/int-and-multi-int.md
+++ b/docs/in-depth/hp-call-types/int-and-multi-int.md
@@ -10,12 +10,13 @@ Hypster provides flexible numeric parameter configuration through `int`, `multi_
 
 ```python
 def int(
-    default: int,
+    default: Optional[int],
     *,
     name: str,
     min: Optional[int] = None,
-    max: Optional[int] = None
-) -> int
+    max: Optional[int] = None,
+    allow_none: bool = False
+) -> Optional[int]
 
 def multi_int(
     default: List[int] = [],
@@ -30,12 +31,13 @@ def multi_int(
 
 ```python
 def float(
-    default: float,
+    default: Optional[float],
     *,
     name: str,
     min: Optional[float] = None,
-    max: Optional[float] = None
-) -> float
+    max: Optional[float] = None,
+    allow_none: bool = False
+) -> Optional[float]
 
 def multi_float(
     default: List[float] = [],
@@ -110,6 +112,22 @@ def training_config(hp: HP):
         "learning_rates": learning_rates
     }
 ```
+
+## Nullable numeric values
+
+Use `allow_none=True` when `None` is a real scalar value:
+
+```python
+def tree_config(hp: HP):
+    max_depth = hp.int(None, name="max_depth", allow_none=True)
+    dropout = hp.float(0.1, name="dropout", min=0.0, max=1.0, allow_none=True)
+    return {"max_depth": max_depth, "dropout": dropout}
+
+instantiate(tree_config, values={"dropout": None})
+# => {"max_depth": None, "dropout": None}
+```
+
+Nullable elements are not supported for `multi_int` or `multi_float`. Use `multi_select(..., allow_none=True)` for nullable categorical lists.
 
 ### Valid Examples
 

--- a/docs/in-depth/hp-call-types/select-and-multi-select.md
+++ b/docs/in-depth/hp-call-types/select-and-multi-select.md
@@ -1,285 +1,122 @@
-# Selectable Types
+# Select & Multi-Select
 
-The `select` and `multi_select` methods enable categorical parameter configuration. These methods support both single and multiple value selection with flexible validation options.
+Use `hp.select()` and `hp.multi_select()` for categorical choices.
 
-I'll help improve the documentation for the select and multi\_select parameters by adding the requested information. Here's the enhanced version:
+Selected choices are part of Hypster's reproducibility surface. They are what `instantiate_with_params(...).params` records and what you pass back through `values=...` to replay a run.
 
-## Select & Multi\_select Parameters
+## List form
 
-The `select` and `multi_select` methods enable categorical parameter configuration using either lists or dictionaries. These methods support both single and multiple value selection with flexible validation options.
-
-### Function Signatures
-
-#### select
-
-```python
-def select(
-    options: Union[Dict[ValidKeyType, Any], List[ValidKeyType]],
-    *,
-    name: str,
-    default: Optional[ValidKeyType] = None,
-    options_only: bool = False
-) -> Any
-```
-
-#### multi\_select
-
-```python
-def multi_select(
-    options: Union[Dict[ValidKeyType, Any], List[ValidKeyType]],
-    *,
-    name: str,
-    default: List[ValidKeyType] = None,
-    options_only: bool = False
-) -> List[Any]
-```
-
-### Parameters
-
-* `options`: Either a list of valid values or a dictionary mapping keys to values
-* `default`: Default value(s) if none provided (single value for select, list for multi\_select)
-* `options_only`: When True, only allows values from the predefined options
-
-## Pre-defined Parameter Forms
-
-### List Form
-
-Use when the parameter keys and values are identical:
+Use list form when the logged choice and returned value are the same simple value:
 
 ```python
 from hypster import HP, instantiate
 
-def model_config(hp: HP):
-    # Single selection from list
-    model_type = hp.select(["haiku", "sonnet"], name="model_type", default="haiku")
+def config(hp: HP):
+    model = hp.select(["haiku", "sonnet"], name="model", default="haiku")
+    features = hp.multi_select(["cache", "trace"], name="features", default=["cache"])
+    return {"model": model, "features": features}
 
-    # Multiple selection from list
-    features = hp.multi_select(["price", "size", "color"], name="features", default=["price", "size"])
-
-    return {
-        "model_type": model_type,
-        "features": features
-    }
-
-# Usage
-cfg = instantiate(model_config, values={"model_type": "sonnet", "features": ["price", "color"]})
+instantiate(config, values={"model": "sonnet", "features": ["cache", "trace"]})
+# => {"model": "sonnet", "features": ["cache", "trace"]}
 ```
 
-### Dictionary Form
+List-form choices must be logging-safe scalar values: `None`, `bool`, `int`, `float`, or `str`. If you need a complex object, use dictionary form.
 
-Use when parameter keys need to map to different values:
+## Dictionary form
 
-```python
-from hypster import HP, instantiate
-
-def llm_config(hp: HP):
-    # Single selection with value mapping
-    model = hp.select({
-        "haiku": "claude-3-haiku-20240307",
-        "sonnet": "claude-3-sonnet-20240229"
-    }, name="model", default="haiku")
-
-    # Multiple selection with object mapping
-    callbacks = hp.multi_select({
-        "cost": cost_callback,
-        "runtime": runtime_callback
-    }, name="callbacks", default=["cost"])
-
-    return {
-        "model": model,
-        "callbacks": callbacks
-    }
-
-# Usage
-cfg = instantiate(llm_config, values={"model": "sonnet", "callbacks": ["cost", "runtime"]})
-```
-
-### Value Resolution
-
-When using dictionary form, the configuration system maps input keys to their corresponding values:
+Use dictionary form when a simple logged key should return a different value. The key is logged and replayed; the mapped value is returned from the config.
 
 ```python
-from hypster import HP, instantiate
+from hypster import HP, instantiate_with_params
 
-def my_config(hp: HP):
-    # Configuration definition with dictionary mapping
-    model = hp.select({
-        "haiku": "claude-3-haiku-20240307",
-        "sonnet": "claude-3-sonnet-20240229"
-    }, name="model", default="haiku")
-
+def config(hp: HP):
+    model = hp.select(
+        {
+            "small": {"layers": 2, "units": [64, 32]},
+            "large": {"layers": 4, "units": [256, 128]},
+        },
+        name="model",
+        default="small",
+    )
     return {"model": model}
 
-# Usage - keys are mapped to their values
-config1 = instantiate(my_config, values={"model": "haiku"})
-# config1 -> {"model": "claude-3-haiku-20240307"}
+run = instantiate_with_params(config, values={"model": "large"})
 
-config2 = instantiate(my_config, values={"model": "sonnet"})
-# config2 -> {"model": "claude-3-sonnet-20240229"}
+run.value
+# => {"model": {"layers": 4, "units": [256, 128]}}
+
+run.params
+# => {"model": "large"}
 ```
 
-#### When to Use Dictionary Form?
+Dictionary form is the recommended way to return:
 
-Dictionary form is recommended when working with:
-
-* Long string values: `{"haiku": "claude-3-haiku-20240307"}`
-* Precise numeric values: `{"small": 1.524322}`
-* Object references: `{"rf": RandomForest(n_estimators=100)}`
-* None values: `{"none": None}`
-* Complex objects like tuples: `{"small": (1, 2)}`
-
-#### Special Value Examples
-
-Dictionary form enables you to define None values and complex objects that cannot be easily represented in list form:
+* objects or callables
+* dictionaries, lists, tuples, or dataclasses
+* long provider/model IDs behind short aliases
+* `None` as a returned value without making `None` the logged choice
 
 ```python
-from hypster import HP, instantiate
-
-def nlp_config(hp: HP):
-    # None values - useful for optional parameters
-    tokenizer = hp.select({
-        "none": None,
-        "basic": "basic_tokenizer",
-        "advanced": "advanced_tokenizer"
-    }, name="tokenizer", default="none")
-    
-    # N-gram ranges as tuples
-    ngram_range = hp.select({
-        "unigram": (1, 1),
-        "bigram": (1, 2), 
-        "trigram": (1, 3)
-    }, name="ngram_range", default="bigram")
-    
-    # Complex objects like lists or dicts
-    model_params = hp.select({
-        "small": {"layers": 2, "units": [64, 32]},
-        "large": {"layers": 4, "units": [256, 128, 64, 32]}
-    }, name="model_params", default="small")
-    
-    return {
-        "tokenizer": tokenizer,
-        "ngram_range": ngram_range,
-        "model_params": model_params
-    }
-
-# Usage examples
-cfg1 = instantiate(nlp_config)
-# cfg1 -> {"tokenizer": None, "ngram_range": (1, 2), "model_params": {"layers": 2, "units": [64, 32]}}
-
-cfg2 = instantiate(nlp_config, values={"tokenizer": "advanced", "ngram_range": "trigram"})
-# cfg2 -> {"tokenizer": "advanced_tokenizer", "ngram_range": (1, 3), "model_params": {"layers": 2, "units": [64, 32]}}
+tokenizer = hp.select(
+    {"none": None, "basic": "basic_tokenizer"},
+    name="tokenizer",
+    default="none",
+)
 ```
 
-## Default Values
+Here the selected param is `"none"` and the returned value is `None`.
 
-The `default` parameter must be a valid option from the predefined choices. For dictionary form, the default must be one of the keys (not values).
+## Explicit None
 
-### List Form Defaults
-
-When using list form, the default must be one of the items in the list:
+If `None` itself is a selectable choice or override, mark the parameter as nullable with `allow_none=True`:
 
 ```python
-# Valid defaults
-model = hp.select(["haiku", "sonnet"], default="haiku")  # OK: "haiku" is in list
-features = hp.multi_select(["price", "size"], default=["price", "size"])  # OK: "price" and "size" are in list
-
-# Invalid defaults - will raise errors
-model = hp.select(["haiku", "sonnet"], default="opus")  # Error: "opus" not in list
-features = hp.multi_select(["price", "size"], default=["color"])  # Error: "color" not in list
+def config(hp: HP):
+    thinking_level = hp.select(
+        [None, "low", "medium", "high"],
+        name="thinking_level",
+        default=None,
+        allow_none=True,
+    )
+    features = hp.multi_select(
+        [None, "cache", "trace"],
+        name="features",
+        default=[None],
+        allow_none=True,
+    )
+    return {"thinking_level": thinking_level, "features": features}
 ```
 
-### Dictionary Form Defaults
+Without `allow_none=True`, `None` defaults, choices, and overrides raise with guidance. This keeps "explicitly selected `None`" separate from "no default was supplied".
 
-When using dictionary form, the default must be one of the dictionary keys:
+## Custom choices
+
+By default, `options_only=False`, so callers may provide a custom choice outside the declared options:
 
 ```python
-# Valid defaults
-model = hp.select({
-    "haiku": "claude-3-haiku-20240307",
-    "sonnet": "claude-3-sonnet-20240229"
-}, default="haiku")  # OK: "haiku" is a key
+def config(hp: HP):
+    return hp.select(["haiku", "sonnet"], name="model")
 
-callbacks = hp.multi_select({
-    "cost": cost_callback,
-    "runtime": runtime_callback
-}, default=["cost"])  # OK: "cost" is a key
-
-# Invalid defaults - will raise errors
-model = hp.select({
-    "haiku": "claude-3-haiku-20240307",
-    "sonnet": "claude-3-sonnet-20240229"
-}, default="claude-3-haiku-20240307")  # Error: using value instead of key
-
-callbacks = hp.multi_select({
-    "cost": cost_callback,
-    "runtime": runtime_callback
-}, default=["timing"])  # Error: "timing" is not a key
+instantiate(config, values={"model": "opus"})
+# => "opus"
 ```
 
-### Instantiating With Missing Default Values
-
-If no default is provided, a value must be specified during configuration:
+Custom choices must still be logging-safe scalar values. Use `options_only=True` to reject anything outside the declared options:
 
 ```python
-# No default provided
-model = hp.select(["haiku", "sonnet"])
+def config(hp: HP):
+    return hp.select(["haiku", "sonnet"], name="model", options_only=True)
 
-# Must provide value during configuration
-config = my_config(values={"model": "haiku"})  # OK
-config = my_config()  # Error: no default and no value provided
+instantiate(config, values={"model": "opus"})
+# ValueError: 'opus' not in allowed options
 ```
 
-## Value Validation
+## Names
 
-The `options_only` parameter determines how strictly values are validated:
-
-```python
-# Flexible validation - allows any value (default)
-model = hp.select(["haiku", "sonnet"], options_only=False)
-
-# Strict validation - only predefined options allowed
-model = hp.select(["haiku", "sonnet"], options_only=True)
-```
-
-### Valid Instantiation Examples
+`name=` must be a valid Python identifier and cannot be a Python keyword. Hypster composes dotted parameter paths from nested names, so literal dots, spaces, and hyphens are not allowed in individual names.
 
 ```python
-from hypster import HP, instantiate
-
-def my_config(hp: HP):
-    model_type = hp.select(["haiku", "sonnet"], name="model_type", options_only=False)
-    return {"model_type": model_type}
-
-# Using predefined values
-cfg1 = instantiate(my_config, values={"model_type": "haiku"})
-
-# Using custom values (when options_only=False)
-cfg2 = instantiate(my_config, values={"model_type": "claude-3-opus-20240229"})
-```
-
-### Invalid Instantiation Examples
-
-```python
-def strict_config(hp: HP):
-    model_type = hp.select(["haiku", "sonnet"], name="model_type", options_only=True)
-    return {"model_type": model_type}
-
-# This will raise an error - value not in options list when options_only=True
-cfg = instantiate(strict_config, values={"model_type": "claude-3-opus-20240229"})
-```
-
-## Required Name Parameter
-
-{% hint style="warning" %}
-All `hp.*` calls that you want to be overrideable must include an explicit `name="..."` argument.
-{% endhint %}
-
-```python
-# Correct usage - explicit names
-model_type = hp.select(["haiku", "sonnet"], name="model_type")
-features = hp.multi_select(["price", "size", "color"], name="features")
-
-# Incorrect usage - missing names (will raise error)
-model_type = hp.select(["haiku", "sonnet"])  # Error: missing name
-features = hp.multi_select(["price", "size", "color"])  # Error: missing name
+hp.select(["a", "b"], name="model_type")  # OK
+hp.select(["a", "b"], name="model.type")  # Error
+hp.select(["a", "b"], name="model-type")  # Error
 ```

--- a/docs/in-depth/hp-call-types/text-and-multi-text.md
+++ b/docs/in-depth/hp-call-types/text-and-multi-text.md
@@ -6,10 +6,11 @@ Hypster provides string parameter configuration through `text` and `multi_text` 
 
 ```python
 def text(
-    default: str,
+    default: Optional[str],
     *,
-    name: str
-) -> str
+    name: str,
+    allow_none: bool = False
+) -> Optional[str]
 
 def multi_text(
     default: List[str] = [],
@@ -17,6 +18,18 @@ def multi_text(
     name: str
 ) -> List[str]
 ```
+
+## Nullable text values
+
+Use `allow_none=True` when `None` is an intentional text value:
+
+```python
+def llm_config(hp: HP):
+    system_prompt = hp.text(None, name="system_prompt", allow_none=True)
+    return {"system_prompt": system_prompt}
+```
+
+Nullable elements are not supported for `multi_text`; use `multi_select(..., allow_none=True)` for nullable categorical lists.
 
 ## Usage Examples
 

--- a/docs/in-depth/nest.md
+++ b/docs/in-depth/nest.md
@@ -1,209 +1,112 @@
-# 🪆 Nested Configurations
+# Nested Configurations
 
-Hypster enables hierarchical configuration management through the `hp.nest()` method, allowing you to compose complex configurations from smaller, reusable components.
-
-> For an in depth tutorial, please check out the article on Medium: [**Implementing Modular-RAG using Haystack and Hypster**](https://towardsdatascience.com/implementing-modular-rag-with-haystack-and-hypster-d2f0ecc88b8f)
-
-## `nest` Function Signature
+Use `hp.nest()` to compose a configuration function from smaller configuration functions while keeping parameter paths stable and replayable.
 
 ```python
-def nest(
-    config_func: Union[str, Path, "Hypster"],
-    *,
-    name: Optional[str] = None,
-    final_vars: List[str] = [],
-    exclude_vars: List[str] = [],
-    values: Dict[str, Any] = {}
-) -> Dict[str, Any]
-```
+from hypster import HP, instantiate
 
-#### Parameters
 
-* `config_func`: Either a path to a saved configuration or a Hypster config object
-* `name`: Optional name for the nested configuration (used in dot notation)
-* `final_vars`: List of variables that cannot be modified by parent configs
-* `exclude_vars`: List of variables to exclude from the configuration
-* `values`: Dictionary of values to override in the nested configuration
-
-## Steps for nesting
-
-{% stepper %}
-{% step %}
-#### Define a reusable config
-
-```python
-from hypster import config, HP
-
-@config
 def llm_config(hp: HP):
-    model = hp.select({
-        "haiku": "claude-3-haiku-20240307",
-        "sonnet": "claude-3-sonnet-20240229"
-    }, default="haiku")
-    temperature = hp.number(0.7, min=0, max=1)
-```
-{% endstep %}
+    provider = hp.select(["openai", "gemini"], name="provider", default="openai")
+    temperature = hp.float(0.2, name="temperature", min=0.0, max=2.0)
+    return {"provider": provider, "temperature": temperature}
 
-{% step %}
-#### Save it
 
-```python
-llm_config.save("configs/llm.py")
-```
-{% endstep %}
+def pipeline_config(hp: HP):
+    llm = hp.nest(llm_config, name="llm")
+    max_tokens = hp.int(4096, name="max_tokens", min=1)
+    return {"llm": llm, "max_tokens": max_tokens}
 
-{% step %}
-#### Define a parent config and use `hp.nest`
 
-```python
-@config
-def qa_config(hp: HP):
-    # Load and nest LLM configuration
-    llm = hp.nest("configs/llm.py")
-
-    # Add QA-specific parameters
-    max_context_length = hp.int(1000, min=100, max=2000)
-
-    # Combine LLM and QA parameters
-    qa_pipeline = QAPipeline(
-        model=llm["model"],
-        temperature=llm["temperature"],
-        max_context_length=max_context_length
-    )
-```
-{% endstep %}
-
-{% step %}
-#### Instantiate using dot notation
-
-```python
-qa_config(values={
-    "llm.model": "sonnet",
-    "llm.temperature": 0.5,
-    "max_context_length": 1500
-})
-```
-{% endstep %}
-{% endstepper %}
-
-## Configuration Sources
-
-`hp.nest()` accepts two types of sources:
-
-### Path to Configuration File
-
-```python
-llm = hp.nest("configs/llm.py")
-```
-
-### Direct Configuration Object
-
-```python
-from hypster import load
-
-# Load the configuration
-llm_config = load("configs/llm.py")
-
-# Use the loaded config
-qa_config = hp.nest(llm_config)
-```
-
-## Value Assignment
-
-Values for nested configurations can be set using either dot notation or nested dictionaries:
-
-```python
-# Using dot notation
-qa_config(values={
-    "llm.model": "sonnet",
-    "llm.temperature": 0.5,
-    "max_context_length": 1500
-})
-
-# Using nested dictionary
-qa_config(values={
-    "llm": {
-        "model": "sonnet",
-        "temperature": 0.5
-    },
-    "max_context_length": 1500
-})
-```
-
-## Hierarchical Nesting
-
-Configurations can be nested multiple times to create modular, reusable components:
-
-```python
-@config
-def indexing_config(hp: HP):
-    # Reuse LLM config for document processing
-    llm = hp.nest("configs/llm.py")
-
-    # Indexing-specific parameters
-    embedding_dim = hp.int(512, min=128, max=1024)
-
-    # Process documents with LLM
-    enriched_docs = process_documents(
-        llm=llm["model"],
-        temperature=llm["temperature"],
-        embedding_dim=embedding_dim
-    )
-
-@config
-def rag_config(hp: HP):
-    # Reuse indexing config (which includes LLM config)
-    indexing = hp.nest("configs/indexing.py")
-
-    # Add retrieval configuration
-    retrieval = hp.nest("configs/retrieval.py")
-```
-
-## Passing Values to Nested Configs
-
-Use the `values` parameter to pass dependent values to nested configuration values:
-
-```python
-retrieval = hp.nest(
-    "configs/retrieval.py",
-    values={
-        "embedding_dim": indexing["embedding_dim"],
-        "top_k": 5
-    }
+run = instantiate(
+    pipeline_config,
+    values={"llm.provider": "gemini", "max_tokens": 8192},
 )
 ```
 
-`final_vars` and `exclude_vars` are also supported.
+## Signature
 
-## Best Practices
+```python
+def nest(
+    child: Callable,
+    *,
+    name: str,
+    values: dict[str, Any] | None = None,
+    args: tuple = (),
+    kwargs: dict[str, Any] | None = None,
+) -> Any
+```
 
-1. **Modular Design**
-   * Create small, focused configurations for specific components
-   * Combine configurations only when there are clear dependencies
-   * Keep configurations reusable across different use cases
-2.  **Clear Naming**
+`name` is required. It must be a valid Python identifier, and it cannot contain dots, spaces, hyphens, or Python keywords. Hypster owns dotted path construction from nested names.
 
-    ```python
-    # Use descriptive names for nestd configs
-    llm = hp.nest("configs/llm.py", name="llm")
-    indexer = hp.nest("configs/indexer.py", name="indexer")
-    ```
-3.  **Value Dependencies**
+## Values
 
-    ```python
-    # Explicitly pass dependent values
+Nested overrides can be provided with dotted keys:
+
+```python
+instantiate(pipeline_config, values={"llm.temperature": 0.7})
+```
+
+Or with nested dictionaries:
+
+```python
+instantiate(pipeline_config, values={"llm": {"temperature": 0.7}})
+```
+
+These are two spellings of the same parameter path. Do not provide both forms for the same leaf:
+
+```python
+instantiate(
+    pipeline_config,
+    values={
+        "llm.temperature": 0.7,
+        "llm": {"temperature": 0.7},
+    },
+)
+# ValueError: Duplicate value for 'llm.temperature'
+```
+
+Nested dictionary keys are individual name segments, so they must be valid Python identifiers. Use dotted keys at the top level when you want to spell a full path.
+
+## Passing Values To Children
+
+Use the `values=` argument on `hp.nest()` when the parent config needs to derive child values:
+
+```python
+def retriever_config(hp: HP):
+    return {"top_k": hp.int(5, name="top_k")}
+
+
+def rag_config(hp: HP):
+    documents = hp.int(100, name="documents")
     retriever = hp.nest(
-        "configs/retriever.py",
-        values={"embedding_dim": embedder["embedding_dim"]}
+        retriever_config,
+        name="retriever",
+        values={"top_k": max(1, documents // 20)},
     )
-    ```
-4.  **File Organization**
+    return {"documents": documents, "retriever": retriever}
+```
 
-    ```python
-    # Keep related configs in a dedicated directory
-    configs/
-    ├── llm.py
-    ├── indexing.py
-    ├── retrieval.py
-    └── rag.py
-    ```
+Explicit child `values=` are normalized with the same dotted/nested rules as top-level `values=`.
+
+## Conditional Nesting
+
+Nested configs can be selected conditionally. Unknown or unreachable values raise by default, so branch-specific overrides must match the active branch.
+
+```python
+def openai_config(hp: HP):
+    return {"model": hp.select(["gpt-4o-mini", "gpt-4.1"], name="model")}
+
+
+def gemini_config(hp: HP):
+    return {"model": hp.select(["flash-lite", "pro"], name="model")}
+
+
+def model_config(hp: HP):
+    provider = hp.select(["openai", "gemini"], name="provider", default="openai")
+    if provider == "openai":
+        return hp.nest(openai_config, name="openai")
+    return hp.nest(gemini_config, name="gemini")
+```
+
+To inspect a branch before passing values to it, run `explore(model_config, values={"provider": "gemini"})`.

--- a/docs/in-depth/values-and-overrides.md
+++ b/docs/in-depth/values-and-overrides.md
@@ -1,6 +1,6 @@
 # 🔧 Values & Overrides
 
-This page explains how to provide overrides to a configuration function using dotted keys and nested dictionaries, and which one takes precedence when both are provided.
+This page explains how to provide overrides to a configuration function using dotted keys and nested dictionaries.
 
 ## Basics
 
@@ -36,30 +36,34 @@ instantiate(parent, values={"child": {"x": 25}})
 # => {"x": 25, "y": 20}
 ```
 
-## Precedence: nested dict wins
+## Duplicate paths
 
-If you provide both dotted keys and a nested dict for the same scope, the nested dict wins.
+Dotted keys and nested dictionaries are two ways to spell the same parameter path. Do not provide the same path twice. Hypster raises even when both values are identical, because duplicate input is ambiguous for logging and replay.
 
 ```python
 instantiate(
     parent,
     values={
-        "child.x": 100,         # dotted notation
-        "child": {"x": 200},  # nested dict
+        "child.x": 100,
+        "child": {"x": 100},
     },
 )
-# => {"x": 200, "y": 20}
+# ValueError: Duplicate value for 'child.x'
 ```
 
 ## Deeply nested
 
-Dotted keys can target deeper levels when there is no nested dict override at that level. You can mix and match as needed, keeping in mind that a nested dict for a scope overrides dotted keys for that scope.
+Dotted keys can target deeper levels, and nested dictionaries can express the same shape. You can mix both forms as long as each final parameter path appears once.
+
+```python
+instantiate(parent, values={"child": {"x": 25}, "other.y": 30})
+```
 
 ## Unknown and unreachable parameters
 
 * Unknown or unreachable values (values for parameters on a branch that wasn’t taken) are handled by `on_unknown` in `instantiate`:
-  * `on_unknown="warn"` (default): issue a warning
-  * `on_unknown="raise"`: raise an error
+  * `on_unknown="raise"` (default): raise an error
+  * `on_unknown="warn"`: issue a warning
   * `on_unknown="ignore"`: silently ignore
 
-Hypster will include helpful suggestions when a name looks like a typo.
+Nested dictionaries participate in the same unknown/unreachable check as dotted paths. Hypster includes helpful suggestions when a name looks like a typo, and errors guide you to run `explore(config, values=...)` to inspect the active branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hypster"
-version = "0.3.10"
+version = "0.4.0"
 description = "A flexible configuration system for Python projects"
 authors = [
     {name = "Gilad Rubin", email = "me@giladrubin.com"}

--- a/src/hypster/__init__.py
+++ b/src/hypster/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
-from .core import ConfigFunc, instantiate
+from .core import ConfigFunc, InstantiationOutput, instantiate, instantiate_with_params
 from .explore import explore
 from .hp import HP
 
@@ -14,4 +14,12 @@ except PackageNotFoundError:  # During editable/source runs before install
     __version__ = "0.0.0"
 
 
-__all__ = ["HP", "instantiate", "explore", "ConfigFunc", "__version__"]
+__all__ = [
+    "HP",
+    "instantiate",
+    "instantiate_with_params",
+    "InstantiationOutput",
+    "explore",
+    "ConfigFunc",
+    "__version__",
+]

--- a/src/hypster/_sentinels.py
+++ b/src/hypster/_sentinels.py
@@ -1,0 +1,3 @@
+"""Internal sentinel values shared across Hypster execution paths."""
+
+NO_DEFAULT = object()

--- a/src/hypster/core.py
+++ b/src/hypster/core.py
@@ -1,17 +1,51 @@
 """The Core API for instantiating configurations."""
 
 import warnings
-from typing import Any, Dict, Literal, Optional, Protocol, Tuple, TypeVar
+from dataclasses import dataclass, field
+from typing import Any, Dict, Generic, Literal, Optional, Protocol, Tuple, TypeVar
 
 from .hp import HP
 from .hp_calls import HPCallError
-from .utils import suggest_similar_names, validate_config_func_signature
+from .utils import normalize_values, suggest_similar_names, validate_config_func_signature
 
 T = TypeVar("T", covariant=True)
+UnknownPolicy = Literal["warn", "raise", "ignore"]
 
 
 class ConfigFunc(Protocol[T]):
     def __call__(self, hp: HP, *args: Any, **kwargs: Any) -> T: ...
+
+
+@dataclass(frozen=True)
+class InstantiationOutput(Generic[T]):
+    """Output of a config execution with its selected params sidecar."""
+
+    value: T
+    params: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "params", dict(self.params))
+
+
+class ParamsTracker:
+    """Collect selected params from HP's parameter-recording hook."""
+
+    def __init__(self) -> None:
+        self.params: Dict[str, Any] = {}
+
+    def record_parameter(
+        self,
+        *,
+        path: str,
+        name: str,
+        kind: str,
+        default_value: Any,
+        selected_value: Any,
+        options: Optional[list[Any]] = None,
+        minimum: Optional[int | float] = None,
+        maximum: Optional[int | float] = None,
+    ) -> None:
+        self.params[path] = selected_value
 
 
 def instantiate(
@@ -20,7 +54,7 @@ def instantiate(
     values: Optional[Dict[str, Any]] = None,
     args: Tuple[Any, ...] = (),
     kwargs: Optional[Dict[str, Any]] = None,
-    on_unknown: Literal["warn", "raise", "ignore"] = "warn",
+    on_unknown: UnknownPolicy = "raise",
 ) -> T:
     """
     Execute a config function with the given values.
@@ -31,8 +65,8 @@ def instantiate(
         args: Additional positional arguments for func
         kwargs: Additional keyword arguments for func
         on_unknown: How to handle unknown/unreachable parameters:
-            - 'warn': Issue warning and continue (default)
-            - 'raise': Raise ValueError
+            - 'raise': Raise ValueError (default)
+            - 'warn': Issue warning and continue
             - 'ignore': Silently ignore unknown parameters
 
     Returns:
@@ -42,31 +76,39 @@ def instantiate(
         ValueError: If func doesn't have hp: HP as first parameter
         ValueError: If unknown parameters in values and on_unknown='raise'
     """
-    # Validate function signature
+    return _run_config(func, values=values, args=args, kwargs=kwargs, on_unknown=on_unknown)
+
+
+def _validate_on_unknown(on_unknown: str) -> None:
+    """Validate unknown-parameter policy at the API boundary."""
+    if on_unknown not in {"warn", "raise", "ignore"}:
+        raise ValueError("on_unknown must be one of 'raise', 'warn', or 'ignore'.")
+
+
+def _run_config(
+    func: ConfigFunc[T],
+    *,
+    values: Optional[Dict[str, Any]] = None,
+    args: Tuple[Any, ...] = (),
+    kwargs: Optional[Dict[str, Any]] = None,
+    on_unknown: UnknownPolicy = "raise",
+    parameter_tracker: Optional[Any] = None,
+) -> T:
+    """Execute a config function through the shared instantiation path."""
     validate_config_func_signature(func)
+    _validate_on_unknown(on_unknown)
 
-    # Prepare values
-    values = values or {}
+    normalized_values = normalize_values(values)
     kwargs = kwargs or {}
-
-    # Create HP instance
-    hp = HP(values)
-
-    # Track called parameters during execution
+    hp = HP(normalized_values, parameter_tracker=parameter_tracker)
     original_called_params = hp.called_params.copy()
 
     try:
-        # Execute the function
         result = func(hp, *args, **kwargs)
-
-        # Check for unknown/unreachable parameters
         called_params = hp.called_params - original_called_params
-        _handle_unknown_parameters(values, called_params, on_unknown)
-
+        _handle_unknown_parameters(normalized_values, called_params, on_unknown)
         return result
-
     except HPCallError as e:
-        # Re-raise HP errors as ValueError for cleaner API
         raise ValueError(str(e)) from e
 
 
@@ -98,9 +140,39 @@ def _handle_unknown_parameters(provided_values: Dict[str, Any], called_params: s
         else:
             error_lines.append(f"  - '{param}': Unknown parameter")
 
+    error_lines.append("")
+    error_lines.append("Run explore(config, values=...) to inspect the active branch.")
+    error_lines.append(
+        "Nested dict values are interpreted as parameter paths; use dict-backed select keys for objects."
+    )
     error_message = "\n".join(error_lines)
 
     if on_unknown == "raise":
         raise ValueError(error_message)
     elif on_unknown == "warn":
         warnings.warn(error_message, UserWarning, stacklevel=3)
+
+
+def instantiate_with_params(
+    func: ConfigFunc[T],
+    *,
+    values: Optional[Dict[str, Any]] = None,
+    args: Tuple[Any, ...] = (),
+    kwargs: Optional[Dict[str, Any]] = None,
+    on_unknown: UnknownPolicy = "raise",
+) -> InstantiationOutput[T]:
+    """
+    Execute a config function and return its value with selected params.
+
+    Args mirror instantiate().
+    """
+    tracker = ParamsTracker()
+    result = _run_config(
+        func,
+        values=values,
+        args=args,
+        kwargs=kwargs,
+        on_unknown=on_unknown,
+        parameter_tracker=tracker,
+    )
+    return InstantiationOutput(value=result, params=tracker.params)

--- a/src/hypster/explore.py
+++ b/src/hypster/explore.py
@@ -5,10 +5,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
-from .core import ConfigFunc, _handle_unknown_parameters
+from .core import ConfigFunc, _handle_unknown_parameters, _validate_on_unknown
 from .hp import HP
 from .hp_calls import HPCallError
-from .utils import validate_config_func_signature
+from .utils import normalize_values, validate_config_func_signature
 
 
 def _format_value(value: Any) -> str:
@@ -125,10 +125,10 @@ class ConfigSchema:
 
 
 class SchemaTracer(HP):
-    def __init__(self, values: Dict[str, Any], exploration_tracker: Optional[Any] = None):
-        tracker = exploration_tracker or self
-        super().__init__(values, exploration_tracker=tracker)
-        if exploration_tracker is None:
+    def __init__(self, values: Dict[str, Any], parameter_tracker: Optional[Any] = None):
+        tracker = parameter_tracker or self
+        super().__init__(values, parameter_tracker=tracker)
+        if parameter_tracker is None:
             self._schema = ConfigSchema(name="")
             self._nodes_by_path: Dict[str, ParameterInfo] = {}
         else:
@@ -209,12 +209,13 @@ def explore(
     values: Optional[Dict[str, Any]] = None,
     args: Tuple[Any, ...] = (),
     kwargs: Optional[Dict[str, Any]] = None,
-    on_unknown: Literal["warn", "raise", "ignore"] = "warn",
+    on_unknown: Literal["warn", "raise", "ignore"] = "raise",
     return_info: bool = False,
 ) -> Optional[ConfigSchema]:
     validate_config_func_signature(func)
+    _validate_on_unknown(on_unknown)
 
-    values = values or {}
+    values = normalize_values(values)
     tracer = SchemaTracer(values)
     kwargs = kwargs or {}
     original_called_params = tracer.called_params.copy()

--- a/src/hypster/hp.py
+++ b/src/hypster/hp.py
@@ -1,8 +1,10 @@
 """The HP Parameter Interface."""
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Protocol, Tuple, Union, overload
 
+from ._sentinels import NO_DEFAULT as _NO_DEFAULT
 from .hp_calls import (
     BoolValidator,
     FloatValidator,
@@ -12,32 +14,48 @@ from .hp_calls import (
     SelectValidator,
     TextValidator,
 )
-from .utils import unflatten_dict
+from .utils import normalize_values, validate_identifier_name, validate_select_choice
 
 if TYPE_CHECKING:  # only for type hints; avoid runtime imports
     from .hpo.types import HpoCategorical, HpoFloat, HpoInt
+
+
+class ParameterTracker(Protocol):
+    """Receives parameter-recording events from HP execution."""
+
+    def record_parameter(
+        self,
+        *,
+        path: str,
+        name: str,
+        kind: str,
+        default_value: Any,
+        selected_value: Any,
+        options: Optional[List[Any]] = None,
+        minimum: Optional[Union[int, float]] = None,
+        maximum: Optional[Union[int, float]] = None,
+    ) -> None: ...
 
 
 @dataclass(frozen=True)
 class OptionsAdapter:
     """Helper to normalize options and defaults for select/multi_select."""
 
-    options: Union[List[Any], Dict[Any, Any]]
-    options_only: bool
+    options: Union[List[Any], Mapping[Any, Any]]
 
-    def keys_and_map(self) -> Tuple[List[Any], Dict[Any, Any]]:
-        if isinstance(self.options, dict):
+    def keys_and_map(self) -> Tuple[List[Any], Mapping[Any, Any]]:
+        if isinstance(self.options, Mapping):
             option_keys = list(self.options.keys())
             option_map = self.options
         else:
             option_keys = list(self.options)
-            option_map = {k: k for k in option_keys}
+            option_map = {}
         return option_keys, option_map
 
-    def resolve_default(self, explicit_default: Optional[Any]) -> Optional[Any]:
-        if explicit_default is not None:
+    def resolve_default(self, explicit_default: Any) -> Any:
+        if explicit_default is not _NO_DEFAULT:
             return explicit_default
-        if isinstance(self.options, dict):
+        if isinstance(self.options, Mapping):
             # First key if available
             return next(iter(self.options.keys()), None)
         # First item if available
@@ -47,10 +65,10 @@ class OptionsAdapter:
 class HP:
     """The HP parameter interface for configuration functions."""
 
-    def __init__(self, values: Dict[str, Any], exploration_tracker: Optional[Any] = None):
+    def __init__(self, values: Dict[str, Any], parameter_tracker: Optional[ParameterTracker] = None):
         """HP is created by instantiate() - users don't instantiate directly."""
         self.values = values or {}
-        self.exploration_tracker = exploration_tracker  # Optional, only for explore mode
+        self.parameter_tracker = parameter_tracker
         self.namespace_stack: List[str] = []  # For nested name prefixes
         self.called_params: set[str] = set()  # Track called parameter names
         self.nested_scopes: set[str] = set()  # Track names that have been nested
@@ -77,10 +95,10 @@ class HP:
         minimum: Optional[Union[int, float]] = None,
         maximum: Optional[Union[int, float]] = None,
     ) -> None:
-        if self.exploration_tracker is None:
+        if self.parameter_tracker is None:
             return
 
-        record = getattr(self.exploration_tracker, "record_parameter", None)
+        record = getattr(self.parameter_tracker, "record_parameter", None)
         if callable(record):
             record(
                 path=path,
@@ -94,10 +112,10 @@ class HP:
             )
 
     def _record_nest(self, *, path: str, name: str) -> None:
-        if self.exploration_tracker is None:
+        if self.parameter_tracker is None:
             return
 
-        record = getattr(self.exploration_tracker, "record_nest", None)
+        record = getattr(self.parameter_tracker, "record_nest", None)
         if callable(record):
             record(path=path, name=name)
 
@@ -112,24 +130,7 @@ class HP:
         if full_path in self.values:
             return self.values[full_path], True
 
-        # Check for nested structure
-        nested_values = unflatten_dict(self.values)
-        try:
-            current = nested_values
-            for part in full_path.split("."):
-                current = current[part]
-            return current, True
-        except (KeyError, TypeError):
-            pass
-
-        # Try with just the name in nested structure
-        try:
-            current = nested_values
-            for part in name.split("."):
-                current = current[part]
-            return current, True
-        except (KeyError, TypeError):
-            return None, False
+        return None, False
 
     def _validate_name_not_called(self, name: str) -> None:
         """Validate that this parameter name hasn't been called before."""
@@ -142,6 +143,7 @@ class HP:
         """Manual name validation for calls that don't use a validator for naming."""
         if name is None:
             raise HPCallError(full_path, "requires 'name' for overrides")
+        validate_identifier_name(name, kind="parameter name")
 
     def _handle_single_value(
         self,
@@ -154,6 +156,7 @@ class HP:
         strict: bool = False,
         min: Optional[Union[int, float]] = None,
         max: Optional[Union[int, float]] = None,
+        allow_none: bool = False,
         track_called: bool = False,
         use_validator_name: bool = True,
     ) -> Any:
@@ -162,6 +165,7 @@ class HP:
         # Validate name (either via validator or manual message)
         if use_validator_name:
             validator.validate_name(name, full_path)
+            validate_identifier_name(name, kind="parameter name")
         else:
             self._validate_name(name, full_path)
 
@@ -169,20 +173,34 @@ class HP:
         if track_called:
             self.called_params.add(full_path)
 
+        if default is None and not allow_none:
+            raise HPCallError(
+                full_path,
+                "default=None requires allow_none=True. How to fix: pass allow_none=True, or use a non-None default.",
+            )
+
         value, found = self._get_value_for_param(name)
-        if found:
-            if supports_strict:
-                validated_value = validator.validate_value(value, full_path, strict=strict)
-            else:
-                validated_value = validator.validate_value(value, full_path)
+        raw_value = value if found else default
+        if raw_value is None:
+            if not allow_none:
+                raise HPCallError(
+                    full_path,
+                    "None is only allowed when allow_none=True. "
+                    "How to fix: pass allow_none=True, or provide a non-None value.",
+                )
+            validated_value = None
         else:
             if supports_strict:
-                validated_value = validator.validate_value(default, full_path, strict=strict)
+                validated_value = validator.validate_value(raw_value, full_path, strict=strict)
             else:
-                validated_value = validator.validate_value(default, full_path)
+                validated_value = validator.validate_value(raw_value, full_path)
 
         # Bounds validation if applicable
-        if (min is not None or max is not None) and hasattr(validator, "validate_bounds"):
+        if (
+            validated_value is not None
+            and (min is not None or max is not None)
+            and hasattr(validator, "validate_bounds")
+        ):
             validator.validate_bounds(validated_value, min, max, full_path)
 
         self._record_parameter(
@@ -208,6 +226,7 @@ class HP:
         strict: bool = False,
         min: Optional[Union[int, float]] = None,
         max: Optional[Union[int, float]] = None,
+        allow_none: bool = False,
     ) -> List[Any]:
         full_path = self._get_full_param_path(name)
 
@@ -215,6 +234,14 @@ class HP:
         self._validate_name(name, full_path)
         self._validate_name_not_called(name)
         self.called_params.add(full_path)
+
+        if allow_none:
+            raise HPCallError(
+                full_path,
+                f"allow_none=True is not supported for hp.{param_type}() yet. "
+                "How to fix: remove allow_none=True, or use hp.multi_select([...], allow_none=True) "
+                "when you need nullable categorical choices.",
+            )
 
         multi_validator = MultiValidator(element_validator)
 
@@ -248,24 +275,30 @@ class HP:
     def _handle_select_single(
         self,
         *,
-        options: Union[List[Any], Dict[Any, Any]],
+        options: Union[List[Any], Mapping[Any, Any]],
         name: str,
-        default: Optional[Any] = None,
+        default: Any = _NO_DEFAULT,
         options_only: bool = False,
+        allow_none: bool = False,
     ) -> Any:
         validator = SelectValidator()
         full_path = self._get_full_param_path(name)
 
         validator.validate_name(name, full_path)
+        validate_identifier_name(name, kind="parameter name")
         self._validate_name_not_called(name)
         self.called_params.add(full_path)
 
-        adapter = OptionsAdapter(options=options, options_only=options_only)
+        is_mapping = isinstance(options, Mapping)
+        adapter = OptionsAdapter(options=options)
         option_keys, option_map = adapter.keys_and_map()
+        for index, option in enumerate(option_keys):
+            validate_select_choice(option, param_path=f"{full_path} option #{index}", allow_none=allow_none)
         actual_default = adapter.resolve_default(default)
 
         value, found = self._get_value_for_param(name)
         if found:
+            validate_select_choice(value, param_path=full_path, allow_none=allow_none)
             validated_key = validator.validate_value(value, option_keys, options_only, full_path)
             self._record_parameter(
                 path=full_path,
@@ -275,46 +308,48 @@ class HP:
                 selected_value=validated_key,
                 options=option_keys,
             )
-            return option_map.get(validated_key, validated_key)
+            return option_map.get(validated_key, validated_key) if is_mapping else validated_key
         else:
-            if actual_default is not None:
-                validated_key = validator.validate_value(actual_default, option_keys, options_only, full_path)
-                self._record_parameter(
-                    path=full_path,
-                    name=name,
-                    kind="select",
-                    default_value=actual_default,
-                    selected_value=validated_key,
-                    options=option_keys,
+            if actual_default is None and default is _NO_DEFAULT and not option_keys:
+                raise HPCallError(
+                    full_path,
+                    "select has no options and no default. "
+                    "How to fix: provide at least one option, pass default=..., or pass allow_none=True.",
                 )
-                return option_map.get(validated_key, validated_key)
+            validate_select_choice(actual_default, param_path=full_path, allow_none=allow_none)
+            validated_key = validator.validate_value(actual_default, option_keys, options_only, full_path)
             self._record_parameter(
                 path=full_path,
                 name=name,
                 kind="select",
                 default_value=actual_default,
-                selected_value=None,
+                selected_value=validated_key,
                 options=option_keys,
             )
-            return None
+            return option_map.get(validated_key, validated_key) if is_mapping else validated_key
 
     def _handle_select_multi(
         self,
         *,
-        options: Union[List[Any], Dict[Any, Any]],
+        options: Union[List[Any], Mapping[Any, Any]],
         name: str,
         default: Optional[List[Any]] = None,
         options_only: bool = False,
+        allow_none: bool = False,
     ) -> List[Any]:
         validator = SelectValidator()
         full_path = self._get_full_param_path(name)
 
         validator.validate_name(name, full_path)
+        validate_identifier_name(name, kind="parameter name")
         self._validate_name_not_called(name)
         self.called_params.add(full_path)
 
-        adapter = OptionsAdapter(options=options, options_only=options_only)
+        is_mapping = isinstance(options, Mapping)
+        adapter = OptionsAdapter(options=options)
         option_keys, option_map = adapter.keys_and_map()
+        for index, option in enumerate(option_keys):
+            validate_select_choice(option, param_path=f"{full_path} option #{index}", allow_none=allow_none)
         actual_default = list(default or [])
 
         value, found = self._get_value_for_param(name)
@@ -324,6 +359,7 @@ class HP:
 
             validated_keys = []
             for i, item in enumerate(value):
+                validate_select_choice(item, param_path=f"{full_path}[{i}]", allow_none=allow_none)
                 validated_key = validator.validate_value(item, option_keys, options_only, f"{full_path}[{i}]")
                 validated_keys.append(validated_key)
 
@@ -335,10 +371,11 @@ class HP:
                 selected_value=validated_keys,
                 options=option_keys,
             )
-            return [option_map.get(k, k) for k in validated_keys]
+            return [option_map.get(k, k) for k in validated_keys] if is_mapping else validated_keys
         else:
             validated_keys = []
             for i, item in enumerate(actual_default):
+                validate_select_choice(item, param_path=f"{full_path}[{i}]", allow_none=allow_none)
                 validated_key = validator.validate_value(item, option_keys, options_only, f"{full_path}[{i}]")
                 validated_keys.append(validated_key)
 
@@ -350,7 +387,7 @@ class HP:
                 selected_value=validated_keys,
                 options=option_keys,
             )
-            return [option_map.get(k, k) for k in validated_keys]
+            return [option_map.get(k, k) for k in validated_keys] if is_mapping else validated_keys
 
     # --- Executor structures ---
     @dataclass(frozen=True)
@@ -365,6 +402,7 @@ class HP:
         max: Optional[Union[int, float]] = None
         track_called: bool = False
         use_validator_name: bool = True
+        allow_none: bool = False
 
     @dataclass(frozen=True)
     class MultiValueSpec:
@@ -376,20 +414,23 @@ class HP:
         strict: bool = False
         min: Optional[Union[int, float]] = None
         max: Optional[Union[int, float]] = None
+        allow_none: bool = False
 
     @dataclass(frozen=True)
     class SelectSingleSpec:
         name: str
-        options: Union[List[Any], Dict[Any, Any]]
-        default: Optional[Any] = None
+        options: Union[List[Any], Mapping[Any, Any]]
+        default: Any = _NO_DEFAULT
         options_only: bool = False
+        allow_none: bool = False
 
     @dataclass(frozen=True)
     class SelectMultiSpec:
         name: str
-        options: Union[List[Any], Dict[Any, Any]]
+        options: Union[List[Any], Mapping[Any, Any]]
         default: Optional[List[Any]] = None
         options_only: bool = False
+        allow_none: bool = False
 
     # --- Unified executors ---
     def _execute_single(self, spec: "HP.SingleValueSpec") -> Any:
@@ -402,6 +443,7 @@ class HP:
             strict=spec.strict,
             min=spec.min,
             max=spec.max,
+            allow_none=spec.allow_none,
             track_called=spec.track_called,
             use_validator_name=spec.use_validator_name,
         )
@@ -416,6 +458,7 @@ class HP:
             strict=spec.strict,
             min=spec.min,
             max=spec.max,
+            allow_none=spec.allow_none,
         )
 
     def _execute_select_single(self, spec: "HP.SelectSingleSpec") -> Any:
@@ -424,6 +467,7 @@ class HP:
             name=spec.name,
             default=spec.default,
             options_only=spec.options_only,
+            allow_none=spec.allow_none,
         )
 
     def _execute_select_multi(self, spec: "HP.SelectMultiSpec") -> List[Any]:
@@ -432,6 +476,7 @@ class HP:
             name=spec.name,
             default=spec.default,
             options_only=spec.options_only,
+            allow_none=spec.allow_none,
         )
 
     # Composition
@@ -452,6 +497,7 @@ class HP:
         # Validate name
         if name is None:
             raise HPCallError(full_path, "requires 'name' for nesting")
+        validate_identifier_name(name, kind="nest name")
 
         # Disallow nesting under a prefix that already has parameters defined by the parent
         # but allow repeated nesting with the same name to surface duplicate param errors later
@@ -473,18 +519,14 @@ class HP:
                 nested_key = key[len(prefix) :]
                 nested_values[nested_key] = value
 
-        # If an explicit nested dict is provided under the name key, it overrides dotted keys
-        if name in self.values and isinstance(self.values[name], dict):
-            nested_values.update(self.values[name])
-
         # Merge with explicit values if provided
         if values:
-            nested_values.update(values)
+            nested_values.update(normalize_values(values))
 
         # Create new HP instance for nested call with namespace
         self._record_nest(path=full_path, name=name)
 
-        nested_hp = self.__class__(nested_values, exploration_tracker=self.exploration_tracker)
+        nested_hp = self.__class__(nested_values, parameter_tracker=self.parameter_tracker)
         nested_hp.namespace_stack = self.namespace_stack + [name]
         nested_hp.called_params = self.called_params  # Share called_params tracking
 
@@ -540,6 +582,7 @@ class HP:
     # --- Public API methods ---
     # Use underscore prefix to avoid conflicts with built-in names
 
+    @overload
     def _int(
         self,
         default: int,
@@ -548,8 +591,34 @@ class HP:
         min: Optional[int] = None,
         max: Optional[int] = None,
         strict: bool = False,
+        allow_none: Literal[False] = False,
         hpo_spec: "HpoInt | None" = None,
-    ) -> int:
+    ) -> int: ...
+
+    @overload
+    def _int(
+        self,
+        default: Optional[int],
+        *,
+        name: str,
+        min: Optional[int] = None,
+        max: Optional[int] = None,
+        strict: bool = False,
+        allow_none: Literal[True],
+        hpo_spec: "HpoInt | None" = None,
+    ) -> Optional[int]: ...
+
+    def _int(
+        self,
+        default: Optional[int],
+        *,
+        name: str,
+        min: Optional[int] = None,
+        max: Optional[int] = None,
+        strict: bool = False,
+        allow_none: bool = False,
+        hpo_spec: "HpoInt | None" = None,
+    ) -> Optional[int]:
         """Integer parameter with optional bounds validation."""
         spec = HP.SingleValueSpec(
             name=name,
@@ -560,11 +629,13 @@ class HP:
             strict=strict,
             min=min,
             max=max,
+            allow_none=allow_none,
             track_called=True,
             use_validator_name=True,
         )
         return self._execute_single(spec)
 
+    @overload
     def _float(
         self,
         default: float,
@@ -573,8 +644,34 @@ class HP:
         min: Optional[float] = None,
         max: Optional[float] = None,
         strict: bool = False,
+        allow_none: Literal[False] = False,
         hpo_spec: "HpoFloat | None" = None,
-    ) -> float:
+    ) -> float: ...
+
+    @overload
+    def _float(
+        self,
+        default: Optional[float],
+        *,
+        name: str,
+        min: Optional[float] = None,
+        max: Optional[float] = None,
+        strict: bool = False,
+        allow_none: Literal[True],
+        hpo_spec: "HpoFloat | None" = None,
+    ) -> Optional[float]: ...
+
+    def _float(
+        self,
+        default: Optional[float],
+        *,
+        name: str,
+        min: Optional[float] = None,
+        max: Optional[float] = None,
+        strict: bool = False,
+        allow_none: bool = False,
+        hpo_spec: "HpoFloat | None" = None,
+    ) -> Optional[float]:
         """Float parameter with optional bounds validation."""
         spec = HP.SingleValueSpec(
             name=name,
@@ -585,12 +682,19 @@ class HP:
             strict=strict,
             min=min,
             max=max,
+            allow_none=allow_none,
             track_called=True,
             use_validator_name=True,
         )
         return self._execute_single(spec)
 
-    def _text(self, default: str, *, name: str) -> str:
+    @overload
+    def _text(self, default: str, *, name: str, allow_none: Literal[False] = False) -> str: ...
+
+    @overload
+    def _text(self, default: Optional[str], *, name: str, allow_none: Literal[True]) -> Optional[str]: ...
+
+    def _text(self, default: Optional[str], *, name: str, allow_none: bool = False) -> Optional[str]:
         """Text parameter."""
         spec = HP.SingleValueSpec(
             name=name,
@@ -598,12 +702,19 @@ class HP:
             param_type="text",
             validator=TextValidator(),
             supports_strict=False,
+            allow_none=allow_none,
             track_called=True,
             use_validator_name=True,
         )
         return self._execute_single(spec)
 
-    def _bool(self, default: bool, *, name: str) -> bool:
+    @overload
+    def _bool(self, default: bool, *, name: str, allow_none: Literal[False] = False) -> bool: ...
+
+    @overload
+    def _bool(self, default: Optional[bool], *, name: str, allow_none: Literal[True]) -> Optional[bool]: ...
+
+    def _bool(self, default: Optional[bool], *, name: str, allow_none: bool = False) -> Optional[bool]:
         """Boolean parameter."""
         spec = HP.SingleValueSpec(
             name=name,
@@ -611,6 +722,7 @@ class HP:
             param_type="bool",
             validator=BoolValidator(),
             supports_strict=False,
+            allow_none=allow_none,
             track_called=True,
             use_validator_name=True,
         )
@@ -618,15 +730,22 @@ class HP:
 
     def _select(
         self,
-        options: Union[List[Any], Dict[Any, Any]],
+        options: Union[List[Any], Mapping[Any, Any]],
         *,
         name: str,
-        default: Optional[Any] = None,
+        default: Any = _NO_DEFAULT,
         options_only: bool = False,
+        allow_none: bool = False,
         hpo_spec: "HpoCategorical | None" = None,
     ) -> Any:
         """Selection parameter from options."""
-        spec = HP.SelectSingleSpec(name=name, options=options, default=default, options_only=options_only)
+        spec = HP.SelectSingleSpec(
+            name=name,
+            options=options,
+            default=default,
+            options_only=options_only,
+            allow_none=allow_none,
+        )
         return self._execute_select_single(spec)
 
     def _multi_int(
@@ -637,6 +756,7 @@ class HP:
         min: Optional[int] = None,
         max: Optional[int] = None,
         strict: bool = False,
+        allow_none: bool = False,
     ) -> List[int]:
         """Multi-integer parameter with optional bounds validation."""
         spec = HP.MultiValueSpec(
@@ -648,6 +768,7 @@ class HP:
             strict=strict,
             min=min,
             max=max,
+            allow_none=allow_none,
         )
         return self._execute_multi(spec)
 
@@ -659,6 +780,7 @@ class HP:
         min: Optional[float] = None,
         max: Optional[float] = None,
         strict: bool = False,
+        allow_none: bool = False,
     ) -> List[float]:
         """Multi-float parameter with optional bounds validation."""
         spec = HP.MultiValueSpec(
@@ -670,10 +792,11 @@ class HP:
             strict=strict,
             min=min,
             max=max,
+            allow_none=allow_none,
         )
         return self._execute_multi(spec)
 
-    def _multi_text(self, default: List[str], *, name: str) -> List[str]:
+    def _multi_text(self, default: List[str], *, name: str, allow_none: bool = False) -> List[str]:
         """Multi-text parameter."""
         spec = HP.MultiValueSpec(
             name=name,
@@ -681,10 +804,11 @@ class HP:
             param_type="multi_text",
             element_validator=TextValidator(),
             supports_strict=False,
+            allow_none=allow_none,
         )
         return self._execute_multi(spec)
 
-    def _multi_bool(self, default: List[bool], *, name: str) -> List[bool]:
+    def _multi_bool(self, default: List[bool], *, name: str, allow_none: bool = False) -> List[bool]:
         """Multi-boolean parameter."""
         spec = HP.MultiValueSpec(
             name=name,
@@ -692,19 +816,27 @@ class HP:
             param_type="multi_bool",
             element_validator=BoolValidator(),
             supports_strict=False,
+            allow_none=allow_none,
         )
         return self._execute_multi(spec)
 
     def _multi_select(
         self,
-        options: Union[List[Any], Dict[Any, Any]],
+        options: Union[List[Any], Mapping[Any, Any]],
         *,
         name: str,
         default: Optional[List[Any]] = None,
         options_only: bool = False,
+        allow_none: bool = False,
     ) -> List[Any]:
         """Multi-selection parameter from options."""
-        spec = HP.SelectMultiSpec(name=name, options=options, default=default, options_only=options_only)
+        spec = HP.SelectMultiSpec(
+            name=name,
+            options=options,
+            default=default,
+            options_only=options_only,
+            allow_none=allow_none,
+        )
         return self._execute_select_multi(spec)
 
     # Map public API names to internal methods

--- a/src/hypster/hpo/optuna.py
+++ b/src/hypster/hpo/optuna.py
@@ -1,24 +1,16 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any, Dict
 
 try:  # optional dependency
     import optuna as _optuna
 except Exception:  # pragma: no cover
     _optuna = None
 
+from .._sentinels import NO_DEFAULT as _NO_DEFAULT
+from ..utils import normalize_values, validate_identifier_name, validate_select_choice
 from .types import HpoCategorical, HpoFloat, HpoInt
-
-
-def _flatten(d: Mapping[str, Any], prefix: str = "") -> Dict[str, Any]:
-    out: Dict[str, Any] = {}
-    for k, v in d.items():
-        key = f"{prefix}.{k}" if prefix else k
-        if isinstance(v, dict):
-            out.update(_flatten(v, key))
-        else:
-            out[key] = v
-    return out
 
 
 class _HPProxy:
@@ -35,6 +27,7 @@ class _HPProxy:
         self.overrides = overrides or {}
 
     def _full(self, name: str) -> str:
+        validate_identifier_name(name, kind="parameter name")
         return ".".join(self.ns + [name]) if self.ns else name
 
     # integers
@@ -46,10 +39,25 @@ class _HPProxy:
         min: int | None = None,
         max: int | None = None,
         strict: bool = False,
+        allow_none: bool = False,
         hpo_spec: HpoInt | None = None,
     ) -> int:
         full = self._full(name)
+        if allow_none:
+            raise ValueError(
+                f"Parameter '{full}': allow_none=True is not supported for HPO numeric suggestions yet.\n\n"
+                "How to fix: remove allow_none=True from HPO numeric parameters, or make this choice categorical."
+            )
+        if default is None:
+            raise ValueError(
+                f"Parameter '{full}': default=None requires allow_none=True, "
+                "but nullable numeric HPO suggestions are not supported yet."
+            )
         if full in self.overrides:
+            if self.overrides[full] is None:
+                raise ValueError(
+                    f"Parameter '{full}': None overrides are not supported for HPO numeric suggestions yet."
+                )
             val = int(self.overrides[full])
             self.collector[full] = val
             return val
@@ -72,10 +80,25 @@ class _HPProxy:
         min: float | None = None,
         max: float | None = None,
         strict: bool = False,
+        allow_none: bool = False,
         hpo_spec: HpoFloat | None = None,
     ) -> float:
         full = self._full(name)
+        if allow_none:
+            raise ValueError(
+                f"Parameter '{full}': allow_none=True is not supported for HPO numeric suggestions yet.\n\n"
+                "How to fix: remove allow_none=True from HPO numeric parameters, or make this choice categorical."
+            )
+        if default is None:
+            raise ValueError(
+                f"Parameter '{full}': default=None requires allow_none=True, "
+                "but nullable numeric HPO suggestions are not supported yet."
+            )
         if full in self.overrides:
+            if self.overrides[full] is None:
+                raise ValueError(
+                    f"Parameter '{full}': None overrides are not supported for HPO numeric suggestions yet."
+                )
             val = float(self.overrides[full])
             self.collector[full] = val
             return val
@@ -93,26 +116,43 @@ class _HPProxy:
         options: Sequence[Any] | Mapping[Any, Any],
         *,
         name: str,
-        default: Any | None = None,
+        default: Any = _NO_DEFAULT,
         options_only: bool = False,
+        allow_none: bool = False,
         hpo_spec: HpoCategorical | None = None,
     ) -> Any:
         full = self._full(name)
+        if isinstance(options, Mapping):
+            keys = list(options.keys())
+        else:
+            keys = list(options)
+        for index, option in enumerate(keys):
+            validate_select_choice(option, param_path=f"{full} option #{index}", allow_none=allow_none)
+        if default is not _NO_DEFAULT:
+            validate_select_choice(default, param_path=full, allow_none=allow_none)
+
         if full in self.overrides:
             key_or_val = self.overrides[full]
-            if isinstance(options, dict):
+            validate_select_choice(key_or_val, param_path=full, allow_none=allow_none)
+            if options_only and key_or_val not in keys:
+                options_str = ", ".join(repr(o) for o in keys[:5])
+                if len(keys) > 5:
+                    options_str += f", ... ({len(keys) - 5} more)"
+                raise ValueError(
+                    f"Parameter '{full}': '{key_or_val}' not in allowed options. Available: [{options_str}]"
+                )
+            if isinstance(options, Mapping) and key_or_val in options:
                 self.collector[full] = key_or_val
                 return options[key_or_val]
             self.collector[full] = key_or_val
             return key_or_val
 
-        if isinstance(options, dict):
-            keys = list(options.keys())
+        if isinstance(options, Mapping):
             key = self.trial.suggest_categorical(full, keys)
             self.collector[full] = key
             return options[key]
         else:
-            choice = self.trial.suggest_categorical(full, list(options))
+            choice = self.trial.suggest_categorical(full, keys)
             self.collector[full] = choice
             return choice
 
@@ -126,9 +166,10 @@ class _HPProxy:
         args: tuple = (),
         kwargs: Dict[str, Any] | None = None,
     ) -> Any:
+        validate_identifier_name(name, kind="nest name")
         overrides = dict(self.overrides)
         if values:
-            flat = _flatten(values)
+            flat = normalize_values(values)
             for k, v in flat.items():
                 overrides[f"{self._full(name)}.{k}"] = v
         nested = _HPProxy(self.trial, self.collector, ns=self.ns + [name], overrides=overrides)

--- a/src/hypster/utils.py
+++ b/src/hypster/utils.py
@@ -1,8 +1,11 @@
 """Utilities for error messages, similarity matching, and validation."""
 
 import inspect
+import keyword
+from collections.abc import Mapping
 from difflib import SequenceMatcher
-from typing import Any, Callable, Dict, List, Tuple
+from functools import lru_cache
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 
 def suggest_similar_names(unknown: str, known: List[str], threshold: float = 0.6) -> List[Tuple[str, float]]:
@@ -18,75 +21,27 @@ def suggest_similar_names(unknown: str, known: List[str], threshold: float = 0.6
     return suggestions
 
 
-def format_error_with_suggestions(
-    unknown_params: Dict[str, Any], suggestions: Dict[str, List[str]], reachability: Dict[str, str]
-) -> str:
-    """
-    Format helpful error messages distinguishing between:
-    - Typos (similar names exist)
-    - Unreachable parameters (exist but not in current conditional path)
-    - Truly unknown parameters
-    """
-    lines = ["Unknown or unreachable parameters:"]
-
-    for param, value in unknown_params.items():
-        if param in suggestions and suggestions[param]:
-            # Typo suggestion
-            similar = suggestions[param][0]  # Take the best suggestion
-            lines.append(f"  - '{param}': Did you mean '{similar}'?")
-        elif param in reachability:
-            # Unreachable parameter
-            lines.append(f"  - '{param}': This parameter exists but is only reachable when {reachability[param]}")
-        else:
-            # Truly unknown
-            lines.append(f"  - '{param}': Unknown parameter")
-
-    return "\n".join(lines)
-
-
-def merge_nested_dicts(dotted: Dict[str, Any], nested: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
-    """
-    Merge dotted keys and nested dicts (nested takes precedence).
-    Returns merged dict and list of conflict warnings.
-    """
-    result = dotted.copy()
-    warnings = []
-
-    # Convert dotted notation to nested structure
-    expanded: Dict[str, Any] = {}
-    for key, value in dotted.items():
-        parts = key.split(".")
-        current = expanded
-        for part in parts[:-1]:
-            if part not in current:
-                current[part] = {}
-            current = current[part]
-        current[parts[-1]] = value
-
-    # Merge with nested dict (nested takes precedence)
-    def merge_recursive(base: Dict[str, Any], override: Dict[str, Any], path: str = "") -> None:
-        for key, value in override.items():
-            full_key = f"{path}.{key}" if path else key
-            if key in base:
-                if isinstance(base[key], dict) and isinstance(value, dict):
-                    merge_recursive(base[key], value, full_key)
-                else:
-                    warnings.append(
-                        f"Parameter '{full_key}' specified in both dotted and nested format, using nested value"
-                    )
-                    base[key] = value
-            else:
-                base[key] = value
-
-    merge_recursive(expanded, nested)
-    return expanded, warnings
-
-
 def validate_config_func_signature(func: Callable) -> None:
     """
     Validate that func has hp: HP as first parameter.
     Raises ValueError with helpful message if not.
     """
+    try:
+        hash(func)
+    except TypeError:
+        _validate_config_func_signature_uncached(func)
+        return
+    _validate_config_func_signature_cached(func)
+
+
+@lru_cache(maxsize=1024)
+def _validate_config_func_signature_cached(func: Callable) -> None:
+    """Cached signature validation for repeat executions of the same config."""
+    _validate_config_func_signature_uncached(func)
+
+
+def _validate_config_func_signature_uncached(func: Callable) -> None:
+    """Validate a config function signature without assuming hashability."""
     try:
         sig = inspect.signature(func)
         params = list(sig.parameters.values())
@@ -119,27 +74,139 @@ def validate_config_func_signature(func: Callable) -> None:
         raise ValueError(f"Error validating configuration function '{func.__name__}': {str(e)}")
 
 
-def flatten_dict(d: Dict[str, Any], parent_key: str = "", sep: str = ".") -> Dict[str, Any]:
-    """Flatten a nested dictionary into dotted notation."""
-    items: List[Tuple[str, Any]] = []
-    for k, v in d.items():
-        new_key = f"{parent_key}{sep}{k}" if parent_key else k
-        if isinstance(v, dict):
-            items.extend(flatten_dict(v, new_key, sep=sep).items())
+def validate_identifier_name(name: Any, *, kind: str = "name") -> str:
+    """Validate a user-facing Hypster name segment."""
+    if not isinstance(name, str):
+        raise ValueError(
+            f"Invalid {kind}: {name!r}\n\n"
+            "  -> Hypster names must be strings\n\n"
+            "How to fix: Use a Python identifier-style string such as 'learning_rate'."
+        )
+    return _validate_identifier_name_cached(name, kind)
+
+
+@lru_cache(maxsize=2048)
+def _validate_identifier_name_cached(name: str, kind: str) -> str:
+    """Cached validation for string identifier segments."""
+    if not name.isidentifier():
+        raise ValueError(
+            f"Invalid {kind}: {name!r}\n\n"
+            "  -> Hypster names must be valid Python identifiers\n\n"
+            "How to fix: Use letters, numbers, and underscores, and do not include dots, spaces, or hyphens."
+        )
+    if keyword.iskeyword(name):
+        raise ValueError(
+            f"Invalid {kind}: {name!r}\n\n"
+            f"  -> {name!r} is a Python keyword and cannot be used as a Hypster name\n\n"
+            f"How to fix: Use a different name, such as '{name}_value'."
+        )
+    return name
+
+
+def validate_parameter_path(path: Any, *, kind: str = "values key") -> str:
+    """Validate a dotted Hypster parameter path."""
+    if not isinstance(path, str):
+        raise ValueError(
+            f"Invalid {kind}: {path!r}\n\n"
+            "  -> Values keys must be strings\n\n"
+            "How to fix: Use a dotted parameter path such as 'model.learning_rate'."
+        )
+    return _validate_parameter_path_cached(path, kind)
+
+
+@lru_cache(maxsize=4096)
+def _validate_parameter_path_cached(path: str, kind: str) -> str:
+    """Cached validation for string dotted parameter paths."""
+    for segment in path.split("."):
+        validate_identifier_name(segment, kind=f"{kind} segment")
+    return path
+
+
+def validate_select_choice(value: Any, *, param_path: str, allow_none: bool = False) -> Any:
+    """Validate a select key/custom value is safe to log and replay."""
+    try:
+        return _validate_select_choice_cached(value, param_path, allow_none)
+    except TypeError:
+        return _validate_select_choice_uncached(value, param_path=param_path, allow_none=allow_none)
+
+
+@lru_cache(maxsize=4096, typed=True)
+def _validate_select_choice_cached(value: Any, param_path: str, allow_none: bool) -> Any:
+    """Cached validation for hashable select choices."""
+    return _validate_select_choice_uncached(value, param_path=param_path, allow_none=allow_none)
+
+
+def _validate_select_choice_uncached(value: Any, *, param_path: str, allow_none: bool = False) -> Any:
+    """Validate a select choice without assuming hashability."""
+    if value is None:
+        if allow_none:
+            return value
+        raise ValueError(
+            f"Parameter '{param_path}': None is only allowed when allow_none=True.\n\n"
+            "How to fix: pass allow_none=True, or use a string key such as 'none' in a dict-backed select."
+        )
+
+    if isinstance(value, (bool, int, float, str)):
+        return value
+
+    raise ValueError(
+        f"Parameter '{param_path}': Select choices must be logging-safe scalar values "
+        f"(None, bool, int, float, or str), got {type(value).__name__} ({value!r}).\n\n"
+        "How to fix: Use dict-backed select so the key is simple and the mapped value can be complex. "
+        "Example: hp.select({'small': {'layers': 2}}, name='model')."
+    )
+
+
+def normalize_values(values: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+    """Flatten nested values into dotted paths and reject duplicate paths."""
+    if values is None:
+        return {}
+    if not isinstance(values, Mapping):
+        raise ValueError(
+            f"Invalid values: expected a dictionary of parameter paths to values, got {type(values).__name__}.\n\n"
+            "How to fix: pass values={'learning_rate': 0.1} or values={'model': {'depth': 3}}."
+        )
+    if not values:
+        return {}
+
+    flat_values: Dict[str, Any] = {}
+    for key, value in values.items():
+        if isinstance(value, Mapping):
+            break
+        flat_values[validate_parameter_path(key)] = value
+    else:
+        return flat_values
+
+    normalized: Dict[str, Any] = {}
+    sources: Dict[str, str] = {}
+
+    def add_validated(path: str, value: Any, source: str) -> None:
+        if path in normalized:
+            raise ValueError(
+                f"Duplicate value for '{path}': provided via both {sources[path]} and {source}.\n\n"
+                "How to fix: Use only one form for each parameter path."
+            )
+        normalized[path] = value
+        sources[path] = source
+
+    def nested_source(parts: tuple[str, ...]) -> str:
+        return "nested dict " + " -> ".join(repr(part) for part in parts)
+
+    def visit_nested(prefix: str, mapping: Mapping[str, Any], source_parts: tuple[str, ...]) -> None:
+        for key, value in mapping.items():
+            segment = validate_identifier_name(key, kind="nested values key")
+            full_path = f"{prefix}.{segment}" if prefix else segment
+            parts = (*source_parts, segment)
+            if isinstance(value, Mapping):
+                visit_nested(full_path, value, parts)
+            else:
+                add_validated(full_path, value, nested_source(parts))
+
+    for key, value in values.items():
+        key_path = validate_parameter_path(key)
+        if isinstance(value, Mapping):
+            visit_nested(key_path, value, (key,))
         else:
-            items.append((new_key, v))
-    return dict(items)
-
-
-def unflatten_dict(d: Dict[str, Any], sep: str = ".") -> Dict[str, Any]:
-    """Convert dotted notation dictionary to nested structure."""
-    result: Dict[str, Any] = {}
-    for key, value in d.items():
-        parts = key.split(sep)
-        current = result
-        for part in parts[:-1]:
-            if part not in current:
-                current[part] = {}
-            current = current[part]
-        current[parts[-1]] = value
-    return result
+            source = f"dotted key {key!r}" if "." in key else f"key {key!r}"
+            add_validated(key_path, value, source)
+    return normalized

--- a/tests/test_basic_parameters.py
+++ b/tests/test_basic_parameters.py
@@ -113,3 +113,50 @@ def test_bool_parameter() -> None:
     # Type validation
     with pytest.raises(ValueError, match="expected boolean"):
         instantiate(config, values={"flag": "true"})
+
+
+def test_allow_none_scalar_params_make_none_explicit() -> None:
+    """None defaults and overrides require allow_none=True for reproducible params."""
+
+    def config(hp: HP) -> Dict[str, object]:
+        return {
+            "depth": hp.int(None, name="depth", allow_none=True),
+            "temperature": hp.float(0.2, name="temperature", allow_none=True),
+            "label": hp.text("baseline", name="label", allow_none=True),
+            "enabled": hp.bool(True, name="enabled", allow_none=True),
+        }
+
+    assert instantiate(config) == {
+        "depth": None,
+        "temperature": 0.2,
+        "label": "baseline",
+        "enabled": True,
+    }
+    assert instantiate(
+        config,
+        values={
+            "depth": 3,
+            "temperature": None,
+            "label": None,
+            "enabled": None,
+        },
+    ) == {
+        "depth": 3,
+        "temperature": None,
+        "label": None,
+        "enabled": None,
+    }
+
+
+def test_none_requires_allow_none_for_scalar_params() -> None:
+    def none_default(hp: HP) -> object:
+        return hp.int(None, name="depth")
+
+    with pytest.raises(ValueError, match="allow_none=True"):
+        instantiate(none_default)
+
+    def none_override(hp: HP) -> object:
+        return hp.float(0.1, name="temperature")
+
+    with pytest.raises(ValueError, match="allow_none=True"):
+        instantiate(none_override, values={"temperature": None})

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -100,5 +100,22 @@ def test_reserved_prefix_collision() -> None:
         nested = hp.nest(child, name="model")
         return {"bad": bad, "nested": nested}
 
-    with pytest.raises(ValueError, match="prefix 'model' reserved"):
+    with pytest.raises(ValueError, match="valid Python identifiers"):
         instantiate(parent)
+
+
+def test_hp_names_must_be_python_identifiers() -> None:
+    def bad_param(hp: HP) -> int:
+        return hp.int(1, name="bad-name")
+
+    with pytest.raises(ValueError, match="valid Python identifiers"):
+        instantiate(bad_param)
+
+    def bad_nest(hp: HP) -> Dict[str, int]:
+        def child(hp: HP) -> int:
+            return hp.int(1, name="value")
+
+        return {"child": hp.nest(child, name="class")}
+
+    with pytest.raises(ValueError, match="Python keyword"):
+        instantiate(bad_nest)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,6 +1,5 @@
 """Test error handling strategies for unknown parameters."""
 
-import warnings
 from typing import Any, Dict
 
 import pytest
@@ -8,33 +7,24 @@ import pytest
 from hypster import HP, instantiate
 
 
-def test_on_unknown_warn_default() -> None:
-    """Test that on_unknown='warn' is the default behavior."""
+def test_on_unknown_raise_default() -> None:
+    """Test that on_unknown='raise' is the default behavior."""
 
     def config(hp: HP) -> Dict[str, float]:
         lr = hp.float(0.1, name="learning_rate")
         return {"lr": lr}
 
-    # Default behavior should warn
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        result = instantiate(config, values={"unknown_param": 0.05})
+    with pytest.raises(ValueError) as exc_info:
+        instantiate(config, values={"unknown_param": 0.05})
 
-        # Should complete successfully with defaults
-        assert result == {"lr": 0.1}
-
-        # Should have issued a warning
-        assert len(w) == 1
-        assert "'unknown_param': Unknown parameter" in str(w[0].message)
+    assert "'unknown_param': Unknown parameter" in str(exc_info.value)
+    assert "explore(config, values=...)" in str(exc_info.value)
 
     # Explicit warn should behave the same
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
+    with pytest.warns(UserWarning, match="'unknown_param': Unknown parameter"):
         result = instantiate(config, values={"unknown_param": 0.05}, on_unknown="warn")
 
-        assert result == {"lr": 0.1}
-        assert len(w) == 1
-        assert "'unknown_param': Unknown parameter" in str(w[0].message)
+    assert result == {"lr": 0.1}
 
 
 def test_on_unknown_raise() -> None:
@@ -61,6 +51,27 @@ def test_on_unknown_ignore() -> None:
     assert result == {"lr": 0.1}
 
 
+def test_on_unknown_invalid_policy_has_guidance() -> None:
+    calls = []
+
+    def config(hp: HP) -> Dict[str, float]:
+        calls.append("executed")
+        return {"lr": hp.float(0.1, name="learning_rate")}
+
+    with pytest.raises(ValueError, match="on_unknown must be one of"):
+        instantiate(config, values={"learning_rate": 0.2}, on_unknown="silent")  # type: ignore[arg-type]
+
+    assert calls == []
+
+
+def test_values_must_be_a_mapping() -> None:
+    def config(hp: HP) -> Dict[str, float]:
+        return {"lr": hp.float(0.1, name="learning_rate")}
+
+    with pytest.raises(ValueError, match="expected a dictionary"):
+        instantiate(config, values=["learning_rate"])  # type: ignore[arg-type]
+
+
 def test_on_unknown_with_suggestions() -> None:
     """Test that error messages include helpful suggestions."""
 
@@ -69,12 +80,10 @@ def test_on_unknown_with_suggestions() -> None:
         temperature = hp.float(0.7, name="temperature")
         return {"lr": learning_rate, "temp": temperature}
 
-    # Typo should suggest similar parameter (in warn mode by default)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        result = instantiate(config, values={"lerning_rate": 0.05})
+    # Typo should suggest similar parameter in warn mode
+    with pytest.warns(UserWarning) as w:
+        result = instantiate(config, values={"lerning_rate": 0.05}, on_unknown="warn")
 
-        assert len(w) == 1
         warning_msg = str(w[0].message)
         assert "lerning_rate" in warning_msg
         assert "learning_rate" in warning_msg  # suggestion
@@ -112,18 +121,27 @@ def test_on_unknown_conditional_reachability() -> None:
             penalty = hp.text("l2", name="penalty")
             return {"model": "logistic", "penalty": penalty}
 
-    # Default warn mode should warn about unreachable parameter
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        result = instantiate(
+    with pytest.raises(ValueError) as exc_info:
+        instantiate(
             config,
             values={"n_trees": 200},  # unreachable when model_type='logistic'
         )
 
-        # Should complete with logistic model
-        assert result == {"model": "logistic", "penalty": "l2"}
+    assert "n_trees" in str(exc_info.value)
+    assert "explore(config, values=...)" in str(exc_info.value)
 
-        # Should warn about unreachable parameter
-        assert len(w) == 1
-        assert "n_trees" in str(w[0].message)
-        assert "unreachable" in str(w[0].message).lower()
+
+def test_nested_values_unknown_keys_participate_in_on_unknown() -> None:
+    def child(hp: HP) -> Dict[str, float]:
+        return {"lr": hp.float(0.1, name="learning_rate")}
+
+    def config(hp: HP) -> Dict[str, Dict[str, float]]:
+        return {"model": hp.nest(child, name="model")}
+
+    with pytest.raises(ValueError) as exc_info:
+        instantiate(config, values={"model": {"lerning_rate": 0.2}})
+
+    error = str(exc_info.value)
+    assert "model.lerning_rate" in error
+    assert "model.learning_rate" in error
+    assert "Nested dict values are interpreted as parameter paths" in error

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -165,18 +165,21 @@ def test_explore_values_select_a_different_branch() -> None:
     )
 
 
-def test_explore_warns_on_unknown_or_unreachable_values() -> None:
+def test_explore_raises_on_unknown_or_unreachable_values_by_default() -> None:
     def config(hp: HP) -> Dict[str, Any]:
         mode = hp.select(["a", "b"], name="mode", default="a")
         if mode == "a":
             hp.int(1, name="count")
         return {"mode": mode}
 
-    with pytest.warns(UserWarning, match="Unknown or unreachable parameters"):
+    with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
         explore(config, values={"missing": 123})
 
-    with pytest.warns(UserWarning, match="Unknown or unreachable parameters"):
+    with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
         explore(config, values={"mode": "b", "count": 9})
+
+    with pytest.warns(UserWarning, match="Unknown or unreachable parameters"):
+        explore(config, values={"missing": 123}, on_unknown="warn")
 
 
 def test_explore_can_raise_on_unknown_values() -> None:
@@ -188,13 +191,30 @@ def test_explore_can_raise_on_unknown_values() -> None:
         explore(config, values={"batchsize": 7}, on_unknown="raise")
 
 
+def test_explore_validates_on_unknown_before_execution() -> None:
+    calls = []
+
+    def config(hp: HP) -> Dict[str, Any]:
+        calls.append("executed")
+        return {"x": hp.int(1, name="x")}
+
+    with pytest.raises(ValueError, match="on_unknown must be one of"):
+        explore(config, on_unknown="silent")  # type: ignore[arg-type]
+
+    assert calls == []
+
+
 def test_explore_to_dict_is_json_serializable() -> None:
     class Provider(Enum):
         OPENAI = "openai"
         GEMINI = "gemini"
 
     def config(hp: HP) -> Dict[str, Any]:
-        provider = hp.select([Provider.OPENAI, Provider.GEMINI], name="provider", default=Provider.OPENAI)
+        provider = hp.select(
+            {"openai": Provider.OPENAI, "gemini": Provider.GEMINI},
+            name="provider",
+            default="openai",
+        )
         return {"provider": provider}
 
     info = explore(config, return_info=True)

--- a/tests/test_hpo_optuna_edge.py
+++ b/tests/test_hpo_optuna_edge.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hypster import HP
 from hypster.hpo.optuna import suggest_values
 from hypster.hpo.types import HpoInt
@@ -30,3 +32,29 @@ def test_include_max_reduces_high():
     name, low, high, step, log = t.calls[0]
     assert (name, low, step, log) == ("n", 0, 2, False)
     assert high == 8
+
+
+def test_hpo_proxy_rejects_invalid_names_and_nullable_numeric_params():
+    def bad_name(hp: HP):
+        return hp.int(1, name="bad-name")
+
+    with pytest.raises(ValueError, match="valid Python identifiers"):
+        suggest_values(TrialSpy(), config=bad_name)
+
+    def nullable_int(hp: HP):
+        return hp.int(None, name="depth", allow_none=True)
+
+    with pytest.raises(ValueError, match="not supported"):
+        suggest_values(TrialSpy(), config=nullable_int)
+
+
+def test_hpo_proxy_rejects_complex_select_choices_with_dict_guidance():
+    class CategoricalTrial(TrialSpy):
+        def suggest_categorical(self, name, options):
+            return options[0]
+
+    def config(hp: HP):
+        return hp.select([{"layers": 2}], name="model")
+
+    with pytest.raises(ValueError, match="Use dict-backed select"):
+        suggest_values(CategoricalTrial(), config=config)

--- a/tests/test_instantiate_with_params.py
+++ b/tests/test_instantiate_with_params.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from hypster import HP, instantiate, instantiate_with_params
+
+
+def test_instantiate_with_params_returns_value_and_replayable_selected_params() -> None:
+    def openai(hp: HP) -> Dict[str, Any]:
+        return {
+            "model": hp.select(["gpt-4o-mini", "gpt-4.1"], name="model", default="gpt-4o-mini"),
+            "temperature": hp.float(0.2, name="temperature", min=0.0, max=2.0),
+        }
+
+    def config(hp: HP) -> Dict[str, Any]:
+        provider = hp.select(["gemini", "openai"], name="provider", default="gemini")
+        if provider == "openai":
+            llm = hp.nest(openai, name="openai")
+        else:
+            llm = {"model": hp.select(["flash-lite", "pro"], name="model", default="flash-lite")}
+        return {"provider": provider, "llm": llm}
+
+    output = instantiate_with_params(config, values={"provider": "openai", "openai.temperature": 0.7})
+
+    assert output.value == {
+        "provider": "openai",
+        "llm": {"model": "gpt-4o-mini", "temperature": 0.7},
+    }
+    assert output.params == {
+        "provider": "openai",
+        "openai.model": "gpt-4o-mini",
+        "openai.temperature": 0.7,
+    }
+    assert instantiate(config, values=output.params) == output.value
+
+
+def test_instantiate_with_params_validates_on_unknown_before_execution() -> None:
+    calls = []
+
+    def config(hp: HP) -> Dict[str, int]:
+        calls.append("executed")
+        return {"x": hp.int(1, name="x")}
+
+    with pytest.raises(ValueError, match="on_unknown must be one of"):
+        instantiate_with_params(config, on_unknown="silent")  # type: ignore[arg-type]
+
+    assert calls == []

--- a/tests/test_multi_parameters.py
+++ b/tests/test_multi_parameters.py
@@ -127,3 +127,25 @@ def test_multi_select_dict_mixed_usage() -> None:
     # Mix of preset keys and custom values
     result = instantiate(config, values={"configs": ["preset1", "custom", "preset2"]})
     assert result == ["config1", "custom", "config2"]
+
+
+def test_multi_select_none_choice_requires_allow_none() -> None:
+    def nullable_config(hp: HP) -> List[object]:
+        return hp.multi_select([None, "cache"], name="features", default=[None], allow_none=True)
+
+    assert instantiate(nullable_config) == [None]
+    assert instantiate(nullable_config, values={"features": [None, "cache"]}) == [None, "cache"]
+
+    def missing_allow_none(hp: HP) -> List[object]:
+        return hp.multi_select([None, "cache"], name="features", default=[None])
+
+    with pytest.raises(ValueError, match="allow_none=True"):
+        instantiate(missing_allow_none)
+
+
+def test_nullable_scalar_multi_params_are_not_supported_yet() -> None:
+    def config(hp: HP) -> List[int]:
+        return hp.multi_int([1, 2], name="depths", allow_none=True)
+
+    with pytest.raises(ValueError, match="not supported"):
+        instantiate(config)

--- a/tests/test_nesting.py
+++ b/tests/test_nesting.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict
 
+import pytest
+
 from hypster import HP, instantiate
 
 
@@ -67,8 +69,8 @@ def test_conditional_nesting() -> None:
     assert result == {"model": {"type": "B", "param": 3.0}}
 
 
-def test_nested_dict_override_precedence() -> None:
-    """Test that nested dict values take precedence over dotted keys."""
+def test_duplicate_dotted_and_nested_values_raise() -> None:
+    """Test that one parameter path cannot be provided in both values forms."""
 
     def child(hp: HP) -> Dict[str, int]:
         x = hp.int(10, name="x")
@@ -78,12 +80,27 @@ def test_nested_dict_override_precedence() -> None:
     def parent(hp: HP) -> Dict[str, int]:
         return hp.nest(child, name="child")
 
-    # Both dotted and nested dict notation - nested dict wins
-    result = instantiate(
-        parent,
-        values={
-            "child.x": 100,  # dotted notation
-            "child": {"x": 200},  # nested dict notation
-        },
-    )
-    assert result == {"x": 200, "y": 20}  # nested dict wins
+    with pytest.raises(ValueError) as exc_info:
+        instantiate(
+            parent,
+            values={
+                "child.x": 100,
+                "child": {"x": 100},
+            },
+        )
+
+    assert "Duplicate value for 'child.x'" in str(exc_info.value)
+    assert "dotted key 'child.x'" in str(exc_info.value)
+    assert "nested dict 'child' -> 'x'" in str(exc_info.value)
+    assert "Use only one form" in str(exc_info.value)
+
+
+def test_nested_values_keys_must_be_identifier_segments() -> None:
+    def child(hp: HP) -> Dict[str, int]:
+        return {"x": hp.int(10, name="x")}
+
+    def parent(hp: HP) -> Dict[str, int]:
+        return hp.nest(child, name="child")
+
+    with pytest.raises(ValueError, match="nested values key"):
+        instantiate(parent, values={"child": {"x.y": 100}})

--- a/tests/test_select_parameters.py
+++ b/tests/test_select_parameters.py
@@ -125,3 +125,57 @@ def test_select_dict_none_and_tuples() -> None:
     result = instantiate(config, values={"tokenizer": "basic", "ngram_range": "trigram"})
     assert result["tokenizer"] == "basic_tokenizer"
     assert result["ngram_range"] == (1, 3)
+
+
+def test_select_none_choice_requires_allow_none() -> None:
+    def nullable_config(hp: HP) -> object:
+        return hp.select([None, "hello"], name="model", default=None, allow_none=True)
+
+    assert instantiate(nullable_config) is None
+    assert instantiate(nullable_config, values={"model": "hello"}) == "hello"
+    assert instantiate(nullable_config, values={"model": None}) is None
+
+    def missing_allow_none(hp: HP) -> object:
+        return hp.select([None, "hello"], name="model", default=None)
+
+    with pytest.raises(ValueError, match="allow_none=True"):
+        instantiate(missing_allow_none)
+
+
+def test_select_rejects_complex_list_options_with_dict_guidance() -> None:
+    def config(hp: HP) -> object:
+        return hp.select([{"layers": 2}, {"layers": 4}], name="model")
+
+    with pytest.raises(ValueError) as exc_info:
+        instantiate(config)
+
+    error = str(exc_info.value)
+    assert "Select choices must be logging-safe" in error
+    assert "Use dict-backed select" in error
+
+
+def test_select_choice_validation_preserves_bool_int_identity() -> None:
+    from hypster.utils import validate_select_choice
+
+    assert type(validate_select_choice(True, param_path="choice")) is bool
+    assert type(validate_select_choice(1, param_path="choice")) is int
+    assert type(validate_select_choice(1.0, param_path="choice")) is float
+
+
+def test_select_dict_keys_are_logged_even_when_values_are_complex() -> None:
+    from hypster import instantiate_with_params
+
+    def config(hp: HP) -> Dict[str, Any]:
+        return hp.select(
+            {
+                "small": {"layers": 2, "units": [64, 32]},
+                "large": {"layers": 4, "units": [256, 128]},
+            },
+            name="model",
+            default="small",
+        )
+
+    output = instantiate_with_params(config, values={"model": "large"})
+
+    assert output.value == {"layers": 4, "units": [256, 128]}
+    assert output.params == {"model": "large"}

--- a/tests/test_utils_additions.py
+++ b/tests/test_utils_additions.py
@@ -1,8 +1,0 @@
-from hypster.utils import flatten_dict, unflatten_dict
-
-
-def test_flatten_unflatten_roundtrip():
-    nested = {"a": {"b": 1, "c": {"d": 2}}, "x": 3}
-    flat = flatten_dict(nested)
-    assert flat == {"a.b": 1, "a.c.d": 2, "x": 3}
-    assert unflatten_dict(flat) == nested

--- a/uv.lock
+++ b/uv.lock
@@ -380,7 +380,7 @@ wheels = [
 
 [[package]]
 name = "hypster"
-version = "0.3.10"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What changed

- Added `instantiate_with_params()` and `InstantiationOutput` so callers can log the returned value plus a flat, replayable `params` dictionary.
- Made unknown/unreachable `values` strict by default across `instantiate()`, `instantiate_with_params()`, and `explore()`.
- Normalized nested `values` into dotted paths, rejected duplicate dotted/nested entries with source-aware errors, and validated path/name segments as Python identifiers.
- Added explicit `allow_none=True` handling for scalar params and `select`/`multi_select` choices.
- Required select choices to be logging-safe scalar values, with dict-backed select documented as the path for complex mapped return values.
- Cleaned up the implementation after thermo/adversarial review: shared the instantiate run loop, validated `on_unknown` before executing user code, removed dead flatten/unflatten helpers and select-choice caches, shared the no-default sentinel, aligned HPO/HP mapping checks, and repaired stale nesting docs.
- Updated docs, domain context, ADR, changelog, and bumped the package to `0.4.0` because the strictness changes are user-visible breaking changes.

## Before / After

Before, a run could instantiate successfully while leaving no complete selected-param sidecar for logging defaults:

```python
cfg = instantiate(config, values={"provider": "openai"})
# returned only the configured object/value
```

After, callers can log defaults and replay the same branch:

```python
run = instantiate_with_params(config, values={"provider": "openai"})

run.value
# configured object/value

run.params
# {"provider": "openai", "openai.model": "gpt-4o-mini", "openai.temperature": 0.2}

assert instantiate(config, values=run.params) == run.value
```

Before, unknown or unreachable values warned by default. After, they fail with guidance:

```python
instantiate(config, values={"aggregation_llm.model": "flash"})
# ValueError: Unknown or unreachable parameters:
#   - 'aggregation_llm.model': Unknown parameter
#
# Run explore(config, values=...) to inspect the active branch.
# Nested dict values are interpreted as parameter paths; use dict-backed select keys for objects.
```

Before, duplicate dotted/nested values could silently choose one shape. After, duplicate paths are malformed input:

```python
instantiate(config, values={"child.x": 1, "child": {"x": 1}})
# ValueError: Duplicate value for 'child.x': provided via both dotted key 'child.x' and nested dict 'child' -> 'x'.
```

## Validation

- `uv run --group dev ruff format .`
- `uv run --group dev ruff check .`
- `uv run --group dev pytest -q` (79 passed)
- `uv run --group dev mypy src/hypster`
- `uv run pytest tests/ --codspeed` (2 benchmarked)
