### PR TITLE
Add interactive notebook instantiation UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interactive errors no longer expose stale selected params in snapshots while `result.params` is raising.
 - Branch choice memory skips incompatible remembered multi-value inputs instead of replaying invalid hidden state.
 - Branch choice memory distinguishes reused parameter paths by reachable branch context and parameter metadata, so same-name branch parameters do not leak values into each other.
+- VS Code notebook outputs now receive a pre-widget background shim so the anywidget renderer does not leave the host's white widget-output background visible in dark themes.
 - Reset now reports exploration or instantiation errors in the snapshot instead of leaking stale values or raising out of the widget action.
 
 ## [0.4.0] - 2026-05-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2026-05-23
 
 ### Added
-- `interact()` for live Jupyter notebook instantiation through an `InteractiveResult` handle with `.value`, `.params`, `.snapshot`, and `.interact()`.
+- `interact()` for live notebook instantiation through an `InteractiveResult` handle with `.value`, `.params`, `.snapshot`, and `.interact()`.
 - A minimal anywidget renderer for interactive instantiation, using file-backed vanilla JavaScript and scoped CSS instead of React or inline HTML blobs.
 - In-memory branch choice memory for interactive sessions, so branch-specific selections are restored when users switch away and back.
 - `auto_apply=False` manual apply mode for staging widget edits before updating `result.value` and `result.params`.
-- The `viz` extra for installing interactive notebook widget dependencies; `jupyter` remains available as a compatibility alias.
+- The `viz` extra for installing interactive notebook widget dependencies across Jupyter Notebook, JupyterLab, and VS Code notebooks.
 - Optional `description=` metadata for hyperparameters and `hp.nest(...)`, surfaced in explore schemas and the notebook UI.
 - Humanized display labels in explore schema metadata, such as rendering `top_k` as "Top K".
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A minimal anywidget renderer for interactive instantiation, using file-backed vanilla JavaScript and scoped CSS instead of React or inline HTML blobs.
 - In-memory branch choice memory for interactive sessions, so branch-specific selections are restored when users switch away and back.
 - `auto_apply=False` manual apply mode for staging widget edits before updating `result.value` and `result.params`.
+- The `viz` extra for installing interactive notebook widget dependencies; `jupyter` remains available as a compatibility alias.
 - Optional `description=` metadata for hyperparameters and `hp.nest(...)`, surfaced in explore schemas and the notebook UI.
 - Humanized display labels in explore schema metadata, such as rendering `top_k` as "Top K".
 
 ### Changed
-- The `jupyter` extra now installs `anywidget` and `jupyterlab_widgets` for the custom notebook renderer.
+- Interactive widget setup errors now tell users to install `hypster[viz]` when widget dependencies are missing.
 - Interactive snapshots expose draft values, applied values, current status, and explicit exploration or instantiation errors for renderer-neutral UIs.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-select and empty multi-value widget edits now round-trip through the notebook transport correctly.
 - Interactive errors no longer expose stale selected params in snapshots while `result.params` is raising.
 - Branch choice memory skips incompatible remembered multi-value inputs instead of replaying invalid hidden state.
+- Branch choice memory distinguishes reused parameter paths by reachable branch context and parameter metadata, so same-name branch parameters do not leak values into each other.
 - Reset now reports exploration or instantiation errors in the snapshot instead of leaking stale values or raising out of the widget action.
 
 ## [0.4.0] - 2026-05-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Humanized display labels in explore schema metadata, such as rendering `top_k` as "Top K".
 
 ### Changed
-- The `jupyter` extra now installs `anywidget` for the custom notebook renderer.
+- The `jupyter` extra now installs `anywidget` and `jupyterlab_widgets` for the custom notebook renderer.
 - Interactive snapshots expose draft values, applied values, current status, and explicit exploration or instantiation errors for renderer-neutral UIs.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-23
+
+### Added
+- `interact()` for live Jupyter notebook instantiation through an `InteractiveResult` handle with `.value`, `.params`, `.snapshot`, and `.interact()`.
+- A minimal anywidget renderer for interactive instantiation, using file-backed vanilla JavaScript and scoped CSS instead of React or inline HTML blobs.
+- In-memory branch choice memory for interactive sessions, so branch-specific selections are restored when users switch away and back.
+- `auto_apply=False` manual apply mode for staging widget edits before updating `result.value` and `result.params`.
+- Optional `description=` metadata for hyperparameters and `hp.nest(...)`, surfaced in explore schemas and the notebook UI.
+- Humanized display labels in explore schema metadata, such as rendering `top_k` as "Top K".
+
+### Changed
+- The `jupyter` extra now installs `anywidget` for the custom notebook renderer.
+- Interactive snapshots expose draft values, applied values, current status, and explicit exploration or instantiation errors for renderer-neutral UIs.
+
+### Fixed
+- The notebook renderer preserves non-string select values instead of letting HTML option values coerce everything to strings.
+- Multi-select and empty multi-value widget edits now round-trip through the notebook transport correctly.
+- Interactive errors no longer expose stale selected params in snapshots while `result.params` is raising.
+- Branch choice memory skips incompatible remembered multi-value inputs instead of replaying invalid hidden state.
+- Reset now reports exploration or instantiation errors in the snapshot instead of leaking stale values or raising out of the widget action.
+
 ## [0.4.0] - 2026-05-22
 
 ### Added

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,54 @@ _Avoid_: replacing the raw return value of `instantiate`
 Structured metadata describing the reachable parameters, defaults, bounds, options, and nesting for a configuration function branch.
 _Avoid_: selected params
 
+**Parameter Description**:
+Optional human-written helper text attached to a parameter for lightweight display in interactive UIs and schema metadata.
+_Avoid_: docstring, tooltip-only text
+
+**Display Label**:
+A human-readable label derived from a parameter or group name unless explicitly provided by schema metadata.
+_Avoid_: parameter path, description
+
+**Interactive Snapshot**:
+A JSON-friendly record of the current interactive exploration state, including reachable widget metadata, current override inputs, selected params, display state, and errors.
+_Avoid_: UI schema, frontend state, selected params
+
+**Interactive Action**:
+A renderer-originated command that asks the interactive controller to change session state and produce a new interactive snapshot.
+_Avoid_: frontend validation, JavaScript branch logic
+
+**Interactive Result**:
+The live object returned by interactive instantiation, exposing the latest instantiation value and selected params for one interactive session.
+_Avoid_: result dict, widget, instantiation value
+
+**Apply Mode**:
+The interactive session behavior that decides whether widget changes are applied immediately or staged until the user explicitly applies them.
+_Avoid_: save mode, persistence mode
+
+**Interactive Baseline**:
+The initial reachable widget state for an interactive session, derived from validated seed values or configuration defaults.
+_Avoid_: reset defaults, saved state
+
+**Draft Values**:
+The current reachable override inputs represented by the interactive widgets, including unapplied edits in manual apply mode.
+_Avoid_: selected params, pending params
+
+**Applied Values**:
+The reachable override inputs that produced the current interactive result value and selected params.
+_Avoid_: saved values, committed params
+
+**Branch Choice Memory**:
+Session-local remembered widget choices used to restore compatible values when conditional parameters become reachable again.
+_Avoid_: selected params, hidden values
+
+**Exploration Error**:
+An error that prevents draft values from producing a valid explore schema.
+_Avoid_: instantiation error, result error
+
+**Instantiation Error**:
+An error that occurs while applying values to produce an instantiation value and selected params.
+_Avoid_: exploration error, validation error
+
 ## Relationships
 
 - A **Configuration Function** can be executed with **Values**.
@@ -83,6 +131,60 @@ _Avoid_: selected params
 - `allow_none=True` applies to scalar parameters and select choices, including `multi_select`; nullable elements for `multi_int`, `multi_float`, `multi_text`, and `multi_bool` are not supported yet and must fail with clear guidance.
 - **Selected Params** contain only **Logging-Safe Values**.
 - An **Explore Schema** describes parameter metadata; it is not the run's **Selected Params**.
+- An **Explore Schema** may include a **Parameter Description** for each reachable parameter.
+- Interactive UI renderers should derive **Display Labels** by humanizing names, such as rendering `top_k` as "Top K".
+- An **Interactive Snapshot** is produced by an interactive controller for one current widget state.
+- An **Interactive Snapshot** includes the current **Explore Schema**, **Draft Values**, **Applied Values**, current **Selected Params**, and any current exploration or instantiation error.
+- An **Interactive Snapshot** may include notebook-friendly display metadata for an **Instantiation Value**, but the raw **Instantiation Value** remains available through the returned proxy.
+- Remembered branch choices in an interactive session are UI input memory; they are not **Selected Params** until their parameter paths are reachable in the current **Interactive Snapshot**.
+- Notebook, Streamlit, and React renderers should consume the same **Interactive Snapshot** contract instead of each inventing a parameter metadata model.
+- A renderer sends **Interactive Actions** to an interactive controller; the controller applies Hypster semantics and returns a new **Interactive Snapshot**.
+- **Interactive Actions** must not implement branch reachability, parameter validation, or selected-param collection in the renderer.
+- The interactive controller must validate **Values** through the same `explore` and `instantiate_with_params` code paths as non-interactive execution.
+- The interactive controller must not soften or duplicate backend validation for **Values**, select choices, nullability, unknown paths, or unreachable paths.
+- `interact(config)` returns an **Interactive Result**.
+- An **Interactive Result** can be displayed more than once, with each view attached to the same live interactive session.
+- `result.interact()` renders another live interactive view attached to the same interactive session.
+- A fresh interactive session seeded from a prior run must be explicit through **Values**, such as `interact(config, values=result.params)`.
+- `interact(config, values=...)` follows the same reachable **Values** rules as `explore` and `instantiate`; unreachable or unknown paths are not accepted as hidden branch memory.
+- Reachable `values=` entries seed both the initial widget state and the remembered branch-choice state for that interactive session.
+- **Branch Choice Memory** is created only from reachable `values=` entries and subsequent user **Interactive Actions** during the live session.
+- **Branch Choice Memory** is in-memory state scoped to one **Interactive Result**; it is not persisted or shared across fresh interactive sessions.
+- When a parameter becomes reachable again, the interactive controller chooses the most recent compatible value from **Branch Choice Memory**, then the parameter default, then the first available option when the parameter kind supports option fallback.
+- Incompatible remembered values are skipped rather than treated as errors.
+- **Branch Choice Memory** applies to nested parameters by **Parameter Path**.
+- Reset restores the **Interactive Baseline**, clears later branch memory and pending edits, and applies that restored state immediately.
+- An **Interactive Result** exposes the latest **Instantiation Value** separately from the latest **Interactive Snapshot**.
+- An **Interactive Result** exposes the latest **Selected Params** through `params`.
+- `result.params` returns a caller-owned plain dictionary copy.
+- `result.value` returns the current **Instantiation Value** itself, not a defensive copy.
+- An **Interactive Result** is a live handle, not the raw **Instantiation Value**.
+- Notebook users read the current instantiated object through `result.value`.
+- Because `interact(config)` returns a live handle instead of a raw **Instantiation Value**, there is no separate `interact_params` API.
+- When the current interactive state cannot instantiate, `result.value` and `result.params` raise the current error instead of returning a stale previous value.
+- `interact(config)` uses immediate **Apply Mode** by default, so valid widget actions update `result.value` and `result.params` live.
+- Users can pass `auto_apply=False` to use manual **Apply Mode**, where widget changes are staged until an explicit Apply action updates `result.value` and `result.params`.
+- Numeric controls may use interaction latency, such as applying on slider release or debounced text commit, so dragging and typing are not interrupted by repeated rerenders.
+- In manual **Apply Mode**, **Draft Values** may differ from **Applied Values**.
+- In manual **Apply Mode**, `explore(config, values=draft_values)` still runs after draft widget changes so reachable widgets and options stay current.
+- In manual **Apply Mode**, `result.value` and `result.params` expose the last **Applied Values** state while unapplied **Draft Values** remain pending.
+- In manual **Apply Mode**, invalid **Draft Values** keep Apply disabled and do not change `result.value` or `result.params`.
+- In manual **Apply Mode**, `result.value` and `result.params` raise only when the last applied state itself has an error, not merely because pending **Draft Values** are invalid.
+- Instantiation happens when **Draft Values** are applied, not lazily when `result.value` or `result.params` is read.
+- In immediate **Apply Mode**, valid **Draft Values** become **Applied Values** after each applied widget action.
+- In immediate **Apply Mode**, invalid widget actions put the session in an applied error state; `result.value` and `result.params` raise until the widget state is fixed.
+- Interactive UI renderers must show current exploration or instantiation errors clearly enough that users do not mistake stale values or params for current ones.
+- Interactive UI renderers must distinguish **Exploration Errors** from **Instantiation Errors**.
+- In manual **Apply Mode**, **Exploration Errors** disable Apply and leave the current **Applied Values** result unchanged.
+- In manual **Apply Mode**, **Instantiation Errors** occur when Apply runs and become the current applied error state.
+- `result.params` represents the latest successful applied instantiation; it raises on an **Instantiation Error** instead of returning attempted params.
+- UI renderers may display attempted params for diagnostics after an **Instantiation Error**, but must label them distinctly from public **Selected Params** and last successful params.
+- The primary interactive UI should not duplicate all **Selected Params** in a separate params panel by default; users inspect the logging payload through `result.params`.
+- The primary interactive UI should not render an **Instantiation Value** preview; users inspect instantiated values through `result.value`.
+- Nested parameters should render as nested containers in the primary interactive UI.
+- **Parameter Descriptions** should render lightly in the primary interactive UI without competing with labels or controls.
+- In immediate **Apply Mode**, an invalid widget action makes the applied state invalid; `result.value` and `result.params` raise until the state is fixed.
+- The UI may show an "applied" or "up to date" status for immediate **Apply Mode**, but this means applied to the live interactive session, not persisted outside the notebook.
 
 ## Documentation requirements
 
@@ -110,3 +212,8 @@ _Avoid_: selected params
 - A params-only shortcut was considered; resolved: skip it until there is a separate execution mode that can avoid constructing the **Instantiation Value**.
 - A nested params helper was considered; resolved: skip it because flat dotted **Selected Params** are the canonical replay/logging shape.
 - Literal dotted names and other path-like names were ambiguous with nested paths; resolved: individual names must be Python identifiers, while Hypster generates dotted **Parameter Paths**.
+- "intermediate representation" was ambiguous with **Explore Schema**; resolved: **Interactive Snapshot** is the UI-agnostic session state contract, while **Explore Schema** remains the reachable parameter metadata inside it.
+- The old interactive UI exposed dict-like result access; resolved: modern interactive APIs expose `.value` and `.params` on an **Interactive Result**, instead of preserving dict-proxy behavior.
+- `interactive_explore` was ambiguous because the UI instantiates the configuration; resolved: the public API is `interact`.
+- The split between `interact` and `interact_params` was considered; resolved: skip it because `interact` already returns an **Interactive Result** handle rather than the raw **Instantiation Value**.
+- A separate Clear-to-defaults action was considered; resolved: skip it because Reset restores the **Interactive Baseline**, including validated seed values.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -135,6 +135,7 @@ _Avoid_: exploration error, validation error
 - Interactive UI renderers should derive **Display Labels** by humanizing names, such as rendering `top_k` as "Top K".
 - An **Interactive Snapshot** is produced by an interactive controller for one current widget state.
 - An **Interactive Snapshot** includes the current **Explore Schema**, **Draft Values**, **Applied Values**, current **Selected Params**, and any current exploration or instantiation error.
+- When an immediate interactive state cannot instantiate, an **Interactive Snapshot** uses `selected_params=None` so renderers do not confuse stale params with the current invalid state.
 - An **Interactive Snapshot** may include notebook-friendly display metadata for an **Instantiation Value**, but the raw **Instantiation Value** remains available through the returned proxy.
 - Remembered branch choices in an interactive session are UI input memory; they are not **Selected Params** until their parameter paths are reachable in the current **Interactive Snapshot**.
 - Notebook, Streamlit, and React renderers should consume the same **Interactive Snapshot** contract instead of each inventing a parameter metadata model.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -137,7 +137,7 @@ _Avoid_: exploration error, validation error
 - An **Interactive Snapshot** includes the current **Explore Schema**, **Draft Values**, **Applied Values**, current **Selected Params**, and any current exploration or instantiation error.
 - When an immediate interactive state cannot instantiate, an **Interactive Snapshot** uses `selected_params=None` so renderers do not confuse stale params with the current invalid state.
 - An **Interactive Snapshot** may include notebook-friendly display metadata for an **Instantiation Value**, but the raw **Instantiation Value** remains available through the returned proxy.
-- Remembered branch choices in an interactive session are UI input memory; they are not **Selected Params** until their parameter paths are reachable in the current **Interactive Snapshot**.
+- Remembered branch choices in an interactive session are UI input memory; they are keyed by reachable branch context and parameter metadata rather than by dotted path alone, and they are not **Selected Params** until their parameter paths are reachable in the current **Interactive Snapshot**.
 - Notebook, Streamlit, and React renderers should consume the same **Interactive Snapshot** contract instead of each inventing a parameter metadata model.
 - A renderer sends **Interactive Actions** to an interactive controller; the controller applies Hypster semantics and returns a new **Interactive Snapshot**.
 - **Interactive Actions** must not implement branch reachability, parameter validation, or selected-param collection in the renderer.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,7 +53,7 @@ Optional human-written helper text attached to a parameter for lightweight displ
 _Avoid_: docstring, tooltip-only text
 
 **Display Label**:
-A human-readable label derived from a parameter or group name unless explicitly provided by schema metadata.
+A human-readable label derived from a config, parameter, or group name unless explicitly provided by schema metadata.
 _Avoid_: parameter path, description
 
 **Interactive Snapshot**:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can install Hypster using uv:
 ```bash
 uv add hypster
 # optional Jupyter notebook/lab UI
-uv add 'hypster[jupyter]'
+uv add 'hypster[viz]'
 # optional HPO backend
 uv add 'hypster[optuna]'
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ You can install Hypster using uv:
 
 ```bash
 uv add hypster
+# optional Jupyter notebook/lab UI
+uv add 'hypster[jupyter]'
 # optional HPO backend
 uv add 'hypster[optuna]'
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can install Hypster using uv:
 
 ```bash
 uv add hypster
-# optional Jupyter notebook/lab UI
+# optional notebook visualization UI
 uv add 'hypster[viz]'
 # optional HPO backend
 uv add 'hypster[optuna]'

--- a/docs/adr/0002-interactive-snapshot-and-modern-notebook-renderer.md
+++ b/docs/adr/0002-interactive-snapshot-and-modern-notebook-renderer.md
@@ -9,7 +9,7 @@ The first Jupyter renderer should use the smallest implementation that still fee
 - Use one anywidget custom widget with file-backed JavaScript and CSS, such as `_esm = Path(...)` and `_css = Path(...)`.
 - Use vanilla JavaScript with simple themed controls; do not introduce React, a bundler, generated HTML blobs, a default value preview, or a default params panel.
 - Sync only compact `snapshot` and `action` traits between Python and the frontend.
-- Keep the raw **Instantiation Value**, full branch history, and **Branch Choice Memory** Python-side in the **Interactive Result** controller.
+- Keep the raw **Instantiation Value**, full branch history, and **Branch Choice Memory** Python-side in the **Interactive Result** controller. Branch memory is keyed by reachable branch context and parameter metadata, not dotted path alone, because different branches may reuse the same parameter path for different parameter meanings.
 - Scope CSS under a Hypster-specific root class because anywidget CSS is loaded globally.
 - Treat saved Jupyter widget state as normal notebook behavior; keep synced state tiny so notebooks remain lightweight even when widget state is saved.
 

--- a/docs/adr/0002-interactive-snapshot-and-modern-notebook-renderer.md
+++ b/docs/adr/0002-interactive-snapshot-and-modern-notebook-renderer.md
@@ -1,13 +1,13 @@
 # Interactive Snapshot and Modern Notebook Renderer
 
-Hypster's restored interactive UI will be built around a headless **Interactive Snapshot** controller contract rather than an ipywidgets-specific state model. The public API is `interact(config)`, which returns a live **Interactive Result** handle with `.value` and `.params` rather than returning the raw instantiation value. This avoids the misleading `interactive_explore` name and avoids a separate `interact_params` API, since the handle can expose selected params directly. The first-class UI target remains Jupyter notebooks, but the renderer should use a modern custom-widget approach such as anywidget while staying minimal, notebook-native, and easy to replace with future Streamlit or React renderers that consume the same snapshot and action contract. Renderers send **Interactive Actions** and render snapshots; Python remains the source of truth for branch reachability, validation, selected-param collection, and replay semantics.
+Hypster's restored interactive UI will be built around a headless **Interactive Snapshot** controller contract rather than an ipywidgets-specific state model. The public API is `interact(config)`, which returns a live **Interactive Result** handle with `.value` and `.params` rather than returning the raw instantiation value. This avoids the misleading `interactive_explore` name and avoids a separate `interact_params` API, since the handle can expose selected params directly. The first-class UI target remains Jupyter notebooks, but the renderer should use a modern custom-widget approach such as anywidget while staying small, theme-aware, and easy to replace with future Streamlit or React renderers that consume the same snapshot and action contract. Renderers send **Interactive Actions** and render snapshots; Python remains the source of truth for branch reachability, validation, selected-param collection, and replay semantics.
 
 ## Notebook renderer direction
 
-The first Jupyter renderer should use the smallest implementation that still feels clear and default:
+The first Jupyter renderer should use the smallest implementation that still feels clear and current:
 
 - Use one anywidget custom widget with file-backed JavaScript and CSS, such as `_esm = Path(...)` and `_css = Path(...)`.
-- Use vanilla JavaScript and native controls; do not introduce React, a bundler, generated HTML blobs, a default value preview, or a default params panel.
+- Use vanilla JavaScript with simple themed controls; do not introduce React, a bundler, generated HTML blobs, a default value preview, or a default params panel.
 - Sync only compact `snapshot` and `action` traits between Python and the frontend.
 - Keep the raw **Instantiation Value**, full branch history, and **Branch Choice Memory** Python-side in the **Interactive Result** controller.
 - Scope CSS under a Hypster-specific root class because anywidget CSS is loaded globally.

--- a/docs/adr/0002-interactive-snapshot-and-modern-notebook-renderer.md
+++ b/docs/adr/0002-interactive-snapshot-and-modern-notebook-renderer.md
@@ -1,0 +1,16 @@
+# Interactive Snapshot and Modern Notebook Renderer
+
+Hypster's restored interactive UI will be built around a headless **Interactive Snapshot** controller contract rather than an ipywidgets-specific state model. The public API is `interact(config)`, which returns a live **Interactive Result** handle with `.value` and `.params` rather than returning the raw instantiation value. This avoids the misleading `interactive_explore` name and avoids a separate `interact_params` API, since the handle can expose selected params directly. The first-class UI target remains Jupyter notebooks, but the renderer should use a modern custom-widget approach such as anywidget so the notebook experience can be polished while future Streamlit or React renderers can consume the same snapshot and action contract. Renderers send **Interactive Actions** and render snapshots; Python remains the source of truth for branch reachability, validation, selected-param collection, and replay semantics.
+
+## Notebook renderer direction
+
+The first Jupyter renderer should use the smallest implementation that can still feel polished:
+
+- Use one anywidget custom widget with file-backed JavaScript and CSS, such as `_esm = Path(...)` and `_css = Path(...)`.
+- Use vanilla JavaScript and native controls; do not introduce React, a bundler, generated HTML blobs, a default value preview, or a default params panel.
+- Sync only compact `snapshot` and `action` traits between Python and the frontend.
+- Keep the raw **Instantiation Value**, full branch history, and **Branch Choice Memory** Python-side in the **Interactive Result** controller.
+- Scope CSS under a Hypster-specific root class because anywidget CSS is loaded globally.
+- Treat saved Jupyter widget state as normal notebook behavior; keep synced state tiny so notebooks remain lightweight even when widget state is saved.
+
+The renderer is deliberately shallow. It renders the current **Interactive Snapshot** and emits **Interactive Actions**; the Python controller owns all semantics.

--- a/docs/adr/0002-interactive-snapshot-and-modern-notebook-renderer.md
+++ b/docs/adr/0002-interactive-snapshot-and-modern-notebook-renderer.md
@@ -1,10 +1,10 @@
 # Interactive Snapshot and Modern Notebook Renderer
 
-Hypster's restored interactive UI will be built around a headless **Interactive Snapshot** controller contract rather than an ipywidgets-specific state model. The public API is `interact(config)`, which returns a live **Interactive Result** handle with `.value` and `.params` rather than returning the raw instantiation value. This avoids the misleading `interactive_explore` name and avoids a separate `interact_params` API, since the handle can expose selected params directly. The first-class UI target remains Jupyter notebooks, but the renderer should use a modern custom-widget approach such as anywidget so the notebook experience can be polished while future Streamlit or React renderers can consume the same snapshot and action contract. Renderers send **Interactive Actions** and render snapshots; Python remains the source of truth for branch reachability, validation, selected-param collection, and replay semantics.
+Hypster's restored interactive UI will be built around a headless **Interactive Snapshot** controller contract rather than an ipywidgets-specific state model. The public API is `interact(config)`, which returns a live **Interactive Result** handle with `.value` and `.params` rather than returning the raw instantiation value. This avoids the misleading `interactive_explore` name and avoids a separate `interact_params` API, since the handle can expose selected params directly. The first-class UI target remains Jupyter notebooks, but the renderer should use a modern custom-widget approach such as anywidget while staying minimal, notebook-native, and easy to replace with future Streamlit or React renderers that consume the same snapshot and action contract. Renderers send **Interactive Actions** and render snapshots; Python remains the source of truth for branch reachability, validation, selected-param collection, and replay semantics.
 
 ## Notebook renderer direction
 
-The first Jupyter renderer should use the smallest implementation that can still feel polished:
+The first Jupyter renderer should use the smallest implementation that still feels clear and default:
 
 - Use one anywidget custom widget with file-backed JavaScript and CSS, such as `_esm = Path(...)` and `_css = Path(...)`.
 - Use vanilla JavaScript and native controls; do not introduce React, a bundler, generated HTML blobs, a default value preview, or a default params panel.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -24,6 +24,7 @@ uv add "hypster[jupyter]"
 
 Dependencies:
 
+* [anywidget](https://github.com/manzt/anywidget)
 * [ipywidgets](https://github.com/jupyter-widgets/ipywidgets)
 {% endtab %}
 
@@ -50,6 +51,7 @@ pip install hypster[jupyter]
 
 Dependencies:
 
+* [anywidget](https://github.com/manzt/anywidget)
 * [ipywidgets](https://github.com/jupyter-widgets/ipywidgets)
 {% endtab %}
 
@@ -64,6 +66,7 @@ uv sync --all-extras --dev
 
 Dependencies:
 
+* [anywidget](https://github.com/manzt/anywidget)
 * [ipywidgets](https://github.com/jupyter-widgets/ipywidgets)
 * [ruff](https://github.com/astral-sh/ruff)
 * [mypy](https://github.com/python/mypy)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -47,7 +47,7 @@ uv add optuna
 Hypster comes with an interactive **Jupyter Notebook UI** to make instantiation as easy as :pie:
 
 ```bash
-pip install hypster[jupyter]
+pip install "hypster[jupyter]"
 ```
 
 Dependencies:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -15,12 +15,14 @@ pip install hypster
 ```
 {% endtab %}
 
-{% tab title="Interactive Jupyter UI (uv)" %}
+{% tab title="Interactive Visualization UI (uv)" %}
 Hypster comes with an interactive **Jupyter Notebook UI** to make instantiation as easy as :pie:
 
 ```bash
-uv add "hypster[jupyter]"
+uv add "hypster[viz]"
 ```
+
+`hypster[jupyter]` is also available as a compatibility alias.
 
 Dependencies:
 
@@ -43,12 +45,14 @@ uv add optuna
 ```
 {% endtab %}
 
-{% tab title="Interactive Jupyter UI (pip)" %}
+{% tab title="Interactive Visualization UI (pip)" %}
 Hypster comes with an interactive **Jupyter Notebook UI** to make instantiation as easy as :pie:
 
 ```bash
-pip install "hypster[jupyter]"
+pip install "hypster[viz]"
 ```
+
+`hypster[jupyter]` is also available as a compatibility alias.
 
 Dependencies:
 
@@ -82,7 +86,7 @@ Hypster's maintainer tooling lives in local `uv` dependency groups rather than a
 ```bash
 git clone https://github.com/gilad-rubin/hypster.git
 cd hypster
-python -m pip install -e ".[jupyter,optuna]"
+python -m pip install -e ".[viz,optuna]"
 python -m pip install pytest pytest-cov "coverage[toml]" ruff mypy pre-commit pytest-codspeed
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,13 +16,11 @@ pip install hypster
 {% endtab %}
 
 {% tab title="Interactive Visualization UI (uv)" %}
-Hypster comes with an interactive **Jupyter Notebook UI** to make instantiation as easy as :pie:
+Hypster comes with an interactive **notebook UI** to make instantiation as easy as :pie:
 
 ```bash
 uv add "hypster[viz]"
 ```
-
-`hypster[jupyter]` is also available as a compatibility alias.
 
 Dependencies:
 
@@ -46,13 +44,11 @@ uv add optuna
 {% endtab %}
 
 {% tab title="Interactive Visualization UI (pip)" %}
-Hypster comes with an interactive **Jupyter Notebook UI** to make instantiation as easy as :pie:
+Hypster comes with an interactive **notebook UI** to make instantiation as easy as :pie:
 
 ```bash
 pip install "hypster[viz]"
 ```
-
-`hypster[jupyter]` is also available as a compatibility alias.
 
 Dependencies:
 
@@ -106,7 +102,7 @@ print(hypster.__version__)
 ## System Requirements
 
 * Python 3.10 or higher
-* Optional: Jupyter Notebook/Lab for interactive features
+* Optional: Jupyter Notebook, JupyterLab, or VS Code notebooks for interactive features
 
 ## Troubleshooting
 
@@ -126,7 +122,7 @@ uv self update
 uv add --upgrade hypster
 ```
 
-3. For Jupyter-related issues, make sure Jupyter is properly installed:
+3. For notebook UI issues, make sure your notebook frontend is properly installed:
 
 ```bash
 # For JupyterLab
@@ -150,7 +146,7 @@ pip install -U pip
 pip install -U hypster
 ```
 
-3. For Jupyter-related issues, make sure Jupyter is properly installed:
+3. For notebook UI issues, make sure your notebook frontend is properly installed:
 
 ```bash
 # For JupyterLab

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -26,6 +26,7 @@ Dependencies:
 
 * [anywidget](https://github.com/manzt/anywidget)
 * [ipywidgets](https://github.com/jupyter-widgets/ipywidgets)
+* [jupyterlab_widgets](https://github.com/jupyter-widgets/ipywidgets/tree/main/python/jupyterlab_widgets)
 {% endtab %}
 
 {% tab title="Hyperparameter Optimization (uv)" %}
@@ -53,6 +54,7 @@ Dependencies:
 
 * [anywidget](https://github.com/manzt/anywidget)
 * [ipywidgets](https://github.com/jupyter-widgets/ipywidgets)
+* [jupyterlab_widgets](https://github.com/jupyter-widgets/ipywidgets/tree/main/python/jupyterlab_widgets)
 {% endtab %}
 
 {% tab title="Development (uv)" %}
@@ -68,6 +70,7 @@ Dependencies:
 
 * [anywidget](https://github.com/manzt/anywidget)
 * [ipywidgets](https://github.com/jupyter-widgets/ipywidgets)
+* [jupyterlab_widgets](https://github.com/jupyter-widgets/ipywidgets/tree/main/python/jupyterlab_widgets)
 * [ruff](https://github.com/astral-sh/ruff)
 * [mypy](https://github.com/python/mypy)
 * [pytest](https://github.com/pytest-dev/pytest)

--- a/docs/getting-started/interactive-instantiation-ui.md
+++ b/docs/getting-started/interactive-instantiation-ui.md
@@ -5,8 +5,16 @@ Use `interact()` in a Jupyter notebook when you want to instantiate a configurat
 Install the notebook renderer with the Jupyter extra:
 
 ```bash
+uv add "hypster[jupyter]"
+```
+
+or:
+
+```bash
 pip install "hypster[jupyter]"
 ```
+
+The extra is named `jupyter` because it installs the widget runtime needed by both JupyterLab and notebook frontends.
 
 ```python
 from hypster import HP, interact

--- a/docs/getting-started/interactive-instantiation-ui.md
+++ b/docs/getting-started/interactive-instantiation-ui.md
@@ -1,6 +1,6 @@
 # Interactive Instantiation UI
 
-Use `interact()` in a Jupyter notebook when you want to instantiate a configuration through a live widget UI.
+Use `interact()` in a notebook when you want to instantiate a configuration through a live widget UI.
 
 Install the notebook renderer with the visualization extra:
 
@@ -14,7 +14,7 @@ or:
 pip install "hypster[viz]"
 ```
 
-`hypster[jupyter]` is also available as a compatibility alias. The `viz` extra installs the widget runtime needed by JupyterLab, VS Code notebooks, and notebook frontends.
+The `viz` extra installs the widget runtime needed by Jupyter Notebook, JupyterLab, and VS Code notebooks.
 
 In VS Code, the Jupyter extension may ask to **Enable Downloads** for `anywidget` support files the first time a widget is displayed. Accept that prompt, then rerun the cell.
 

--- a/docs/getting-started/interactive-instantiation-ui.md
+++ b/docs/getting-started/interactive-instantiation-ui.md
@@ -2,6 +2,12 @@
 
 Use `interact()` in a Jupyter notebook when you want to instantiate a configuration through a live widget UI.
 
+Install the notebook renderer with the Jupyter extra:
+
+```bash
+pip install "hypster[jupyter]"
+```
+
 ```python
 from hypster import HP, interact
 
@@ -45,6 +51,8 @@ result = interact(model_cfg, auto_apply=False)
 ```
 
 In manual mode, the UI continues to explore draft values so dependent controls stay current, but `result.value` and `result.params` keep returning the last applied state until Apply succeeds.
+
+If a widget selection is invalid, the UI shows the current error. In auto-apply mode, `result.value` and `result.params` raise that error until the widget state is fixed; snapshots report `selected_params=None` so renderer code does not confuse stale params with the current invalid state.
 
 ## Continuing An Interaction
 

--- a/docs/getting-started/interactive-instantiation-ui.md
+++ b/docs/getting-started/interactive-instantiation-ui.md
@@ -1,33 +1,61 @@
-# 🎮 Interactive Instantiation (UI)
+# Interactive Instantiation UI
 
-{% hint style="info" %}
-**Note**: Interactive UI functionality has been temporarily removed in v0.3 as part of the major revamp. The Hypster team is working on bringing back an improved UI experience in a future release.
-{% endhint %}
-
-## Current Workflow
-
-For now, you can instantiate configurations manually using the `instantiate()` function:
+Use `interact()` in a Jupyter notebook when you want to instantiate a configuration through a live widget UI.
 
 ```python
-from hypster import HP, instantiate
+from hypster import HP, interact
+
 
 def model_cfg(hp: HP):
-    model_name = hp.select(["gpt-4", "claude-3-sonnet"], name="model_name")
-    temperature = hp.float(0.2, name="temperature", min=0.0, max=1.0)
-    max_tokens = hp.int(256, name="max_tokens", min=0, max=4096)
-    return {"model_name": model_name, "temperature": temperature, "max_tokens": max_tokens}
+    provider = hp.select(
+        ["openai", "gemini"],
+        name="provider",
+        default="openai",
+        description="Chooses which provider branch is active.",
+    )
+    if provider == "gemini":
+        model = hp.select(["flash-lite", "pro"], name="model", default="flash-lite")
+    else:
+        model = hp.select(["gpt-4o-mini", "gpt-4.1"], name="model", default="gpt-4o-mini")
 
-# Manual configuration
-cfg = instantiate(
-    model_cfg,
-    values={
-        "model_name": "gpt-4",
-        "temperature": 0.5,
-        "max_tokens": 1024,
-    },
-)
+    temperature = hp.float(0.2, name="temperature", min=0.0, max=1.0)
+    return {"provider": provider, "model": model, "temperature": temperature}
+
+
+result = interact(model_cfg)
 ```
 
-## Stay Updated
+`interact()` returns an interactive result handle, not the raw configured object. After changing the widget, read the current applied object and replayable selected params from Python:
 
-Follow the [GitHub repository](https://github.com/gilad-rubin/hypster) for updates on when the interactive UI will be restored with enhanced capabilities.
+```python
+result.value
+result.params
+```
+
+`result.params` is a flat dotted-path dictionary that can be replayed through `instantiate(..., values=result.params)` or logged to experiment-tracking tools.
+
+## Applying Changes
+
+By default, widget changes apply immediately. Valid changes update `result.value` and `result.params` in the running kernel.
+
+Use manual apply mode when you want to stage widget edits before updating the applied result:
+
+```python
+result = interact(model_cfg, auto_apply=False)
+```
+
+In manual mode, the UI continues to explore draft values so dependent controls stay current, but `result.value` and `result.params` keep returning the last applied state until Apply succeeds.
+
+## Continuing An Interaction
+
+Call `result.interact()` to render another live view of the same interaction:
+
+```python
+result.interact()
+```
+
+To start a fresh session from a previous selection, pass selected params explicitly:
+
+```python
+result2 = interact(model_cfg, values=result.params)
+```

--- a/docs/getting-started/interactive-instantiation-ui.md
+++ b/docs/getting-started/interactive-instantiation-ui.md
@@ -2,19 +2,21 @@
 
 Use `interact()` in a Jupyter notebook when you want to instantiate a configuration through a live widget UI.
 
-Install the notebook renderer with the Jupyter extra:
+Install the notebook renderer with the visualization extra:
 
 ```bash
-uv add "hypster[jupyter]"
+uv add "hypster[viz]"
 ```
 
 or:
 
 ```bash
-pip install "hypster[jupyter]"
+pip install "hypster[viz]"
 ```
 
-The extra is named `jupyter` because it installs the widget runtime needed by both JupyterLab and notebook frontends.
+`hypster[jupyter]` is also available as a compatibility alias. The `viz` extra installs the widget runtime needed by JupyterLab, VS Code notebooks, and notebook frontends.
+
+In VS Code, the Jupyter extension may ask to **Enable Downloads** for `anywidget` support files the first time a widget is displayed. Accept that prompt, then rerun the cell.
 
 ```python
 from hypster import HP, interact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hypster"
-version = "0.4.0"
+version = "0.5.0"
 description = "A flexible configuration system for Python projects"
 authors = [
     {name = "Gilad Rubin", email = "me@giladrubin.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-jupyter = ["anywidget>=0.9.0", "ipywidgets>=8.0.0", "jupyterlab_widgets>=3.0.0"]
 viz = ["anywidget>=0.9.0", "ipywidgets>=8.0.0", "jupyterlab_widgets>=3.0.0"]
 optuna = ["optuna>=3.6"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-jupyter = ["anywidget>=0.9.0", "ipywidgets>=8.0.0"]
+jupyter = ["anywidget>=0.9.0", "ipywidgets>=8.0.0", "jupyterlab_widgets>=3.0.0"]
 optuna = ["optuna>=3.6"]
 
 [project.urls]
@@ -86,6 +86,7 @@ dev = [
     { include-group = "test" },
     "anywidget>=0.9.0",
     "ipywidgets>=8.0.0",
+    "jupyterlab_widgets>=3.0.0",
 ]
 lint = [
     "mypy>=0.950",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-jupyter = ["ipywidgets>=8.0.0"]
+jupyter = ["anywidget>=0.9.0", "ipywidgets>=8.0.0"]
 optuna = ["optuna>=3.6"]
 
 [project.urls]
@@ -84,6 +84,7 @@ include = [
 dev = [
     { include-group = "lint" },
     { include-group = "test" },
+    "anywidget>=0.9.0",
     "ipywidgets>=8.0.0",
 ]
 lint = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = []
 
 [project.optional-dependencies]
 jupyter = ["anywidget>=0.9.0", "ipywidgets>=8.0.0", "jupyterlab_widgets>=3.0.0"]
+viz = ["anywidget>=0.9.0", "ipywidgets>=8.0.0", "jupyterlab_widgets>=3.0.0"]
 optuna = ["optuna>=3.6"]
 
 [project.urls]

--- a/src/hypster/__init__.py
+++ b/src/hypster/__init__.py
@@ -6,6 +6,7 @@ from importlib.metadata import version as _pkg_version
 from .core import ConfigFunc, InstantiationOutput, instantiate, instantiate_with_params
 from .explore import explore
 from .hp import HP
+from .interactive import InteractiveResult, interact
 
 try:
     # Resolve version from installed package metadata; __name__ == "hypster" at package top-level
@@ -19,7 +20,9 @@ __all__ = [
     "instantiate",
     "instantiate_with_params",
     "InstantiationOutput",
+    "InteractiveResult",
     "explore",
+    "interact",
     "ConfigFunc",
     "__version__",
 ]

--- a/src/hypster/_version.py
+++ b/src/hypster/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/hypster/core.py
+++ b/src/hypster/core.py
@@ -44,6 +44,7 @@ class ParamsTracker:
         options: Optional[list[Any]] = None,
         minimum: Optional[int | float] = None,
         maximum: Optional[int | float] = None,
+        description: Optional[str] = None,
     ) -> None:
         self.params[path] = selected_value
 

--- a/src/hypster/explore.py
+++ b/src/hypster/explore.py
@@ -114,6 +114,7 @@ class ConfigSchema:
     def to_dict(self) -> Dict[str, Any]:
         return {
             "name": self.name,
+            "display_label": _humanize_name(self.name),
             "parameters": [parameter.to_dict() for parameter in self.parameters],
         }
 

--- a/src/hypster/explore.py
+++ b/src/hypster/explore.py
@@ -33,6 +33,22 @@ def _to_jsonable(value: Any) -> Any:
     return repr(value)
 
 
+def _humanize_name(name: str) -> str:
+    acronyms = {
+        "api": "API",
+        "hp": "HP",
+        "hpo": "HPO",
+        "id": "ID",
+        "k": "K",
+        "llm": "LLM",
+        "mlflow": "MLflow",
+        "openai": "OpenAI",
+        "ui": "UI",
+        "url": "URL",
+    }
+    return " ".join(acronyms.get(part, part.capitalize()) for part in name.split("_"))
+
+
 @dataclass
 class ParameterInfo:
     name: str
@@ -43,6 +59,7 @@ class ParameterInfo:
     options: Optional[List[Any]] = None
     minimum: Optional[int | float] = None
     maximum: Optional[int | float] = None
+    description: Optional[str] = None
     children: List["ParameterInfo"] = field(default_factory=list)
 
     def is_group(self) -> bool:
@@ -58,6 +75,8 @@ class ParameterInfo:
             "options": _to_jsonable(self.options),
             "minimum": _to_jsonable(self.minimum),
             "maximum": _to_jsonable(self.maximum),
+            "description": self.description,
+            "display_label": _humanize_name(self.name),
             "children": [child.to_dict() for child in self.children],
         }
 
@@ -135,8 +154,9 @@ class SchemaTracer(HP):
             self._schema = tracker._schema
             self._nodes_by_path = tracker._nodes_by_path
 
-    def record_nest(self, *, path: str, name: str) -> None:
-        self._ensure_group(path, name)
+    def record_nest(self, *, path: str, name: str, description: Optional[str] = None) -> None:
+        group = self._ensure_group(path, name)
+        group.description = description
 
     def record_parameter(
         self,
@@ -149,6 +169,7 @@ class SchemaTracer(HP):
         options: Optional[List[Any]] = None,
         minimum: Optional[int | float] = None,
         maximum: Optional[int | float] = None,
+        description: Optional[str] = None,
     ) -> None:
         parent_path = path.rpartition(".")[0]
         container = self._schema.parameters if not parent_path else self._ensure_group_path(parent_path).children
@@ -162,6 +183,7 @@ class SchemaTracer(HP):
             options=options,
             minimum=minimum,
             maximum=maximum,
+            description=description,
         )
         existing = self._nodes_by_path.get(path)
         if existing is None:
@@ -175,6 +197,7 @@ class SchemaTracer(HP):
         existing.options = options
         existing.minimum = minimum
         existing.maximum = maximum
+        existing.description = description
 
     def build_schema(self, root_name: str) -> ConfigSchema:
         self._schema.name = root_name
@@ -215,8 +238,8 @@ def explore(
     validate_config_func_signature(func)
     _validate_on_unknown(on_unknown)
 
-    values = normalize_values(values)
-    tracer = SchemaTracer(values)
+    normalized_values: Dict[str, Any] = normalize_values(values)
+    tracer = SchemaTracer(normalized_values)
     kwargs = kwargs or {}
     original_called_params = tracer.called_params.copy()
 
@@ -226,7 +249,7 @@ def explore(
         raise ValueError(str(e)) from e
 
     called_params = tracer.called_params - original_called_params
-    _handle_unknown_parameters(values, called_params, on_unknown)
+    _handle_unknown_parameters(normalized_values, called_params, on_unknown)
 
     schema = tracer.build_schema(getattr(func, "__name__", func.__class__.__name__))
 

--- a/src/hypster/hp.py
+++ b/src/hypster/hp.py
@@ -34,6 +34,7 @@ class ParameterTracker(Protocol):
         options: Optional[List[Any]] = None,
         minimum: Optional[Union[int, float]] = None,
         maximum: Optional[Union[int, float]] = None,
+        description: Optional[str] = None,
     ) -> None: ...
 
 
@@ -94,6 +95,7 @@ class HP:
         options: Optional[List[Any]] = None,
         minimum: Optional[Union[int, float]] = None,
         maximum: Optional[Union[int, float]] = None,
+        description: Optional[str] = None,
     ) -> None:
         if self.parameter_tracker is None:
             return
@@ -109,15 +111,16 @@ class HP:
                 options=options,
                 minimum=minimum,
                 maximum=maximum,
+                description=description,
             )
 
-    def _record_nest(self, *, path: str, name: str) -> None:
+    def _record_nest(self, *, path: str, name: str, description: Optional[str] = None) -> None:
         if self.parameter_tracker is None:
             return
 
         record = getattr(self.parameter_tracker, "record_nest", None)
         if callable(record):
-            record(path=path, name=name)
+            record(path=path, name=name, description=description)
 
     def _get_value_for_param(self, name: str) -> tuple[Any, bool]:
         """Get value for parameter, returns (value, found)."""
@@ -159,6 +162,7 @@ class HP:
         allow_none: bool = False,
         track_called: bool = False,
         use_validator_name: bool = True,
+        description: Optional[str] = None,
     ) -> Any:
         full_path = self._get_full_param_path(name)
 
@@ -211,6 +215,7 @@ class HP:
             selected_value=validated_value,
             minimum=min,
             maximum=max,
+            description=description,
         )
 
         return validated_value
@@ -227,6 +232,7 @@ class HP:
         min: Optional[Union[int, float]] = None,
         max: Optional[Union[int, float]] = None,
         allow_none: bool = False,
+        description: Optional[str] = None,
     ) -> List[Any]:
         full_path = self._get_full_param_path(name)
 
@@ -268,6 +274,7 @@ class HP:
             selected_value=validated_values,
             minimum=min,
             maximum=max,
+            description=description,
         )
 
         return validated_values
@@ -280,6 +287,7 @@ class HP:
         default: Any = _NO_DEFAULT,
         options_only: bool = False,
         allow_none: bool = False,
+        description: Optional[str] = None,
     ) -> Any:
         validator = SelectValidator()
         full_path = self._get_full_param_path(name)
@@ -307,6 +315,7 @@ class HP:
                 default_value=actual_default,
                 selected_value=validated_key,
                 options=option_keys,
+                description=description,
             )
             return option_map.get(validated_key, validated_key) if is_mapping else validated_key
         else:
@@ -325,6 +334,7 @@ class HP:
                 default_value=actual_default,
                 selected_value=validated_key,
                 options=option_keys,
+                description=description,
             )
             return option_map.get(validated_key, validated_key) if is_mapping else validated_key
 
@@ -336,6 +346,7 @@ class HP:
         default: Optional[List[Any]] = None,
         options_only: bool = False,
         allow_none: bool = False,
+        description: Optional[str] = None,
     ) -> List[Any]:
         validator = SelectValidator()
         full_path = self._get_full_param_path(name)
@@ -370,6 +381,7 @@ class HP:
                 default_value=actual_default,
                 selected_value=validated_keys,
                 options=option_keys,
+                description=description,
             )
             return [option_map.get(k, k) for k in validated_keys] if is_mapping else validated_keys
         else:
@@ -386,6 +398,7 @@ class HP:
                 default_value=actual_default,
                 selected_value=validated_keys,
                 options=option_keys,
+                description=description,
             )
             return [option_map.get(k, k) for k in validated_keys] if is_mapping else validated_keys
 
@@ -403,6 +416,7 @@ class HP:
         track_called: bool = False
         use_validator_name: bool = True
         allow_none: bool = False
+        description: Optional[str] = None
 
     @dataclass(frozen=True)
     class MultiValueSpec:
@@ -415,6 +429,7 @@ class HP:
         min: Optional[Union[int, float]] = None
         max: Optional[Union[int, float]] = None
         allow_none: bool = False
+        description: Optional[str] = None
 
     @dataclass(frozen=True)
     class SelectSingleSpec:
@@ -423,6 +438,7 @@ class HP:
         default: Any = _NO_DEFAULT
         options_only: bool = False
         allow_none: bool = False
+        description: Optional[str] = None
 
     @dataclass(frozen=True)
     class SelectMultiSpec:
@@ -431,6 +447,7 @@ class HP:
         default: Optional[List[Any]] = None
         options_only: bool = False
         allow_none: bool = False
+        description: Optional[str] = None
 
     # --- Unified executors ---
     def _execute_single(self, spec: "HP.SingleValueSpec") -> Any:
@@ -446,6 +463,7 @@ class HP:
             allow_none=spec.allow_none,
             track_called=spec.track_called,
             use_validator_name=spec.use_validator_name,
+            description=spec.description,
         )
 
     def _execute_multi(self, spec: "HP.MultiValueSpec") -> List[Any]:
@@ -459,6 +477,7 @@ class HP:
             min=spec.min,
             max=spec.max,
             allow_none=spec.allow_none,
+            description=spec.description,
         )
 
     def _execute_select_single(self, spec: "HP.SelectSingleSpec") -> Any:
@@ -468,6 +487,7 @@ class HP:
             default=spec.default,
             options_only=spec.options_only,
             allow_none=spec.allow_none,
+            description=spec.description,
         )
 
     def _execute_select_multi(self, spec: "HP.SelectMultiSpec") -> List[Any]:
@@ -477,6 +497,7 @@ class HP:
             default=spec.default,
             options_only=spec.options_only,
             allow_none=spec.allow_none,
+            description=spec.description,
         )
 
     # Composition
@@ -488,6 +509,7 @@ class HP:
         values: Optional[Dict[str, Any]] = None,
         args: tuple = (),
         kwargs: Optional[Dict[str, Any]] = None,
+        description: Optional[str] = None,
     ) -> Any:
         """Nest another configuration function."""
         from .utils import validate_config_func_signature
@@ -524,7 +546,7 @@ class HP:
             nested_values.update(normalize_values(values))
 
         # Create new HP instance for nested call with namespace
-        self._record_nest(path=full_path, name=name)
+        self._record_nest(path=full_path, name=name, description=description)
 
         nested_hp = self.__class__(nested_values, parameter_tracker=self.parameter_tracker)
         nested_hp.namespace_stack = self.namespace_stack + [name]
@@ -593,6 +615,7 @@ class HP:
         strict: bool = False,
         allow_none: Literal[False] = False,
         hpo_spec: "HpoInt | None" = None,
+        description: Optional[str] = None,
     ) -> int: ...
 
     @overload
@@ -606,6 +629,7 @@ class HP:
         strict: bool = False,
         allow_none: Literal[True],
         hpo_spec: "HpoInt | None" = None,
+        description: Optional[str] = None,
     ) -> Optional[int]: ...
 
     def _int(
@@ -618,6 +642,7 @@ class HP:
         strict: bool = False,
         allow_none: bool = False,
         hpo_spec: "HpoInt | None" = None,
+        description: Optional[str] = None,
     ) -> Optional[int]:
         """Integer parameter with optional bounds validation."""
         spec = HP.SingleValueSpec(
@@ -630,6 +655,7 @@ class HP:
             min=min,
             max=max,
             allow_none=allow_none,
+            description=description,
             track_called=True,
             use_validator_name=True,
         )
@@ -646,6 +672,7 @@ class HP:
         strict: bool = False,
         allow_none: Literal[False] = False,
         hpo_spec: "HpoFloat | None" = None,
+        description: Optional[str] = None,
     ) -> float: ...
 
     @overload
@@ -659,6 +686,7 @@ class HP:
         strict: bool = False,
         allow_none: Literal[True],
         hpo_spec: "HpoFloat | None" = None,
+        description: Optional[str] = None,
     ) -> Optional[float]: ...
 
     def _float(
@@ -671,6 +699,7 @@ class HP:
         strict: bool = False,
         allow_none: bool = False,
         hpo_spec: "HpoFloat | None" = None,
+        description: Optional[str] = None,
     ) -> Optional[float]:
         """Float parameter with optional bounds validation."""
         spec = HP.SingleValueSpec(
@@ -683,18 +712,40 @@ class HP:
             min=min,
             max=max,
             allow_none=allow_none,
+            description=description,
             track_called=True,
             use_validator_name=True,
         )
         return self._execute_single(spec)
 
     @overload
-    def _text(self, default: str, *, name: str, allow_none: Literal[False] = False) -> str: ...
+    def _text(
+        self,
+        default: str,
+        *,
+        name: str,
+        allow_none: Literal[False] = False,
+        description: Optional[str] = None,
+    ) -> str: ...
 
     @overload
-    def _text(self, default: Optional[str], *, name: str, allow_none: Literal[True]) -> Optional[str]: ...
+    def _text(
+        self,
+        default: Optional[str],
+        *,
+        name: str,
+        allow_none: Literal[True],
+        description: Optional[str] = None,
+    ) -> Optional[str]: ...
 
-    def _text(self, default: Optional[str], *, name: str, allow_none: bool = False) -> Optional[str]:
+    def _text(
+        self,
+        default: Optional[str],
+        *,
+        name: str,
+        allow_none: bool = False,
+        description: Optional[str] = None,
+    ) -> Optional[str]:
         """Text parameter."""
         spec = HP.SingleValueSpec(
             name=name,
@@ -703,18 +754,40 @@ class HP:
             validator=TextValidator(),
             supports_strict=False,
             allow_none=allow_none,
+            description=description,
             track_called=True,
             use_validator_name=True,
         )
         return self._execute_single(spec)
 
     @overload
-    def _bool(self, default: bool, *, name: str, allow_none: Literal[False] = False) -> bool: ...
+    def _bool(
+        self,
+        default: bool,
+        *,
+        name: str,
+        allow_none: Literal[False] = False,
+        description: Optional[str] = None,
+    ) -> bool: ...
 
     @overload
-    def _bool(self, default: Optional[bool], *, name: str, allow_none: Literal[True]) -> Optional[bool]: ...
+    def _bool(
+        self,
+        default: Optional[bool],
+        *,
+        name: str,
+        allow_none: Literal[True],
+        description: Optional[str] = None,
+    ) -> Optional[bool]: ...
 
-    def _bool(self, default: Optional[bool], *, name: str, allow_none: bool = False) -> Optional[bool]:
+    def _bool(
+        self,
+        default: Optional[bool],
+        *,
+        name: str,
+        allow_none: bool = False,
+        description: Optional[str] = None,
+    ) -> Optional[bool]:
         """Boolean parameter."""
         spec = HP.SingleValueSpec(
             name=name,
@@ -723,6 +796,7 @@ class HP:
             validator=BoolValidator(),
             supports_strict=False,
             allow_none=allow_none,
+            description=description,
             track_called=True,
             use_validator_name=True,
         )
@@ -737,6 +811,7 @@ class HP:
         options_only: bool = False,
         allow_none: bool = False,
         hpo_spec: "HpoCategorical | None" = None,
+        description: Optional[str] = None,
     ) -> Any:
         """Selection parameter from options."""
         spec = HP.SelectSingleSpec(
@@ -745,6 +820,7 @@ class HP:
             default=default,
             options_only=options_only,
             allow_none=allow_none,
+            description=description,
         )
         return self._execute_select_single(spec)
 
@@ -757,6 +833,7 @@ class HP:
         max: Optional[int] = None,
         strict: bool = False,
         allow_none: bool = False,
+        description: Optional[str] = None,
     ) -> List[int]:
         """Multi-integer parameter with optional bounds validation."""
         spec = HP.MultiValueSpec(
@@ -769,6 +846,7 @@ class HP:
             min=min,
             max=max,
             allow_none=allow_none,
+            description=description,
         )
         return self._execute_multi(spec)
 
@@ -781,6 +859,7 @@ class HP:
         max: Optional[float] = None,
         strict: bool = False,
         allow_none: bool = False,
+        description: Optional[str] = None,
     ) -> List[float]:
         """Multi-float parameter with optional bounds validation."""
         spec = HP.MultiValueSpec(
@@ -793,10 +872,18 @@ class HP:
             min=min,
             max=max,
             allow_none=allow_none,
+            description=description,
         )
         return self._execute_multi(spec)
 
-    def _multi_text(self, default: List[str], *, name: str, allow_none: bool = False) -> List[str]:
+    def _multi_text(
+        self,
+        default: List[str],
+        *,
+        name: str,
+        allow_none: bool = False,
+        description: Optional[str] = None,
+    ) -> List[str]:
         """Multi-text parameter."""
         spec = HP.MultiValueSpec(
             name=name,
@@ -805,10 +892,18 @@ class HP:
             element_validator=TextValidator(),
             supports_strict=False,
             allow_none=allow_none,
+            description=description,
         )
         return self._execute_multi(spec)
 
-    def _multi_bool(self, default: List[bool], *, name: str, allow_none: bool = False) -> List[bool]:
+    def _multi_bool(
+        self,
+        default: List[bool],
+        *,
+        name: str,
+        allow_none: bool = False,
+        description: Optional[str] = None,
+    ) -> List[bool]:
         """Multi-boolean parameter."""
         spec = HP.MultiValueSpec(
             name=name,
@@ -817,6 +912,7 @@ class HP:
             element_validator=BoolValidator(),
             supports_strict=False,
             allow_none=allow_none,
+            description=description,
         )
         return self._execute_multi(spec)
 
@@ -828,6 +924,7 @@ class HP:
         default: Optional[List[Any]] = None,
         options_only: bool = False,
         allow_none: bool = False,
+        description: Optional[str] = None,
     ) -> List[Any]:
         """Multi-selection parameter from options."""
         spec = HP.SelectMultiSpec(
@@ -836,6 +933,7 @@ class HP:
             default=default,
             options_only=options_only,
             allow_none=allow_none,
+            description=description,
         )
         return self._execute_select_multi(spec)
 

--- a/src/hypster/interactive/__init__.py
+++ b/src/hypster/interactive/__init__.py
@@ -1,0 +1,3 @@
+from .session import InteractiveResult, interact
+
+__all__ = ["InteractiveResult", "interact"]

--- a/src/hypster/interactive/branch_memory.py
+++ b/src/hypster/interactive/branch_memory.py
@@ -38,13 +38,30 @@ def _is_compatible(parameter: ParameterInfo, value: Any) -> bool:
         return isinstance(value, float) and _matches_bounds(value, parameter)
     if parameter.kind == "text":
         return isinstance(value, str)
+    if parameter.kind == "multi_int":
+        return isinstance(value, list) and all(
+            isinstance(item, int) and _matches_bounds(item, parameter) for item in value
+        )
+    if parameter.kind == "multi_float":
+        return isinstance(value, list) and all(
+            isinstance(item, float) and _matches_bounds(item, parameter) for item in value
+        )
+    if parameter.kind == "multi_text":
+        return isinstance(value, list) and all(isinstance(item, str) for item in value)
+    if parameter.kind == "multi_bool":
+        return isinstance(value, list) and all(isinstance(item, bool) for item in value)
     return True
 
 
 def _matches_options(kind: str, value: Any, options: Iterable[Any]) -> bool:
     option_set = set(options)
     if kind == "multi_select":
-        return isinstance(value, list) and set(value).issubset(option_set)
+        if not isinstance(value, list):
+            return False
+        try:
+            return set(value).issubset(option_set)
+        except TypeError:
+            return False
     return value in option_set
 
 

--- a/src/hypster/interactive/branch_memory.py
+++ b/src/hypster/interactive/branch_memory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable
+import json
+from typing import Any, Dict, Iterable, Mapping
 
 from hypster.explore import ParameterInfo
 
@@ -11,20 +12,47 @@ class BranchChoiceMemory:
     def __init__(self) -> None:
         self._history: Dict[str, list[Any]] = {}
 
-    def remember(self, path: str, value: Any) -> None:
-        history = self._history.setdefault(path, [])
+    def remember(self, parameter: ParameterInfo, value: Any, context: Mapping[str, Any]) -> None:
+        history = self._history.setdefault(_memory_key(parameter, context), [])
         history[:] = [item for item in history if item != value]
         history.append(value)
 
-    def remember_many(self, values: Dict[str, Any]) -> None:
-        for path, value in values.items():
-            self.remember(path, value)
+    def remember_many(self, parameters: list[ParameterInfo], values: Dict[str, Any]) -> None:
+        for index, parameter in enumerate(parameters):
+            if parameter.path not in values:
+                continue
+            self.remember(parameter, values[parameter.path], _context_for(parameters, values, index))
 
-    def latest_compatible(self, parameter: ParameterInfo) -> tuple[bool, Any]:
-        for value in reversed(self._history.get(parameter.path, [])):
+    def latest_compatible(self, parameter: ParameterInfo, context: Mapping[str, Any]) -> tuple[bool, Any]:
+        for value in reversed(self._history.get(_memory_key(parameter, context), [])):
             if _is_compatible(parameter, value):
                 return True, value
         return False, None
+
+
+def _memory_key(parameter: ParameterInfo, context: Mapping[str, Any]) -> str:
+    signature = {
+        "path": parameter.path,
+        "name": parameter.name,
+        "kind": parameter.kind,
+        "default": parameter.default_value,
+        "options": parameter.options,
+        "minimum": parameter.minimum,
+        "maximum": parameter.maximum,
+    }
+    return _stable_json({"parameter": signature, "context": dict(context)})
+
+
+def _context_for(parameters: list[ParameterInfo], values: Mapping[str, Any], index: int) -> Dict[str, Any]:
+    context: Dict[str, Any] = {}
+    for previous in parameters[:index]:
+        if previous.path in values:
+            context[previous.path] = values[previous.path]
+    return context
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, default=repr, separators=(",", ":"))
 
 
 def _is_compatible(parameter: ParameterInfo, value: Any) -> bool:

--- a/src/hypster/interactive/branch_memory.py
+++ b/src/hypster/interactive/branch_memory.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+from hypster.explore import ParameterInfo
+
+
+class BranchChoiceMemory:
+    """Session-local memory for values that may become reachable again."""
+
+    def __init__(self) -> None:
+        self._history: Dict[str, list[Any]] = {}
+
+    def remember(self, path: str, value: Any) -> None:
+        history = self._history.setdefault(path, [])
+        history[:] = [item for item in history if item != value]
+        history.append(value)
+
+    def remember_many(self, values: Dict[str, Any]) -> None:
+        for path, value in values.items():
+            self.remember(path, value)
+
+    def latest_compatible(self, parameter: ParameterInfo) -> tuple[bool, Any]:
+        for value in reversed(self._history.get(parameter.path, [])):
+            if _is_compatible(parameter, value):
+                return True, value
+        return False, None
+
+
+def _is_compatible(parameter: ParameterInfo, value: Any) -> bool:
+    if parameter.options is not None:
+        return _matches_options(parameter.kind, value, parameter.options)
+    if parameter.kind == "bool":
+        return isinstance(value, bool)
+    if parameter.kind == "int":
+        return isinstance(value, int) and _matches_bounds(value, parameter)
+    if parameter.kind == "float":
+        return isinstance(value, float) and _matches_bounds(value, parameter)
+    if parameter.kind == "text":
+        return isinstance(value, str)
+    return True
+
+
+def _matches_options(kind: str, value: Any, options: Iterable[Any]) -> bool:
+    option_set = set(options)
+    if kind == "multi_select":
+        return isinstance(value, list) and set(value).issubset(option_set)
+    return value in option_set
+
+
+def _matches_bounds(value: int | float, parameter: ParameterInfo) -> bool:
+    if parameter.minimum is not None and value < parameter.minimum:
+        return False
+    if parameter.maximum is not None and value > parameter.maximum:
+        return False
+    return True

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -1,59 +1,165 @@
 .hypster-widget {
+  --hypster-border: color-mix(in srgb, currentColor 14%, transparent);
+  --hypster-muted: color-mix(in srgb, currentColor 58%, transparent);
+  --hypster-surface: color-mix(in srgb, Canvas 96%, currentColor 4%);
+  --hypster-surface-strong: color-mix(in srgb, Canvas 90%, currentColor 10%);
+  border: 1px solid var(--hypster-border);
+  border-radius: 8px;
   display: grid;
-  gap: 10px;
+  gap: 14px;
   max-width: 640px;
-  padding: 4px 0;
-  color: inherit;
+  padding: 16px;
+  color: CanvasText;
+  background: Canvas;
   font: 14px/1.35 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .hypster-title {
-  font-weight: 600;
+  font-size: 15px;
+  font-weight: 650;
 }
 
 .hypster-status {
-  color: rgba(127, 127, 127, 0.9);
+  border-radius: 999px;
+  justify-self: start;
+  padding: 3px 9px;
   font-size: 12px;
+  color: var(--hypster-muted);
+  background: var(--hypster-surface);
 }
 
 .hypster-status-error,
 .hypster-status-draft_error {
   color: #9f1d1d;
+  background: #fff1f1;
 }
 
 .hypster-group {
-  border: 1px solid rgba(127, 127, 127, 0.35);
+  border: 1px solid var(--hypster-border);
+  border-radius: 8px;
   display: grid;
-  gap: 10px;
+  gap: 12px;
   margin: 0;
-  padding: 10px 12px 12px;
+  padding: 14px;
 }
 
 .hypster-group > legend {
-  padding: 0 4px;
-  font-weight: 600;
+  padding: 0 5px;
+  font-weight: 650;
 }
 
 .hypster-field {
   display: grid;
-  gap: 4px;
+  gap: 6px;
   min-width: 0;
 }
 
 .hypster-field-header {
-  font-weight: 600;
+  font-weight: 580;
 }
 
 .hypster-description {
-  color: rgba(127, 127, 127, 0.9);
+  color: var(--hypster-muted);
   font-size: 12px;
 }
 
 .hypster-field input,
 .hypster-field select {
+  border: 1px solid var(--hypster-border);
+  border-radius: 6px;
   box-sizing: border-box;
+  min-height: 32px;
+  padding: 5px 8px;
+  color: inherit;
+  background: Canvas;
+}
+
+.hypster-choice {
+  position: relative;
+}
+
+.hypster-choice-trigger {
+  align-items: center;
+  background: Canvas;
+  border: 1px solid var(--hypster-border);
+  border-radius: 6px;
+  box-sizing: border-box;
+  color: inherit;
+  display: flex;
   font: inherit;
-  max-width: 100%;
+  justify-content: space-between;
+  min-height: 32px;
+  padding: 5px 8px;
+  width: 100%;
+}
+
+.hypster-choice-trigger:hover,
+.hypster-choice-open .hypster-choice-trigger {
+  background: var(--hypster-surface);
+}
+
+.hypster-choice-trigger:focus-visible,
+.hypster-choice-option:focus-visible {
+  outline: 2px solid color-mix(in srgb, Highlight 70%, transparent);
+  outline-offset: 2px;
+}
+
+.hypster-choice-value {
+  min-width: 0;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hypster-choice-arrow {
+  border-bottom: 1.5px solid currentColor;
+  border-right: 1.5px solid currentColor;
+  display: inline-block;
+  height: 7px;
+  margin-left: 12px;
+  opacity: 0.58;
+  transform: translateY(-2px) rotate(45deg);
+  width: 7px;
+}
+
+.hypster-choice-menu {
+  background: Canvas;
+  border: 1px solid var(--hypster-border);
+  border-radius: 6px;
+  box-shadow: 0 10px 24px color-mix(in srgb, CanvasText 16%, transparent);
+  box-sizing: border-box;
+  display: grid;
+  gap: 2px;
+  left: 0;
+  margin-top: 4px;
+  max-height: 220px;
+  min-width: 100%;
+  overflow: auto;
+  padding: 4px;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  z-index: 20;
+}
+
+.hypster-choice-menu[hidden] {
+  display: none;
+}
+
+.hypster-choice-option {
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  color: inherit;
+  font: inherit;
+  min-height: 30px;
+  padding: 5px 8px;
+  text-align: left;
+}
+
+.hypster-choice-option:hover {
+  background: var(--hypster-surface-strong);
 }
 
 .hypster-field input[type="checkbox"] {
@@ -67,21 +173,16 @@
 }
 
 .hypster-actions button {
-  border: 1px solid rgba(127, 127, 127, 0.55);
-  border-radius: 2px;
-  padding: 2px 8px;
+  border: 1px solid var(--hypster-border);
+  border-radius: 6px;
+  padding: 5px 10px;
   color: inherit;
-  background: rgba(127, 127, 127, 0.12);
+  background: var(--hypster-surface);
   cursor: pointer;
-  font: inherit;
 }
 
 .hypster-actions button:hover:not(:disabled) {
-  background: rgba(127, 127, 127, 0.18);
-}
-
-.hypster-actions button:active:not(:disabled) {
-  background: rgba(127, 127, 127, 0.24);
+  background: var(--hypster-surface-strong);
 }
 
 .hypster-actions button:disabled {

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -1,0 +1,91 @@
+.hypster-widget {
+  --hypster-border: color-mix(in srgb, currentColor 14%, transparent);
+  --hypster-muted: color-mix(in srgb, currentColor 58%, transparent);
+  --hypster-surface: color-mix(in srgb, Canvas 96%, currentColor 4%);
+  border: 1px solid var(--hypster-border);
+  border-radius: 8px;
+  display: grid;
+  gap: 14px;
+  max-width: 640px;
+  padding: 16px;
+  color: CanvasText;
+  background: Canvas;
+  font: 14px/1.35 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.hypster-title {
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.hypster-status {
+  border-radius: 999px;
+  justify-self: start;
+  padding: 3px 9px;
+  font-size: 12px;
+  color: var(--hypster-muted);
+  background: var(--hypster-surface);
+}
+
+.hypster-status-error,
+.hypster-status-draft_error {
+  color: #9f1d1d;
+  background: #fff1f1;
+}
+
+.hypster-group {
+  border: 1px solid var(--hypster-border);
+  border-radius: 8px;
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 14px;
+}
+
+.hypster-group > legend {
+  padding: 0 5px;
+  font-weight: 650;
+}
+
+.hypster-field {
+  display: grid;
+  gap: 6px;
+}
+
+.hypster-field-header {
+  font-weight: 580;
+}
+
+.hypster-description {
+  color: var(--hypster-muted);
+  font-size: 12px;
+}
+
+.hypster-field input,
+.hypster-field select {
+  border: 1px solid var(--hypster-border);
+  border-radius: 6px;
+  box-sizing: border-box;
+  min-height: 32px;
+  padding: 5px 8px;
+  color: inherit;
+  background: Canvas;
+}
+
+.hypster-field input[type="checkbox"] {
+  justify-self: start;
+  min-height: auto;
+}
+
+.hypster-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.hypster-actions button {
+  border: 1px solid var(--hypster-border);
+  border-radius: 6px;
+  padding: 5px 10px;
+  color: inherit;
+  background: var(--hypster-surface);
+}

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -1,12 +1,13 @@
 .hypster-widget {
+  --hypster-background: Canvas;
   --hypster-border: color-mix(in srgb, currentColor 14%, transparent);
   --hypster-error: color-mix(in srgb, #d93025 76%, CanvasText 24%);
   --hypster-error-border: color-mix(in srgb, #d93025 30%, transparent);
-  --hypster-error-surface: color-mix(in srgb, #d93025 12%, Canvas 88%);
+  --hypster-error-surface: color-mix(in srgb, #d93025 12%, var(--hypster-background) 88%);
   --hypster-muted: color-mix(in srgb, currentColor 58%, transparent);
   --hypster-menu-shadow: 0 8px 18px rgb(0 0 0 / 18%);
-  --hypster-surface: color-mix(in srgb, Canvas 96%, currentColor 4%);
-  --hypster-surface-strong: color-mix(in srgb, Canvas 90%, currentColor 10%);
+  --hypster-surface: color-mix(in srgb, var(--hypster-background) 96%, currentColor 4%);
+  --hypster-surface-strong: color-mix(in srgb, var(--hypster-background) 90%, currentColor 10%);
   border: 1px solid var(--hypster-border);
   border-radius: 8px;
   display: grid;
@@ -14,7 +15,7 @@
   max-width: 640px;
   padding: 16px;
   color: CanvasText;
-  background: Canvas;
+  background: var(--hypster-background);
   font: 14px/1.35 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
@@ -96,7 +97,7 @@
   min-height: 32px;
   padding: 5px 8px;
   color: inherit;
-  background: Canvas;
+  background: var(--hypster-background);
 }
 
 .hypster-choice {
@@ -105,7 +106,7 @@
 
 .hypster-choice-trigger {
   align-items: center;
-  background: Canvas;
+  background: var(--hypster-background);
   border: 1px solid var(--hypster-border);
   border-radius: 6px;
   box-sizing: border-box;
@@ -149,7 +150,7 @@
 }
 
 .hypster-choice-menu {
-  background: Canvas;
+  background: var(--hypster-background);
   border: 1px solid var(--hypster-border);
   border-radius: 6px;
   box-shadow: var(--hypster-menu-shadow);

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -1,39 +1,21 @@
 .hypster-widget {
-  --hypster-background: Canvas;
   --hypster-border: color-mix(in srgb, currentColor 14%, transparent);
   --hypster-error: color-mix(in srgb, #d93025 76%, CanvasText 24%);
   --hypster-error-border: color-mix(in srgb, #d93025 30%, transparent);
-  --hypster-error-surface: color-mix(in srgb, #d93025 12%, var(--hypster-background) 88%);
+  --hypster-error-surface: color-mix(in srgb, #d93025 12%, Canvas 88%);
   --hypster-muted: color-mix(in srgb, currentColor 58%, transparent);
   --hypster-menu-shadow: 0 8px 18px rgb(0 0 0 / 18%);
-  --hypster-surface: color-mix(in srgb, var(--hypster-background) 96%, currentColor 4%);
-  --hypster-surface-strong: color-mix(in srgb, var(--hypster-background) 90%, currentColor 10%);
+  --hypster-surface: color-mix(in srgb, Canvas 96%, currentColor 4%);
+  --hypster-surface-strong: color-mix(in srgb, Canvas 90%, currentColor 10%);
   border: 1px solid var(--hypster-border);
   border-radius: 8px;
   display: grid;
   gap: 14px;
-  isolation: isolate;
   max-width: 640px;
   padding: 16px;
-  position: relative;
-  z-index: 0;
   color: CanvasText;
-  background: var(--hypster-background);
+  background: Canvas;
   font: 14px/1.35 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-}
-
-.hypster-widget::before {
-  content: "";
-  position: absolute;
-  inset: -32px -100vw -32px -32px;
-  z-index: 0;
-  background: var(--hypster-background);
-  pointer-events: none;
-}
-
-.hypster-widget > * {
-  position: relative;
-  z-index: 1;
 }
 
 .hypster-theme-light {
@@ -114,7 +96,7 @@
   min-height: 32px;
   padding: 5px 8px;
   color: inherit;
-  background: var(--hypster-background);
+  background: Canvas;
 }
 
 .hypster-choice {
@@ -123,7 +105,7 @@
 
 .hypster-choice-trigger {
   align-items: center;
-  background: var(--hypster-background);
+  background: Canvas;
   border: 1px solid var(--hypster-border);
   border-radius: 6px;
   box-sizing: border-box;
@@ -167,7 +149,7 @@
 }
 
 .hypster-choice-menu {
-  background: var(--hypster-background);
+  background: Canvas;
   border: 1px solid var(--hypster-border);
   border-radius: 6px;
   box-shadow: var(--hypster-menu-shadow);

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -1,180 +1,59 @@
 .hypster-widget {
-  --hypster-border: color-mix(in srgb, currentColor 14%, transparent);
-  --hypster-muted: color-mix(in srgb, currentColor 58%, transparent);
-  --hypster-surface: color-mix(in srgb, Canvas 96%, currentColor 4%);
-  --hypster-surface-strong: color-mix(in srgb, Canvas 90%, currentColor 10%);
-  border: 1px solid var(--hypster-border);
-  border-radius: 8px;
   display: grid;
-  gap: 14px;
+  gap: 10px;
   max-width: 640px;
-  padding: 16px;
-  color: CanvasText;
-  background: Canvas;
+  padding: 4px 0;
+  color: inherit;
   font: 14px/1.35 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .hypster-title {
-  font-size: 15px;
-  font-weight: 650;
+  font-weight: 600;
 }
 
 .hypster-status {
-  border-radius: 999px;
-  justify-self: start;
-  padding: 3px 9px;
+  color: rgba(127, 127, 127, 0.9);
   font-size: 12px;
-  color: var(--hypster-muted);
-  background: var(--hypster-surface);
 }
 
 .hypster-status-error,
 .hypster-status-draft_error {
   color: #9f1d1d;
-  background: #fff1f1;
 }
 
 .hypster-group {
-  border: 1px solid var(--hypster-border);
-  border-radius: 8px;
+  border: 1px solid rgba(127, 127, 127, 0.35);
   display: grid;
-  gap: 12px;
+  gap: 10px;
   margin: 0;
-  padding: 14px;
+  padding: 10px 12px 12px;
 }
 
 .hypster-group > legend {
-  padding: 0 5px;
-  font-weight: 650;
+  padding: 0 4px;
+  font-weight: 600;
 }
 
 .hypster-field {
   display: grid;
-  gap: 6px;
+  gap: 4px;
   min-width: 0;
 }
 
 .hypster-field-header {
-  font-weight: 580;
+  font-weight: 600;
 }
 
 .hypster-description {
-  color: var(--hypster-muted);
+  color: rgba(127, 127, 127, 0.9);
   font-size: 12px;
 }
 
 .hypster-field input,
 .hypster-field select {
-  border: 1px solid var(--hypster-border);
-  border-radius: 6px;
   box-sizing: border-box;
-  min-height: 32px;
-  padding: 5px 8px;
-  color: inherit;
-  background: Canvas;
-}
-
-.hypster-choice {
-  position: relative;
-}
-
-.hypster-choice-trigger {
-  align-items: center;
-  background: Canvas;
-  border: 1px solid var(--hypster-border);
-  border-radius: 6px;
-  box-sizing: border-box;
-  color: inherit;
-  display: flex;
   font: inherit;
-  justify-content: space-between;
-  min-height: 32px;
-  padding: 5px 8px;
-  width: 100%;
-}
-
-.hypster-choice-trigger:hover,
-.hypster-choice-open .hypster-choice-trigger {
-  background: var(--hypster-surface);
-}
-
-.hypster-choice-trigger:focus-visible,
-.hypster-choice-option:focus-visible {
-  outline: 2px solid color-mix(in srgb, Highlight 70%, transparent);
-  outline-offset: 2px;
-}
-
-.hypster-choice-value {
-  min-width: 0;
-  overflow: hidden;
-  text-align: left;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.hypster-choice-arrow {
-  border-bottom: 1.5px solid currentColor;
-  border-right: 1.5px solid currentColor;
-  display: inline-block;
-  height: 7px;
-  margin-left: 12px;
-  opacity: 0.58;
-  transform: translateY(-2px) rotate(45deg);
-  width: 7px;
-}
-
-.hypster-choice-menu {
-  background: Canvas;
-  border: 1px solid var(--hypster-border);
-  border-radius: 6px;
-  box-shadow: 0 10px 24px color-mix(in srgb, CanvasText 16%, transparent);
-  box-sizing: border-box;
-  display: grid;
-  gap: 2px;
-  left: 0;
-  margin-top: 4px;
-  max-height: 220px;
-  min-width: 100%;
-  overflow: auto;
-  padding: 4px;
-  position: absolute;
-  right: 0;
-  top: 100%;
-  z-index: 20;
-}
-
-.hypster-choice-menu[hidden] {
-  display: none;
-}
-
-.hypster-choice-option {
-  background: transparent;
-  border: 0;
-  border-radius: 4px;
-  color: inherit;
-  font: inherit;
-  min-height: 30px;
-  padding: 5px 8px 5px 26px;
-  position: relative;
-  text-align: left;
-}
-
-.hypster-choice-option:hover,
-.hypster-choice-option[aria-selected="true"] {
-  background: var(--hypster-surface-strong);
-}
-
-.hypster-choice-option[aria-selected="true"]::before {
-  background: currentColor;
-  border-radius: 999px;
-  content: "";
-  height: 6px;
-  left: 10px;
-  opacity: 0.72;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 6px;
+  max-width: 100%;
 }
 
 .hypster-field input[type="checkbox"] {
@@ -188,9 +67,5 @@
 }
 
 .hypster-actions button {
-  border: 1px solid var(--hypster-border);
-  border-radius: 6px;
-  padding: 5px 10px;
-  color: inherit;
-  background: var(--hypster-surface);
+  font: inherit;
 }

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -67,5 +67,24 @@
 }
 
 .hypster-actions button {
+  border: 1px solid rgba(127, 127, 127, 0.55);
+  border-radius: 2px;
+  padding: 2px 8px;
+  color: inherit;
+  background: rgba(127, 127, 127, 0.12);
+  cursor: pointer;
   font: inherit;
+}
+
+.hypster-actions button:hover:not(:disabled) {
+  background: rgba(127, 127, 127, 0.18);
+}
+
+.hypster-actions button:active:not(:disabled) {
+  background: rgba(127, 127, 127, 0.24);
+}
+
+.hypster-actions button:disabled {
+  cursor: default;
+  opacity: 0.55;
 }

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -2,6 +2,7 @@
   --hypster-border: color-mix(in srgb, currentColor 14%, transparent);
   --hypster-muted: color-mix(in srgb, currentColor 58%, transparent);
   --hypster-surface: color-mix(in srgb, Canvas 96%, currentColor 4%);
+  --hypster-surface-strong: color-mix(in srgb, Canvas 90%, currentColor 10%);
   border: 1px solid var(--hypster-border);
   border-radius: 8px;
   display: grid;
@@ -50,6 +51,7 @@
 .hypster-field {
   display: grid;
   gap: 6px;
+  min-width: 0;
 }
 
 .hypster-field-header {
@@ -70,6 +72,109 @@
   padding: 5px 8px;
   color: inherit;
   background: Canvas;
+}
+
+.hypster-choice {
+  position: relative;
+}
+
+.hypster-choice-trigger {
+  align-items: center;
+  background: Canvas;
+  border: 1px solid var(--hypster-border);
+  border-radius: 6px;
+  box-sizing: border-box;
+  color: inherit;
+  display: flex;
+  font: inherit;
+  justify-content: space-between;
+  min-height: 32px;
+  padding: 5px 8px;
+  width: 100%;
+}
+
+.hypster-choice-trigger:hover,
+.hypster-choice-open .hypster-choice-trigger {
+  background: var(--hypster-surface);
+}
+
+.hypster-choice-trigger:focus-visible,
+.hypster-choice-option:focus-visible {
+  outline: 2px solid color-mix(in srgb, Highlight 70%, transparent);
+  outline-offset: 2px;
+}
+
+.hypster-choice-value {
+  min-width: 0;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hypster-choice-arrow {
+  border-bottom: 1.5px solid currentColor;
+  border-right: 1.5px solid currentColor;
+  display: inline-block;
+  height: 7px;
+  margin-left: 12px;
+  opacity: 0.58;
+  transform: translateY(-2px) rotate(45deg);
+  width: 7px;
+}
+
+.hypster-choice-menu {
+  background: Canvas;
+  border: 1px solid var(--hypster-border);
+  border-radius: 6px;
+  box-shadow: 0 10px 24px color-mix(in srgb, CanvasText 16%, transparent);
+  box-sizing: border-box;
+  display: grid;
+  gap: 2px;
+  left: 0;
+  margin-top: 4px;
+  max-height: 220px;
+  min-width: 100%;
+  overflow: auto;
+  padding: 4px;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  z-index: 20;
+}
+
+.hypster-choice-menu[hidden] {
+  display: none;
+}
+
+.hypster-choice-option {
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  color: inherit;
+  font: inherit;
+  min-height: 30px;
+  padding: 5px 8px 5px 26px;
+  position: relative;
+  text-align: left;
+}
+
+.hypster-choice-option:hover,
+.hypster-choice-option[aria-selected="true"] {
+  background: var(--hypster-surface-strong);
+}
+
+.hypster-choice-option[aria-selected="true"]::before {
+  background: currentColor;
+  border-radius: 999px;
+  content: "";
+  height: 6px;
+  left: 10px;
+  opacity: 0.72;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 6px;
 }
 
 .hypster-field input[type="checkbox"] {

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -190,16 +190,26 @@
 }
 
 .hypster-actions button {
-  border: 1px solid var(--hypster-border);
-  border-radius: 6px;
-  padding: 5px 10px;
-  color: inherit;
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  padding: 4px 10px;
+  color: color-mix(in srgb, currentColor 72%, transparent);
   background: var(--hypster-surface);
   cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.35;
 }
 
 .hypster-actions button:hover:not(:disabled) {
+  border-color: var(--hypster-border);
   background: var(--hypster-surface-strong);
+}
+
+.hypster-actions button:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 .hypster-actions button:disabled {

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -12,11 +12,22 @@
   border-radius: 8px;
   display: grid;
   gap: 14px;
+  isolation: isolate;
   max-width: 640px;
   padding: 16px;
+  position: relative;
   color: CanvasText;
   background: var(--hypster-background);
   font: 14px/1.35 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.hypster-widget::before {
+  content: "";
+  position: absolute;
+  inset: -32px -100vw -32px -32px;
+  z-index: -1;
+  background: var(--hypster-background);
+  pointer-events: none;
 }
 
 .hypster-theme-light {

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -1,6 +1,7 @@
 .hypster-widget {
   --hypster-border: color-mix(in srgb, currentColor 14%, transparent);
   --hypster-muted: color-mix(in srgb, currentColor 58%, transparent);
+  --hypster-menu-shadow: 0 8px 18px rgb(0 0 0 / 18%);
   --hypster-surface: color-mix(in srgb, Canvas 96%, currentColor 4%);
   --hypster-surface-strong: color-mix(in srgb, Canvas 90%, currentColor 10%);
   border: 1px solid var(--hypster-border);
@@ -127,7 +128,7 @@
   background: Canvas;
   border: 1px solid var(--hypster-border);
   border-radius: 6px;
-  box-shadow: 0 10px 24px color-mix(in srgb, CanvasText 16%, transparent);
+  box-shadow: var(--hypster-menu-shadow);
   box-sizing: border-box;
   display: grid;
   gap: 2px;

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -16,6 +16,7 @@
   max-width: 640px;
   padding: 16px;
   position: relative;
+  z-index: 0;
   color: CanvasText;
   background: var(--hypster-background);
   font: 14px/1.35 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -25,9 +26,14 @@
   content: "";
   position: absolute;
   inset: -32px -100vw -32px -32px;
-  z-index: -1;
+  z-index: 0;
   background: var(--hypster-background);
   pointer-events: none;
+}
+
+.hypster-widget > * {
+  position: relative;
+  z-index: 1;
 }
 
 .hypster-theme-light {

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -18,6 +18,14 @@
   font: 14px/1.35 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
+.hypster-theme-light {
+  color-scheme: light;
+}
+
+.hypster-theme-dark {
+  color-scheme: dark;
+}
+
 .hypster-header {
   align-items: start;
   display: flex;
@@ -190,17 +198,25 @@
 }
 
 .hypster-actions button {
+  -webkit-appearance: none;
   appearance: none;
   border: 1px solid transparent;
   border-radius: 5px;
+  box-sizing: border-box;
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  min-height: 25px;
+  min-width: 52px;
   padding: 4px 10px;
   color: color-mix(in srgb, currentColor 72%, transparent);
   background: var(--hypster-surface);
   cursor: pointer;
-  font: inherit;
+  font-family: inherit;
   font-size: 12px;
   font-weight: 500;
   line-height: 1.35;
+  text-transform: none;
 }
 
 .hypster-actions button:hover:not(:disabled) {

--- a/src/hypster/interactive/interact.css
+++ b/src/hypster/interactive/interact.css
@@ -1,5 +1,8 @@
 .hypster-widget {
   --hypster-border: color-mix(in srgb, currentColor 14%, transparent);
+  --hypster-error: color-mix(in srgb, #d93025 76%, CanvasText 24%);
+  --hypster-error-border: color-mix(in srgb, #d93025 30%, transparent);
+  --hypster-error-surface: color-mix(in srgb, #d93025 12%, Canvas 88%);
   --hypster-muted: color-mix(in srgb, currentColor 58%, transparent);
   --hypster-menu-shadow: 0 8px 18px rgb(0 0 0 / 18%);
   --hypster-surface: color-mix(in srgb, Canvas 96%, currentColor 4%);
@@ -15,24 +18,37 @@
   font: 14px/1.35 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
+.hypster-header {
+  align-items: start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
 .hypster-title {
   font-size: 15px;
   font-weight: 650;
+  min-width: 0;
 }
 
 .hypster-status {
-  border-radius: 999px;
-  justify-self: start;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  max-width: 60%;
   padding: 3px 9px;
   font-size: 12px;
   color: var(--hypster-muted);
   background: var(--hypster-surface);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hypster-status-error,
 .hypster-status-draft_error {
-  color: #9f1d1d;
-  background: #fff1f1;
+  border-color: var(--hypster-error-border);
+  color: var(--hypster-error);
+  background: var(--hypster-error-surface);
 }
 
 .hypster-group {

--- a/src/hypster/interactive/interact.js
+++ b/src/hypster/interactive/interact.js
@@ -215,16 +215,33 @@ function applyHostTheme(el) {
 
 function outputSurfaceElements(el) {
   const elements = [el];
+  const ownerDocument = el.ownerDocument || document;
   let current = el.parentElement;
 
-  for (let depth = 0; current && current !== document.body && current !== document.documentElement && depth < 6; depth += 1) {
+  for (
+    let depth = 0;
+    current && current !== ownerDocument.body && current !== ownerDocument.documentElement && depth < 12;
+    depth += 1
+  ) {
     elements.push(current);
-    const className = String(current.className || "");
-    if (/cell-output|outputarea|output-area|jp-outputarea|widget-subarea|widget-area|vscode-cell-output/i.test(className)) {
-      break;
-    }
     current = current.parentElement;
   }
+
+  const rootNode = el.getRootNode?.();
+  if (rootNode?.host instanceof HTMLElement) {
+    let host = rootNode.host;
+    for (
+      let depth = 0;
+      host && host !== ownerDocument.body && host !== ownerDocument.documentElement && depth < 8;
+      depth += 1
+    ) {
+      elements.push(host);
+      host = host.parentElement;
+    }
+  }
+
+  if (ownerDocument.body) elements.push(ownerDocument.body);
+  if (ownerDocument.documentElement) elements.push(ownerDocument.documentElement);
 
   return elements;
 }
@@ -251,6 +268,7 @@ function setTrackedStyle(el, element, property, value, priority = "") {
 
 function paintOutputSurface(el, state) {
   for (const element of outputSurfaceElements(el)) {
+    if (!element?.style) continue;
     setTrackedStyle(el, element, "background-color", state.background, "important");
     setTrackedStyle(el, element, "color-scheme", state.theme);
   }

--- a/src/hypster/interactive/interact.js
+++ b/src/hypster/interactive/interact.js
@@ -11,6 +11,15 @@ function optionValue(option) {
   return JSON.parse(option.dataset.value);
 }
 
+function encodedValue(value) {
+  return JSON.stringify(value);
+}
+
+function decodedValue(element) {
+  if (element.dataset.value == null) return element.value;
+  return JSON.parse(element.dataset.value);
+}
+
 function valueFor(snapshot, parameter) {
   if (hasOwn(snapshot.draft_values, parameter.path)) {
     return snapshot.draft_values[parameter.path];
@@ -63,6 +72,14 @@ function labelFor(parameter) {
   return parameter.display_label || parameter.name;
 }
 
+function closeChoiceMenus(root) {
+  for (const choice of root.querySelectorAll(".hypster-choice-open")) {
+    choice.classList.remove("hypster-choice-open");
+    choice.querySelector(".hypster-choice-trigger")?.setAttribute("aria-expanded", "false");
+    choice.querySelector(".hypster-choice-menu")?.setAttribute("hidden", "");
+  }
+}
+
 function renderParameter(model, snapshot, parameter) {
   if (parameter.kind === "group") {
     const group = document.createElement("fieldset");
@@ -85,7 +102,7 @@ function renderParameter(model, snapshot, parameter) {
     return group;
   }
 
-  const field = document.createElement("label");
+  const field = document.createElement("div");
   field.className = "hypster-field";
 
   const header = document.createElement("span");
@@ -107,7 +124,11 @@ function renderParameter(model, snapshot, parameter) {
 function renderControl(snapshot, parameter) {
   const currentValue = valueFor(snapshot, parameter);
 
-  if (parameter.kind === "select" || parameter.kind === "multi_select") {
+  if (parameter.kind === "select") {
+    return renderChoiceControl(parameter, currentValue);
+  }
+
+  if (parameter.kind === "multi_select") {
     const select = document.createElement("select");
     select.dataset.path = parameter.path;
     select.dataset.kind = parameter.kind;
@@ -115,7 +136,7 @@ function renderControl(snapshot, parameter) {
     for (const optionValue of parameter.options || []) {
       const option = document.createElement("option");
       option.value = String(select.options.length);
-      option.dataset.value = JSON.stringify(optionValue);
+      option.dataset.value = encodedValue(optionValue);
       option.textContent = String(optionValue);
       option.selected = Array.isArray(currentValue)
         ? currentValue.some((selectedValue) => valuesEqual(selectedValue, optionValue))
@@ -149,6 +170,53 @@ function renderControl(snapshot, parameter) {
 
   input.type = "text";
   return input;
+}
+
+function renderChoiceControl(parameter, currentValue) {
+  const choice = document.createElement("div");
+  choice.className = "hypster-choice";
+  choice.dataset.path = parameter.path;
+  choice.dataset.kind = parameter.kind;
+
+  const trigger = document.createElement("button");
+  trigger.type = "button";
+  trigger.className = "hypster-choice-trigger";
+  trigger.dataset.hypsterChoiceTrigger = "";
+  trigger.setAttribute("aria-haspopup", "listbox");
+  trigger.setAttribute("aria-expanded", "false");
+
+  const value = document.createElement("span");
+  value.className = "hypster-choice-value";
+  value.textContent = String(currentValue ?? "");
+  trigger.append(value);
+
+  const arrow = document.createElement("span");
+  arrow.className = "hypster-choice-arrow";
+  arrow.setAttribute("aria-hidden", "true");
+  trigger.append(arrow);
+
+  choice.append(trigger);
+
+  const menu = document.createElement("div");
+  menu.className = "hypster-choice-menu";
+  menu.setAttribute("role", "listbox");
+  menu.setAttribute("hidden", "");
+
+  for (const optionValue of parameter.options || []) {
+    const option = document.createElement("button");
+    option.type = "button";
+    option.className = "hypster-choice-option";
+    option.dataset.hypsterChoiceOption = "";
+    option.dataset.path = parameter.path;
+    option.dataset.value = encodedValue(optionValue);
+    option.setAttribute("role", "option");
+    option.setAttribute("aria-selected", valuesEqual(optionValue, currentValue) ? "true" : "false");
+    option.textContent = String(optionValue);
+    menu.append(option);
+  }
+
+  choice.append(menu);
+  return choice;
 }
 
 function renderStatus(snapshot) {
@@ -204,6 +272,39 @@ function render(model, el) {
 
 export default {
   render({ model, el }) {
+    el.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const option = target.closest("[data-hypster-choice-option]");
+      if (option instanceof HTMLElement && option.dataset.path) {
+        closeChoiceMenus(el);
+        send(model, {
+          type: "set_value",
+          path: option.dataset.path,
+          value: decodedValue(option),
+        });
+        return;
+      }
+
+      const trigger = target.closest("[data-hypster-choice-trigger]");
+      if (trigger instanceof HTMLElement) {
+        const choice = trigger.closest(".hypster-choice");
+        if (!(choice instanceof HTMLElement)) return;
+        const menu = choice.querySelector(".hypster-choice-menu");
+        const isOpen = choice.classList.contains("hypster-choice-open");
+        closeChoiceMenus(el);
+        if (!isOpen) {
+          choice.classList.add("hypster-choice-open");
+          trigger.setAttribute("aria-expanded", "true");
+          menu?.removeAttribute("hidden");
+        }
+        return;
+      }
+
+      closeChoiceMenus(el);
+    });
+
     el.addEventListener("change", (event) => {
       const target = event.target;
       if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement)) return;

--- a/src/hypster/interactive/interact.js
+++ b/src/hypster/interactive/interact.js
@@ -15,11 +15,6 @@ function encodedValue(value) {
   return JSON.stringify(value);
 }
 
-function decodedValue(element) {
-  if (element.dataset.value == null) return element.value;
-  return JSON.parse(element.dataset.value);
-}
-
 function valueFor(snapshot, parameter) {
   if (hasOwn(snapshot.draft_values, parameter.path)) {
     return snapshot.draft_values[parameter.path];
@@ -72,14 +67,6 @@ function labelFor(parameter) {
   return parameter.display_label || parameter.name;
 }
 
-function closeChoiceMenus(root) {
-  for (const choice of root.querySelectorAll(".hypster-choice-open")) {
-    choice.classList.remove("hypster-choice-open");
-    choice.querySelector(".hypster-choice-trigger")?.setAttribute("aria-expanded", "false");
-    choice.querySelector(".hypster-choice-menu")?.setAttribute("hidden", "");
-  }
-}
-
 function renderParameter(model, snapshot, parameter) {
   if (parameter.kind === "group") {
     const group = document.createElement("fieldset");
@@ -124,11 +111,7 @@ function renderParameter(model, snapshot, parameter) {
 function renderControl(snapshot, parameter) {
   const currentValue = valueFor(snapshot, parameter);
 
-  if (parameter.kind === "select") {
-    return renderChoiceControl(parameter, currentValue);
-  }
-
-  if (parameter.kind === "multi_select") {
+  if (parameter.kind === "select" || parameter.kind === "multi_select") {
     const select = document.createElement("select");
     select.dataset.path = parameter.path;
     select.dataset.kind = parameter.kind;
@@ -170,53 +153,6 @@ function renderControl(snapshot, parameter) {
 
   input.type = "text";
   return input;
-}
-
-function renderChoiceControl(parameter, currentValue) {
-  const choice = document.createElement("div");
-  choice.className = "hypster-choice";
-  choice.dataset.path = parameter.path;
-  choice.dataset.kind = parameter.kind;
-
-  const trigger = document.createElement("button");
-  trigger.type = "button";
-  trigger.className = "hypster-choice-trigger";
-  trigger.dataset.hypsterChoiceTrigger = "";
-  trigger.setAttribute("aria-haspopup", "listbox");
-  trigger.setAttribute("aria-expanded", "false");
-
-  const value = document.createElement("span");
-  value.className = "hypster-choice-value";
-  value.textContent = String(currentValue ?? "");
-  trigger.append(value);
-
-  const arrow = document.createElement("span");
-  arrow.className = "hypster-choice-arrow";
-  arrow.setAttribute("aria-hidden", "true");
-  trigger.append(arrow);
-
-  choice.append(trigger);
-
-  const menu = document.createElement("div");
-  menu.className = "hypster-choice-menu";
-  menu.setAttribute("role", "listbox");
-  menu.setAttribute("hidden", "");
-
-  for (const optionValue of parameter.options || []) {
-    const option = document.createElement("button");
-    option.type = "button";
-    option.className = "hypster-choice-option";
-    option.dataset.hypsterChoiceOption = "";
-    option.dataset.path = parameter.path;
-    option.dataset.value = encodedValue(optionValue);
-    option.setAttribute("role", "option");
-    option.setAttribute("aria-selected", valuesEqual(optionValue, currentValue) ? "true" : "false");
-    option.textContent = String(optionValue);
-    menu.append(option);
-  }
-
-  choice.append(menu);
-  return choice;
 }
 
 function renderStatus(snapshot) {
@@ -272,39 +208,6 @@ function render(model, el) {
 
 export default {
   render({ model, el }) {
-    el.addEventListener("click", (event) => {
-      const target = event.target;
-      if (!(target instanceof Element)) return;
-
-      const option = target.closest("[data-hypster-choice-option]");
-      if (option instanceof HTMLElement && option.dataset.path) {
-        closeChoiceMenus(el);
-        send(model, {
-          type: "set_value",
-          path: option.dataset.path,
-          value: decodedValue(option),
-        });
-        return;
-      }
-
-      const trigger = target.closest("[data-hypster-choice-trigger]");
-      if (trigger instanceof HTMLElement) {
-        const choice = trigger.closest(".hypster-choice");
-        if (!(choice instanceof HTMLElement)) return;
-        const menu = choice.querySelector(".hypster-choice-menu");
-        const isOpen = choice.classList.contains("hypster-choice-open");
-        closeChoiceMenus(el);
-        if (!isOpen) {
-          choice.classList.add("hypster-choice-open");
-          trigger.setAttribute("aria-expanded", "true");
-          menu?.removeAttribute("hidden");
-        }
-        return;
-      }
-
-      closeChoiceMenus(el);
-    });
-
     el.addEventListener("change", (event) => {
       const target = event.target;
       if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement)) return;

--- a/src/hypster/interactive/interact.js
+++ b/src/hypster/interactive/interact.js
@@ -1,0 +1,179 @@
+function controlValue(input) {
+  if (input instanceof HTMLSelectElement && input.multiple) {
+    return Array.from(input.selectedOptions, (option) => option.value);
+  }
+  if (input.type === "checkbox") {
+    return input.checked;
+  }
+  if (input.dataset.kind === "int") {
+    return Number.parseInt(input.value, 10);
+  }
+  if (input.dataset.kind === "float") {
+    return Number.parseFloat(input.value);
+  }
+  return input.value;
+}
+
+function send(model, action) {
+  model.set("action", { id: crypto.randomUUID(), ...action });
+  model.save_changes();
+}
+
+function labelFor(parameter) {
+  return parameter.display_label || parameter.name;
+}
+
+function renderParameter(model, parameter) {
+  if (parameter.kind === "group") {
+    const group = document.createElement("fieldset");
+    group.className = "hypster-group";
+
+    const legend = document.createElement("legend");
+    legend.textContent = labelFor(parameter);
+    group.append(legend);
+
+    if (parameter.description) {
+      const description = document.createElement("p");
+      description.className = "hypster-description";
+      description.textContent = parameter.description;
+      group.append(description);
+    }
+
+    for (const child of parameter.children || []) {
+      group.append(renderParameter(model, child));
+    }
+    return group;
+  }
+
+  const field = document.createElement("label");
+  field.className = "hypster-field";
+
+  const header = document.createElement("span");
+  header.className = "hypster-field-header";
+  header.textContent = labelFor(parameter);
+  field.append(header);
+
+  if (parameter.description) {
+    const description = document.createElement("span");
+    description.className = "hypster-description";
+    description.textContent = parameter.description;
+    field.append(description);
+  }
+
+  field.append(renderControl(model, parameter));
+  return field;
+}
+
+function renderControl(model, parameter) {
+  if (parameter.kind === "select" || parameter.kind === "multi_select") {
+    const select = document.createElement("select");
+    select.dataset.path = parameter.path;
+    select.dataset.kind = parameter.kind;
+    select.multiple = parameter.kind === "multi_select";
+    for (const optionValue of parameter.options || []) {
+      const option = document.createElement("option");
+      option.value = optionValue;
+      option.textContent = String(optionValue);
+      option.selected = Array.isArray(parameter.selected_value)
+        ? parameter.selected_value.includes(optionValue)
+        : optionValue === parameter.selected_value;
+      select.append(option);
+    }
+    return select;
+  }
+
+  if (parameter.kind === "bool") {
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = Boolean(parameter.selected_value);
+    checkbox.dataset.path = parameter.path;
+    checkbox.dataset.kind = parameter.kind;
+    return checkbox;
+  }
+
+  const input = document.createElement("input");
+  input.dataset.path = parameter.path;
+  input.dataset.kind = parameter.kind;
+  input.value = parameter.selected_value ?? "";
+
+  if (parameter.kind === "int" || parameter.kind === "float") {
+    input.type = "number";
+    if (parameter.minimum != null) input.min = parameter.minimum;
+    if (parameter.maximum != null) input.max = parameter.maximum;
+    if (parameter.kind === "float") input.step = "any";
+    return input;
+  }
+
+  input.type = "text";
+  return input;
+}
+
+function renderStatus(snapshot) {
+  const status = document.createElement("div");
+  status.className = `hypster-status hypster-status-${snapshot.status}`;
+  status.textContent = snapshot.status === "pending" ? "Pending changes" : "Up to date";
+
+  if (snapshot.error) {
+    status.textContent = snapshot.error.message;
+  }
+
+  return status;
+}
+
+function render(model, el) {
+  const snapshot = model.get("snapshot");
+  el.replaceChildren();
+
+  const root = document.createElement("div");
+  root.className = "hypster-widget";
+
+  const title = document.createElement("div");
+  title.className = "hypster-title";
+  title.textContent = snapshot.schema?.name || "Hypster";
+  root.append(title);
+  root.append(renderStatus(snapshot));
+
+  for (const parameter of snapshot.schema?.parameters || []) {
+    root.append(renderParameter(model, parameter));
+  }
+
+  const actions = document.createElement("div");
+  actions.className = "hypster-actions";
+
+  const reset = document.createElement("button");
+  reset.type = "button";
+  reset.textContent = "Reset";
+  reset.addEventListener("click", () => send(model, { type: "reset" }));
+  actions.append(reset);
+
+  if (snapshot.mode?.auto_apply === false) {
+    const apply = document.createElement("button");
+    apply.type = "button";
+    apply.textContent = "Apply";
+    apply.disabled = snapshot.status === "draft_error";
+    apply.addEventListener("click", () => send(model, { type: "apply" }));
+    actions.append(apply);
+  }
+
+  root.append(actions);
+  el.append(root);
+}
+
+export default {
+  render({ model, el }) {
+    el.addEventListener("change", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement)) return;
+      if (!target.dataset.path) return;
+
+      send(model, {
+        type: "set_value",
+        path: target.dataset.path,
+        value: controlValue(target),
+      });
+    });
+
+    model.on("change:snapshot", () => render(model, el));
+    render(model, el);
+  },
+};

--- a/src/hypster/interactive/interact.js
+++ b/src/hypster/interactive/interact.js
@@ -15,6 +15,11 @@ function encodedValue(value) {
   return JSON.stringify(value);
 }
 
+function decodedValue(element) {
+  if (element.dataset.value == null) return element.value;
+  return JSON.parse(element.dataset.value);
+}
+
 function valueFor(snapshot, parameter) {
   if (hasOwn(snapshot.draft_values, parameter.path)) {
     return snapshot.draft_values[parameter.path];
@@ -67,6 +72,14 @@ function labelFor(parameter) {
   return parameter.display_label || parameter.name;
 }
 
+function closeChoiceMenus(root) {
+  for (const choice of root.querySelectorAll(".hypster-choice-open")) {
+    choice.classList.remove("hypster-choice-open");
+    choice.querySelector(".hypster-choice-trigger")?.setAttribute("aria-expanded", "false");
+    choice.querySelector(".hypster-choice-menu")?.setAttribute("hidden", "");
+  }
+}
+
 function renderParameter(model, snapshot, parameter) {
   if (parameter.kind === "group") {
     const group = document.createElement("fieldset");
@@ -111,7 +124,11 @@ function renderParameter(model, snapshot, parameter) {
 function renderControl(snapshot, parameter) {
   const currentValue = valueFor(snapshot, parameter);
 
-  if (parameter.kind === "select" || parameter.kind === "multi_select") {
+  if (parameter.kind === "select") {
+    return renderChoiceControl(parameter, currentValue);
+  }
+
+  if (parameter.kind === "multi_select") {
     const select = document.createElement("select");
     select.dataset.path = parameter.path;
     select.dataset.kind = parameter.kind;
@@ -153,6 +170,53 @@ function renderControl(snapshot, parameter) {
 
   input.type = "text";
   return input;
+}
+
+function renderChoiceControl(parameter, currentValue) {
+  const choice = document.createElement("div");
+  choice.className = "hypster-choice";
+  choice.dataset.path = parameter.path;
+  choice.dataset.kind = parameter.kind;
+
+  const trigger = document.createElement("button");
+  trigger.type = "button";
+  trigger.className = "hypster-choice-trigger";
+  trigger.dataset.hypsterChoiceTrigger = "";
+  trigger.setAttribute("aria-haspopup", "listbox");
+  trigger.setAttribute("aria-expanded", "false");
+
+  const value = document.createElement("span");
+  value.className = "hypster-choice-value";
+  value.textContent = String(currentValue ?? "");
+  trigger.append(value);
+
+  const arrow = document.createElement("span");
+  arrow.className = "hypster-choice-arrow";
+  arrow.setAttribute("aria-hidden", "true");
+  trigger.append(arrow);
+
+  choice.append(trigger);
+
+  const menu = document.createElement("div");
+  menu.className = "hypster-choice-menu";
+  menu.setAttribute("role", "listbox");
+  menu.setAttribute("hidden", "");
+
+  for (const optionValue of parameter.options || []) {
+    const option = document.createElement("button");
+    option.type = "button";
+    option.className = "hypster-choice-option";
+    option.dataset.hypsterChoiceOption = "";
+    option.dataset.path = parameter.path;
+    option.dataset.value = encodedValue(optionValue);
+    option.setAttribute("role", "option");
+    option.setAttribute("aria-selected", valuesEqual(optionValue, currentValue) ? "true" : "false");
+    option.textContent = String(optionValue);
+    menu.append(option);
+  }
+
+  choice.append(menu);
+  return choice;
 }
 
 function renderStatus(snapshot) {
@@ -208,6 +272,39 @@ function render(model, el) {
 
 export default {
   render({ model, el }) {
+    el.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const option = target.closest("[data-hypster-choice-option]");
+      if (option instanceof HTMLElement && option.dataset.path) {
+        closeChoiceMenus(el);
+        send(model, {
+          type: "set_value",
+          path: option.dataset.path,
+          value: decodedValue(option),
+        });
+        return;
+      }
+
+      const trigger = target.closest("[data-hypster-choice-trigger]");
+      if (trigger instanceof HTMLElement) {
+        const choice = trigger.closest(".hypster-choice");
+        if (!(choice instanceof HTMLElement)) return;
+        const menu = choice.querySelector(".hypster-choice-menu");
+        const isOpen = choice.classList.contains("hypster-choice-open");
+        closeChoiceMenus(el);
+        if (!isOpen) {
+          choice.classList.add("hypster-choice-open");
+          trigger.setAttribute("aria-expanded", "true");
+          menu?.removeAttribute("hidden");
+        }
+        return;
+      }
+
+      closeChoiceMenus(el);
+    });
+
     el.addEventListener("change", (event) => {
       const target = event.target;
       if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement)) return;

--- a/src/hypster/interactive/interact.js
+++ b/src/hypster/interactive/interact.js
@@ -82,66 +82,16 @@ function closeChoiceMenus(root) {
 
 function themeDocuments(baseDocument) {
   const documents = [];
+  if (baseDocument) documents.push(baseDocument);
+
   try {
     const parentDocument = globalThis.parent?.document;
-    if (parentDocument) documents.push(parentDocument);
+    if (parentDocument && !documents.includes(parentDocument)) documents.push(parentDocument);
   } catch {
     // Cross-origin notebook hosts can block parent access.
   }
-  if (baseDocument && !documents.includes(baseDocument)) documents.push(baseDocument);
+
   return documents;
-}
-
-function themeFromColor(value) {
-  const raw = String(value || "").trim();
-  if (!raw || raw === "transparent" || raw === "rgba(0, 0, 0, 0)") return null;
-
-  const rgb = raw.match(/rgba?\(([^)]+)\)/i);
-  if (rgb) {
-    const parts = (rgb[1].match(/[\d.]+/g) || []).map(Number);
-    if (parts.length >= 3 && parts.slice(0, 3).every(Number.isFinite)) {
-      if (parts.length >= 4 && parts[3] < 0.1) return null;
-      const luminance = 0.299 * parts[0] + 0.587 * parts[1] + 0.114 * parts[2];
-      return { background: raw, luminance, theme: luminance > 150 ? "light" : "dark" };
-    }
-  }
-
-  const hex = raw.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
-  if (hex) {
-    const digits =
-      hex[1].length === 3
-        ? hex[1].split("").map((digit) => digit + digit).join("")
-        : hex[1];
-    const red = Number.parseInt(digits.slice(0, 2), 16);
-    const green = Number.parseInt(digits.slice(2, 4), 16);
-    const blue = Number.parseInt(digits.slice(4, 6), 16);
-    const luminance = 0.299 * red + 0.587 * green + 0.114 * blue;
-    return { background: raw, luminance, theme: luminance > 150 ? "light" : "dark" };
-  }
-
-  return null;
-}
-
-function fallbackBackground(theme) {
-  return theme === "light" ? "#ffffff" : "#111111";
-}
-
-function themeState(theme, parsedColor = null) {
-  const safeTheme = theme === "light" ? "light" : "dark";
-  let background = parsedColor?.background || fallbackBackground(safeTheme);
-
-  if (typeof parsedColor?.luminance === "number") {
-    const backgroundLooksLight = parsedColor.luminance > 150;
-    if ((safeTheme === "dark" && backgroundLooksLight) || (safeTheme === "light" && !backgroundLooksLight)) {
-      background = fallbackBackground(safeTheme);
-    }
-  }
-
-  return {
-    background,
-    luminance: parsedColor?.luminance ?? null,
-    theme: safeTheme,
-  };
 }
 
 function themeFromDocument(doc) {
@@ -149,147 +99,52 @@ function themeFromDocument(doc) {
   const html = doc.documentElement;
   if (!body || !html) return null;
 
-  const view = doc.defaultView || globalThis;
-  const rootStyle = view.getComputedStyle?.(html);
-  const bodyStyle = view.getComputedStyle?.(body);
-  const backgroundCandidates = [
-    rootStyle?.getPropertyValue("--vscode-editor-background"),
-    rootStyle?.getPropertyValue("--jp-layout-color0"),
-    rootStyle?.getPropertyValue("--jp-layout-color1"),
-    bodyStyle?.backgroundColor,
-    rootStyle?.backgroundColor,
-  ];
-  const parsedBackground = backgroundCandidates.map(themeFromColor).find(Boolean);
-
   const vscodeThemeKind = body.getAttribute("data-vscode-theme-kind") || html.getAttribute("data-vscode-theme-kind");
-  if (vscodeThemeKind) return themeState(vscodeThemeKind.includes("light") ? "light" : "dark", parsedBackground);
+  if (vscodeThemeKind) return vscodeThemeKind.includes("light") ? "light" : "dark";
 
   const classNames = `${body.className || ""} ${html.className || ""}`.toLowerCase();
   if (classNames.includes("vscode-high-contrast-light") || classNames.includes("vscode-light")) {
-    return themeState("light", parsedBackground);
+    return "light";
   }
   if (classNames.includes("vscode-high-contrast") || classNames.includes("vscode-dark")) {
-    return themeState("dark", parsedBackground);
+    return "dark";
   }
 
   const jupyterThemeLight = body.dataset.jpThemeLight ?? html.dataset.jpThemeLight;
-  if (jupyterThemeLight === "true") return themeState("light", parsedBackground);
-  if (jupyterThemeLight === "false") return themeState("dark", parsedBackground);
-  if (classNames.includes("jp-mod-light")) return themeState("light", parsedBackground);
-  if (classNames.includes("jp-mod-dark")) return themeState("dark", parsedBackground);
+  if (jupyterThemeLight === "true") return "light";
+  if (jupyterThemeLight === "false") return "dark";
+  if (classNames.includes("jp-mod-light") || classNames.includes("jp-mod-theme-light")) return "light";
+  if (classNames.includes("jp-mod-dark") || classNames.includes("jp-mod-theme-dark")) return "dark";
 
   const dataTheme = body.dataset.theme || html.dataset.theme || body.dataset.mode || html.dataset.mode;
-  if (dataTheme === "light" || dataTheme === "dark") return themeState(dataTheme, parsedBackground);
-
-  const colorScheme = rootStyle?.getPropertyValue("color-scheme").trim();
-  const colorSchemes = colorScheme?.split(/\s+/) || [];
-  if (colorSchemes.includes("dark") && !colorSchemes.includes("light")) return themeState("dark", parsedBackground);
-  if (colorSchemes.includes("light") && !colorSchemes.includes("dark")) return themeState("light", parsedBackground);
-
-  if (parsedBackground) return themeState(parsedBackground.theme, parsedBackground);
+  if (dataTheme === "light" || dataTheme === "dark") return dataTheme;
 
   return null;
 }
 
 function detectHostTheme(baseDocument) {
   for (const doc of themeDocuments(baseDocument)) {
-    const state = themeFromDocument(doc);
-    if (state) return state;
+    const theme = themeFromDocument(doc);
+    if (theme) return theme;
   }
 
-  const preferredTheme = globalThis.matchMedia?.("(prefers-color-scheme: light)").matches ? "light" : "dark";
-  return themeState(preferredTheme);
+  return globalThis.matchMedia?.("(prefers-color-scheme: light)").matches ? "light" : "dark";
 }
 
 function applyHostTheme(el) {
-  const state = detectHostTheme(el.ownerDocument || document);
   const root = el.querySelector(".hypster-widget");
-  if (root) {
-    root.classList.toggle("hypster-theme-light", state.theme === "light");
-    root.classList.toggle("hypster-theme-dark", state.theme === "dark");
-    root.dataset.hypsterTheme = state.theme;
-    root.style.setProperty("--hypster-background", state.background);
-  }
-  paintOutputSurface(el, state);
-}
+  if (!root) return;
 
-function outputSurfaceElements(el) {
-  const elements = [el];
-  const ownerDocument = el.ownerDocument || document;
-  let current = el.parentElement;
-
-  for (
-    let depth = 0;
-    current && current !== ownerDocument.body && current !== ownerDocument.documentElement && depth < 12;
-    depth += 1
-  ) {
-    elements.push(current);
-    current = current.parentElement;
-  }
-
-  const rootNode = el.getRootNode?.();
-  if (rootNode?.host instanceof HTMLElement) {
-    let host = rootNode.host;
-    for (
-      let depth = 0;
-      host && host !== ownerDocument.body && host !== ownerDocument.documentElement && depth < 8;
-      depth += 1
-    ) {
-      elements.push(host);
-      host = host.parentElement;
-    }
-  }
-
-  if (ownerDocument.body) elements.push(ownerDocument.body);
-  if (ownerDocument.documentElement) elements.push(ownerDocument.documentElement);
-
-  return elements;
-}
-
-function rememberStyle(el, element, property) {
-  if (!el.__hypsterStyleRecords) el.__hypsterStyleRecords = new Map();
-  let record = el.__hypsterStyleRecords.get(element);
-  if (!record) {
-    record = new Map();
-    el.__hypsterStyleRecords.set(element, record);
-  }
-  if (!record.has(property)) {
-    record.set(property, {
-      priority: element.style.getPropertyPriority(property),
-      value: element.style.getPropertyValue(property),
-    });
-  }
-}
-
-function setTrackedStyle(el, element, property, value, priority = "") {
-  rememberStyle(el, element, property);
-  element.style.setProperty(property, value, priority);
-}
-
-function paintOutputSurface(el, state) {
-  for (const element of outputSurfaceElements(el)) {
-    if (!element?.style) continue;
-    setTrackedStyle(el, element, "background-color", state.background, "important");
-    setTrackedStyle(el, element, "color-scheme", state.theme);
-  }
-
-  setTrackedStyle(el, el, "display", "block");
-  setTrackedStyle(el, el, "width", "100%");
-}
-
-function restoreOutputSurface(el) {
-  for (const [element, record] of el.__hypsterStyleRecords || new Map()) {
-    for (const [property, previous] of record) {
-      element.style.setProperty(property, previous.value, previous.priority);
-    }
-  }
-  delete el.__hypsterStyleRecords;
+  const theme = detectHostTheme(el.ownerDocument || document);
+  root.classList.toggle("hypster-theme-light", theme === "light");
+  root.classList.toggle("hypster-theme-dark", theme === "dark");
+  root.dataset.hypsterTheme = theme;
 }
 
 function watchHostTheme(el) {
   const apply = () => applyHostTheme(el);
   const observers = [];
-  const watchedAttributes = ["class", "data-vscode-theme-kind", "data-jp-theme-light", "data-theme", "data-mode", "style"];
+  const watchedAttributes = ["class", "data-vscode-theme-kind", "data-jp-theme-light", "data-theme", "data-mode"];
 
   for (const doc of themeDocuments(el.ownerDocument || document)) {
     try {
@@ -472,9 +327,8 @@ function render(model, el) {
 
   const root = document.createElement("div");
   const theme = detectHostTheme(el.ownerDocument || document);
-  root.className = `hypster-widget hypster-theme-${theme.theme}`;
-  root.dataset.hypsterTheme = theme.theme;
-  root.style.setProperty("--hypster-background", theme.background);
+  root.className = `hypster-widget hypster-theme-${theme}`;
+  root.dataset.hypsterTheme = theme;
 
   const header = document.createElement("div");
   header.className = "hypster-header";
@@ -510,7 +364,6 @@ function render(model, el) {
 
   root.append(actions);
   el.append(root);
-  paintOutputSurface(el, theme);
 }
 
 export default {
@@ -567,7 +420,6 @@ export default {
 
     return () => {
       cleanupTheme();
-      restoreOutputSurface(el);
       model.off?.("change:snapshot", rerender);
     };
   },

--- a/src/hypster/interactive/interact.js
+++ b/src/hypster/interactive/interact.js
@@ -80,6 +80,140 @@ function closeChoiceMenus(root) {
   }
 }
 
+function themeDocuments(baseDocument) {
+  const documents = [];
+  try {
+    const parentDocument = globalThis.parent?.document;
+    if (parentDocument) documents.push(parentDocument);
+  } catch {
+    // Cross-origin notebook hosts can block parent access.
+  }
+  if (baseDocument && !documents.includes(baseDocument)) documents.push(baseDocument);
+  return documents;
+}
+
+function themeFromColor(value) {
+  const raw = String(value || "").trim();
+  if (!raw || raw === "transparent" || raw === "rgba(0, 0, 0, 0)") return null;
+
+  const rgb = raw.match(/rgba?\(([^)]+)\)/i);
+  if (rgb) {
+    const parts = rgb[1].split(/,\s*|\s+/).filter(Boolean).map(Number);
+    if (parts.length >= 3 && parts.slice(0, 3).every(Number.isFinite)) {
+      if (parts.length >= 4 && parts[3] === 0) return null;
+      const luminance = 0.299 * parts[0] + 0.587 * parts[1] + 0.114 * parts[2];
+      return luminance > 150 ? "light" : "dark";
+    }
+  }
+
+  const hex = raw.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (hex) {
+    const digits =
+      hex[1].length === 3
+        ? hex[1].split("").map((digit) => digit + digit).join("")
+        : hex[1];
+    const red = Number.parseInt(digits.slice(0, 2), 16);
+    const green = Number.parseInt(digits.slice(2, 4), 16);
+    const blue = Number.parseInt(digits.slice(4, 6), 16);
+    const luminance = 0.299 * red + 0.587 * green + 0.114 * blue;
+    return luminance > 150 ? "light" : "dark";
+  }
+
+  return null;
+}
+
+function themeFromDocument(doc) {
+  const body = doc.body;
+  const html = doc.documentElement;
+  if (!body || !html) return null;
+
+  const vscodeThemeKind = body.getAttribute("data-vscode-theme-kind") || html.getAttribute("data-vscode-theme-kind");
+  if (vscodeThemeKind) return vscodeThemeKind.includes("light") ? "light" : "dark";
+
+  const classNames = `${body.className || ""} ${html.className || ""}`.toLowerCase();
+  if (classNames.includes("vscode-high-contrast-light") || classNames.includes("vscode-light")) return "light";
+  if (classNames.includes("vscode-high-contrast") || classNames.includes("vscode-dark")) return "dark";
+
+  const jupyterThemeLight = body.dataset.jpThemeLight ?? html.dataset.jpThemeLight;
+  if (jupyterThemeLight === "true") return "light";
+  if (jupyterThemeLight === "false") return "dark";
+  if (classNames.includes("jp-mod-light")) return "light";
+  if (classNames.includes("jp-mod-dark")) return "dark";
+
+  const dataTheme = body.dataset.theme || html.dataset.theme || body.dataset.mode || html.dataset.mode;
+  if (dataTheme === "light" || dataTheme === "dark") return dataTheme;
+
+  const view = doc.defaultView || globalThis;
+  const rootStyle = view.getComputedStyle?.(html);
+  const bodyStyle = view.getComputedStyle?.(body);
+  const colorScheme = rootStyle?.getPropertyValue("color-scheme").trim();
+  const colorSchemes = colorScheme?.split(/\s+/) || [];
+  if (colorSchemes.includes("dark") && !colorSchemes.includes("light")) return "dark";
+  if (colorSchemes.includes("light") && !colorSchemes.includes("dark")) return "light";
+
+  const backgroundCandidates = [
+    rootStyle?.getPropertyValue("--vscode-editor-background"),
+    rootStyle?.getPropertyValue("--jp-layout-color0"),
+    rootStyle?.getPropertyValue("--jp-layout-color1"),
+    bodyStyle?.backgroundColor,
+    rootStyle?.backgroundColor,
+  ];
+  for (const candidate of backgroundCandidates) {
+    const theme = themeFromColor(candidate);
+    if (theme) return theme;
+  }
+
+  return null;
+}
+
+function detectHostTheme(baseDocument) {
+  for (const doc of themeDocuments(baseDocument)) {
+    const theme = themeFromDocument(doc);
+    if (theme) return theme;
+  }
+
+  if (globalThis.matchMedia?.("(prefers-color-scheme: light)").matches) return "light";
+  return "dark";
+}
+
+function applyHostTheme(el) {
+  const root = el.querySelector(".hypster-widget");
+  if (!root) return;
+
+  const theme = detectHostTheme(el.ownerDocument || document);
+  root.classList.toggle("hypster-theme-light", theme === "light");
+  root.classList.toggle("hypster-theme-dark", theme === "dark");
+  root.dataset.hypsterTheme = theme;
+}
+
+function watchHostTheme(el) {
+  const apply = () => applyHostTheme(el);
+  const observers = [];
+  const watchedAttributes = ["class", "data-vscode-theme-kind", "data-jp-theme-light", "data-theme", "data-mode", "style"];
+
+  for (const doc of themeDocuments(el.ownerDocument || document)) {
+    try {
+      const Observer = doc.defaultView?.MutationObserver || globalThis.MutationObserver;
+      if (!Observer) continue;
+      const observer = new Observer(apply);
+      observer.observe(doc.body, { attributes: true, attributeFilter: watchedAttributes });
+      observer.observe(doc.documentElement, { attributes: true, attributeFilter: watchedAttributes });
+      observers.push(observer);
+    } catch {
+      // Some hosts expose a partial or inaccessible parent document.
+    }
+  }
+
+  const mediaQuery = globalThis.matchMedia?.("(prefers-color-scheme: dark)");
+  mediaQuery?.addEventListener?.("change", apply);
+  apply();
+
+  return () => {
+    for (const observer of observers) observer.disconnect();
+    mediaQuery?.removeEventListener?.("change", apply);
+  };
+}
+
 function renderParameter(model, snapshot, parameter) {
   if (parameter.kind === "group") {
     const group = document.createElement("fieldset");
@@ -237,7 +371,9 @@ function render(model, el) {
   el.replaceChildren();
 
   const root = document.createElement("div");
-  root.className = "hypster-widget";
+  const theme = detectHostTheme(el.ownerDocument || document);
+  root.className = `hypster-widget hypster-theme-${theme}`;
+  root.dataset.hypsterTheme = theme;
 
   const header = document.createElement("div");
   header.className = "hypster-header";
@@ -322,7 +458,14 @@ export default {
       });
     });
 
-    model.on("change:snapshot", () => render(model, el));
+    const rerender = () => render(model, el);
+    model.on("change:snapshot", rerender);
     render(model, el);
+    const cleanupTheme = watchHostTheme(el);
+
+    return () => {
+      cleanupTheme();
+      model.off?.("change:snapshot", rerender);
+    };
   },
 };

--- a/src/hypster/interactive/interact.js
+++ b/src/hypster/interactive/interact.js
@@ -222,10 +222,11 @@ function renderChoiceControl(parameter, currentValue) {
 function renderStatus(snapshot) {
   const status = document.createElement("div");
   status.className = `hypster-status hypster-status-${snapshot.status}`;
-  status.textContent = snapshot.status === "pending" ? "Pending changes" : "Up to date";
+  status.textContent = snapshot.status === "pending" ? "Pending changes" : "Applied";
 
   if (snapshot.error) {
-    status.textContent = snapshot.error.message;
+    status.textContent = `Error: ${snapshot.error.message}`;
+    status.title = snapshot.error.message;
   }
 
   return status;
@@ -238,11 +239,15 @@ function render(model, el) {
   const root = document.createElement("div");
   root.className = "hypster-widget";
 
+  const header = document.createElement("div");
+  header.className = "hypster-header";
+
   const title = document.createElement("div");
   title.className = "hypster-title";
-  title.textContent = snapshot.schema?.name || "Hypster";
-  root.append(title);
-  root.append(renderStatus(snapshot));
+  title.textContent = snapshot.schema?.display_label || snapshot.schema?.name || "Hypster";
+  header.append(title);
+  header.append(renderStatus(snapshot));
+  root.append(header);
 
   for (const parameter of snapshot.schema?.parameters || []) {
     root.append(renderParameter(model, snapshot, parameter));

--- a/src/hypster/interactive/interact.js
+++ b/src/hypster/interactive/interact.js
@@ -98,11 +98,11 @@ function themeFromColor(value) {
 
   const rgb = raw.match(/rgba?\(([^)]+)\)/i);
   if (rgb) {
-    const parts = rgb[1].split(/,\s*|\s+/).filter(Boolean).map(Number);
+    const parts = (rgb[1].match(/[\d.]+/g) || []).map(Number);
     if (parts.length >= 3 && parts.slice(0, 3).every(Number.isFinite)) {
-      if (parts.length >= 4 && parts[3] === 0) return null;
+      if (parts.length >= 4 && parts[3] < 0.1) return null;
       const luminance = 0.299 * parts[0] + 0.587 * parts[1] + 0.114 * parts[2];
-      return luminance > 150 ? "light" : "dark";
+      return { background: raw, luminance, theme: luminance > 150 ? "light" : "dark" };
     }
   }
 
@@ -116,10 +116,32 @@ function themeFromColor(value) {
     const green = Number.parseInt(digits.slice(2, 4), 16);
     const blue = Number.parseInt(digits.slice(4, 6), 16);
     const luminance = 0.299 * red + 0.587 * green + 0.114 * blue;
-    return luminance > 150 ? "light" : "dark";
+    return { background: raw, luminance, theme: luminance > 150 ? "light" : "dark" };
   }
 
   return null;
+}
+
+function fallbackBackground(theme) {
+  return theme === "light" ? "#ffffff" : "#111111";
+}
+
+function themeState(theme, parsedColor = null) {
+  const safeTheme = theme === "light" ? "light" : "dark";
+  let background = parsedColor?.background || fallbackBackground(safeTheme);
+
+  if (typeof parsedColor?.luminance === "number") {
+    const backgroundLooksLight = parsedColor.luminance > 150;
+    if ((safeTheme === "dark" && backgroundLooksLight) || (safeTheme === "light" && !backgroundLooksLight)) {
+      background = fallbackBackground(safeTheme);
+    }
+  }
+
+  return {
+    background,
+    luminance: parsedColor?.luminance ?? null,
+    theme: safeTheme,
+  };
 }
 
 function themeFromDocument(doc) {
@@ -127,30 +149,9 @@ function themeFromDocument(doc) {
   const html = doc.documentElement;
   if (!body || !html) return null;
 
-  const vscodeThemeKind = body.getAttribute("data-vscode-theme-kind") || html.getAttribute("data-vscode-theme-kind");
-  if (vscodeThemeKind) return vscodeThemeKind.includes("light") ? "light" : "dark";
-
-  const classNames = `${body.className || ""} ${html.className || ""}`.toLowerCase();
-  if (classNames.includes("vscode-high-contrast-light") || classNames.includes("vscode-light")) return "light";
-  if (classNames.includes("vscode-high-contrast") || classNames.includes("vscode-dark")) return "dark";
-
-  const jupyterThemeLight = body.dataset.jpThemeLight ?? html.dataset.jpThemeLight;
-  if (jupyterThemeLight === "true") return "light";
-  if (jupyterThemeLight === "false") return "dark";
-  if (classNames.includes("jp-mod-light")) return "light";
-  if (classNames.includes("jp-mod-dark")) return "dark";
-
-  const dataTheme = body.dataset.theme || html.dataset.theme || body.dataset.mode || html.dataset.mode;
-  if (dataTheme === "light" || dataTheme === "dark") return dataTheme;
-
   const view = doc.defaultView || globalThis;
   const rootStyle = view.getComputedStyle?.(html);
   const bodyStyle = view.getComputedStyle?.(body);
-  const colorScheme = rootStyle?.getPropertyValue("color-scheme").trim();
-  const colorSchemes = colorScheme?.split(/\s+/) || [];
-  if (colorSchemes.includes("dark") && !colorSchemes.includes("light")) return "dark";
-  if (colorSchemes.includes("light") && !colorSchemes.includes("dark")) return "light";
-
   const backgroundCandidates = [
     rootStyle?.getPropertyValue("--vscode-editor-background"),
     rootStyle?.getPropertyValue("--jp-layout-color0"),
@@ -158,32 +159,113 @@ function themeFromDocument(doc) {
     bodyStyle?.backgroundColor,
     rootStyle?.backgroundColor,
   ];
-  for (const candidate of backgroundCandidates) {
-    const theme = themeFromColor(candidate);
-    if (theme) return theme;
+  const parsedBackground = backgroundCandidates.map(themeFromColor).find(Boolean);
+
+  const vscodeThemeKind = body.getAttribute("data-vscode-theme-kind") || html.getAttribute("data-vscode-theme-kind");
+  if (vscodeThemeKind) return themeState(vscodeThemeKind.includes("light") ? "light" : "dark", parsedBackground);
+
+  const classNames = `${body.className || ""} ${html.className || ""}`.toLowerCase();
+  if (classNames.includes("vscode-high-contrast-light") || classNames.includes("vscode-light")) {
+    return themeState("light", parsedBackground);
   }
+  if (classNames.includes("vscode-high-contrast") || classNames.includes("vscode-dark")) {
+    return themeState("dark", parsedBackground);
+  }
+
+  const jupyterThemeLight = body.dataset.jpThemeLight ?? html.dataset.jpThemeLight;
+  if (jupyterThemeLight === "true") return themeState("light", parsedBackground);
+  if (jupyterThemeLight === "false") return themeState("dark", parsedBackground);
+  if (classNames.includes("jp-mod-light")) return themeState("light", parsedBackground);
+  if (classNames.includes("jp-mod-dark")) return themeState("dark", parsedBackground);
+
+  const dataTheme = body.dataset.theme || html.dataset.theme || body.dataset.mode || html.dataset.mode;
+  if (dataTheme === "light" || dataTheme === "dark") return themeState(dataTheme, parsedBackground);
+
+  const colorScheme = rootStyle?.getPropertyValue("color-scheme").trim();
+  const colorSchemes = colorScheme?.split(/\s+/) || [];
+  if (colorSchemes.includes("dark") && !colorSchemes.includes("light")) return themeState("dark", parsedBackground);
+  if (colorSchemes.includes("light") && !colorSchemes.includes("dark")) return themeState("light", parsedBackground);
+
+  if (parsedBackground) return themeState(parsedBackground.theme, parsedBackground);
 
   return null;
 }
 
 function detectHostTheme(baseDocument) {
   for (const doc of themeDocuments(baseDocument)) {
-    const theme = themeFromDocument(doc);
-    if (theme) return theme;
+    const state = themeFromDocument(doc);
+    if (state) return state;
   }
 
-  if (globalThis.matchMedia?.("(prefers-color-scheme: light)").matches) return "light";
-  return "dark";
+  const preferredTheme = globalThis.matchMedia?.("(prefers-color-scheme: light)").matches ? "light" : "dark";
+  return themeState(preferredTheme);
 }
 
 function applyHostTheme(el) {
+  const state = detectHostTheme(el.ownerDocument || document);
   const root = el.querySelector(".hypster-widget");
-  if (!root) return;
+  if (root) {
+    root.classList.toggle("hypster-theme-light", state.theme === "light");
+    root.classList.toggle("hypster-theme-dark", state.theme === "dark");
+    root.dataset.hypsterTheme = state.theme;
+    root.style.setProperty("--hypster-background", state.background);
+  }
+  paintOutputSurface(el, state);
+}
 
-  const theme = detectHostTheme(el.ownerDocument || document);
-  root.classList.toggle("hypster-theme-light", theme === "light");
-  root.classList.toggle("hypster-theme-dark", theme === "dark");
-  root.dataset.hypsterTheme = theme;
+function outputSurfaceElements(el) {
+  const elements = [el];
+  let current = el.parentElement;
+
+  for (let depth = 0; current && current !== document.body && current !== document.documentElement && depth < 6; depth += 1) {
+    elements.push(current);
+    const className = String(current.className || "");
+    if (/cell-output|outputarea|output-area|jp-outputarea|widget-subarea|widget-area|vscode-cell-output/i.test(className)) {
+      break;
+    }
+    current = current.parentElement;
+  }
+
+  return elements;
+}
+
+function rememberStyle(el, element, property) {
+  if (!el.__hypsterStyleRecords) el.__hypsterStyleRecords = new Map();
+  let record = el.__hypsterStyleRecords.get(element);
+  if (!record) {
+    record = new Map();
+    el.__hypsterStyleRecords.set(element, record);
+  }
+  if (!record.has(property)) {
+    record.set(property, {
+      priority: element.style.getPropertyPriority(property),
+      value: element.style.getPropertyValue(property),
+    });
+  }
+}
+
+function setTrackedStyle(el, element, property, value, priority = "") {
+  rememberStyle(el, element, property);
+  element.style.setProperty(property, value, priority);
+}
+
+function paintOutputSurface(el, state) {
+  for (const element of outputSurfaceElements(el)) {
+    setTrackedStyle(el, element, "background-color", state.background, "important");
+    setTrackedStyle(el, element, "color-scheme", state.theme);
+  }
+
+  setTrackedStyle(el, el, "display", "block");
+  setTrackedStyle(el, el, "width", "100%");
+}
+
+function restoreOutputSurface(el) {
+  for (const [element, record] of el.__hypsterStyleRecords || new Map()) {
+    for (const [property, previous] of record) {
+      element.style.setProperty(property, previous.value, previous.priority);
+    }
+  }
+  delete el.__hypsterStyleRecords;
 }
 
 function watchHostTheme(el) {
@@ -372,8 +454,9 @@ function render(model, el) {
 
   const root = document.createElement("div");
   const theme = detectHostTheme(el.ownerDocument || document);
-  root.className = `hypster-widget hypster-theme-${theme}`;
-  root.dataset.hypsterTheme = theme;
+  root.className = `hypster-widget hypster-theme-${theme.theme}`;
+  root.dataset.hypsterTheme = theme.theme;
+  root.style.setProperty("--hypster-background", theme.background);
 
   const header = document.createElement("div");
   header.className = "hypster-header";
@@ -409,6 +492,7 @@ function render(model, el) {
 
   root.append(actions);
   el.append(root);
+  paintOutputSurface(el, theme);
 }
 
 export default {
@@ -465,6 +549,7 @@ export default {
 
     return () => {
       cleanupTheme();
+      restoreOutputSurface(el);
       model.off?.("change:snapshot", rerender);
     };
   },

--- a/src/hypster/interactive/interact.js
+++ b/src/hypster/interactive/interact.js
@@ -1,6 +1,46 @@
+function hasOwn(object, key) {
+  return Object.prototype.hasOwnProperty.call(object || {}, key);
+}
+
+function valuesEqual(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function optionValue(option) {
+  if (option.dataset.value == null) return option.value;
+  return JSON.parse(option.dataset.value);
+}
+
+function valueFor(snapshot, parameter) {
+  if (hasOwn(snapshot.draft_values, parameter.path)) {
+    return snapshot.draft_values[parameter.path];
+  }
+  return parameter.selected_value;
+}
+
+function encodedControlValue(input) {
+  const kind = input.dataset.kind;
+  if (
+    kind === "int" ||
+    kind === "float" ||
+    ["multi_int", "multi_float", "multi_text", "multi_bool"].includes(kind)
+  ) {
+    return { encoded_value: { kind, value: input.value } };
+  }
+  return { value: controlValue(input) };
+}
+
+function actionId() {
+  return globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
 function controlValue(input) {
   if (input instanceof HTMLSelectElement && input.multiple) {
-    return Array.from(input.selectedOptions, (option) => option.value);
+    return Array.from(input.selectedOptions, optionValue);
+  }
+  if (input instanceof HTMLSelectElement) {
+    const option = input.selectedOptions[0];
+    return option ? optionValue(option) : null;
   }
   if (input.type === "checkbox") {
     return input.checked;
@@ -15,7 +55,7 @@ function controlValue(input) {
 }
 
 function send(model, action) {
-  model.set("action", { id: crypto.randomUUID(), ...action });
+  model.set("action", { id: actionId(), ...action });
   model.save_changes();
 }
 
@@ -23,7 +63,7 @@ function labelFor(parameter) {
   return parameter.display_label || parameter.name;
 }
 
-function renderParameter(model, parameter) {
+function renderParameter(model, snapshot, parameter) {
   if (parameter.kind === "group") {
     const group = document.createElement("fieldset");
     group.className = "hypster-group";
@@ -40,7 +80,7 @@ function renderParameter(model, parameter) {
     }
 
     for (const child of parameter.children || []) {
-      group.append(renderParameter(model, child));
+      group.append(renderParameter(model, snapshot, child));
     }
     return group;
   }
@@ -60,11 +100,13 @@ function renderParameter(model, parameter) {
     field.append(description);
   }
 
-  field.append(renderControl(model, parameter));
+  field.append(renderControl(snapshot, parameter));
   return field;
 }
 
-function renderControl(model, parameter) {
+function renderControl(snapshot, parameter) {
+  const currentValue = valueFor(snapshot, parameter);
+
   if (parameter.kind === "select" || parameter.kind === "multi_select") {
     const select = document.createElement("select");
     select.dataset.path = parameter.path;
@@ -72,11 +114,12 @@ function renderControl(model, parameter) {
     select.multiple = parameter.kind === "multi_select";
     for (const optionValue of parameter.options || []) {
       const option = document.createElement("option");
-      option.value = optionValue;
+      option.value = String(select.options.length);
+      option.dataset.value = JSON.stringify(optionValue);
       option.textContent = String(optionValue);
-      option.selected = Array.isArray(parameter.selected_value)
-        ? parameter.selected_value.includes(optionValue)
-        : optionValue === parameter.selected_value;
+      option.selected = Array.isArray(currentValue)
+        ? currentValue.some((selectedValue) => valuesEqual(selectedValue, optionValue))
+        : valuesEqual(optionValue, currentValue);
       select.append(option);
     }
     return select;
@@ -85,7 +128,7 @@ function renderControl(model, parameter) {
   if (parameter.kind === "bool") {
     const checkbox = document.createElement("input");
     checkbox.type = "checkbox";
-    checkbox.checked = Boolean(parameter.selected_value);
+    checkbox.checked = Boolean(currentValue);
     checkbox.dataset.path = parameter.path;
     checkbox.dataset.kind = parameter.kind;
     return checkbox;
@@ -94,7 +137,7 @@ function renderControl(model, parameter) {
   const input = document.createElement("input");
   input.dataset.path = parameter.path;
   input.dataset.kind = parameter.kind;
-  input.value = parameter.selected_value ?? "";
+  input.value = parameter.kind.startsWith("multi_") ? JSON.stringify(currentValue ?? []) : (currentValue ?? "");
 
   if (parameter.kind === "int" || parameter.kind === "float") {
     input.type = "number";
@@ -134,7 +177,7 @@ function render(model, el) {
   root.append(renderStatus(snapshot));
 
   for (const parameter of snapshot.schema?.parameters || []) {
-    root.append(renderParameter(model, parameter));
+    root.append(renderParameter(model, snapshot, parameter));
   }
 
   const actions = document.createElement("div");
@@ -169,7 +212,7 @@ export default {
       send(model, {
         type: "set_value",
         path: target.dataset.path,
-        value: controlValue(target),
+        ...encodedControlValue(target),
       });
     });
 

--- a/src/hypster/interactive/session.py
+++ b/src/hypster/interactive/session.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Generic, Mapping, Optional, Tuple, TypeVar
+
+from hypster.core import ConfigFunc, UnknownPolicy, instantiate_with_params
+from hypster.explore import ConfigSchema, ParameterInfo, explore
+from hypster.utils import normalize_values
+
+from .branch_memory import BranchChoiceMemory
+
+T = TypeVar("T")
+
+
+def _parameters(schema: ConfigSchema) -> list[ParameterInfo]:
+    parameters: list[ParameterInfo] = []
+    for parameter in schema.parameters:
+        parameters.extend(_flatten_parameter(parameter))
+    return parameters
+
+
+def _flatten_parameter(parameter: ParameterInfo) -> list[ParameterInfo]:
+    if not parameter.is_group():
+        return [parameter]
+
+    parameters: list[ParameterInfo] = []
+    for child in parameter.children:
+        parameters.extend(_flatten_parameter(child))
+    return parameters
+
+
+@dataclass
+class InteractiveError:
+    kind: str
+    message: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {"kind": self.kind, "message": self.message}
+
+
+@dataclass
+class InteractiveSession(Generic[T]):
+    func: ConfigFunc[T]
+    values: Optional[Mapping[str, Any]] = None
+    args: Tuple[Any, ...] = ()
+    kwargs: Optional[Dict[str, Any]] = None
+    on_unknown: UnknownPolicy = "raise"
+    auto_apply: bool = True
+
+    def __post_init__(self) -> None:
+        self._kwargs = dict(self.kwargs or {})
+        self._draft_values: Dict[str, Any] = {}
+        self._applied_values: Dict[str, Any] = {}
+        self._params: Dict[str, Any] = {}
+        self._schema: ConfigSchema | None = None
+        self._baseline_values: Dict[str, Any] = {}
+        self._value: T
+        self._draft_error: InteractiveError | None = None
+        self._applied_error: InteractiveError | None = None
+        self._memory = BranchChoiceMemory()
+        self._initialize(normalize_values(dict(self.values or {})))
+
+    @property
+    def value(self) -> T:
+        if self._applied_error is not None:
+            raise RuntimeError(self._applied_error.message)
+        return self._value
+
+    @property
+    def params(self) -> Dict[str, Any]:
+        if self._applied_error is not None:
+            raise RuntimeError(self._applied_error.message)
+        return dict(self._params)
+
+    @property
+    def snapshot(self) -> Dict[str, Any]:
+        return {
+            "schema": self._schema.to_dict() if self._schema is not None else None,
+            "draft_values": dict(self._draft_values),
+            "applied_values": dict(self._applied_values),
+            "selected_params": dict(self._params),
+            "mode": {"auto_apply": self.auto_apply},
+            "status": self._status(),
+            "error": self._snapshot_error(),
+        }
+
+    def dispatch(self, action: Mapping[str, Any]) -> Dict[str, Any]:
+        action_type = action.get("type")
+        if action_type == "set_value":
+            self._set_value(str(action["path"]), action.get("value"))
+            return self.snapshot
+        if action_type == "reset":
+            self._reset()
+            return self.snapshot
+        if action_type == "apply":
+            self._apply_current_draft()
+            return self.snapshot
+        raise ValueError(f"Unknown interactive action type: {action_type!r}")
+
+    def _status(self) -> str:
+        if self._applied_error is not None:
+            return "error"
+        if self._draft_error is not None:
+            return "draft_error"
+        if not self.auto_apply and self._draft_values != self._applied_values:
+            return "pending"
+        return "applied"
+
+    def _snapshot_error(self) -> Dict[str, str] | None:
+        error = self._applied_error or self._draft_error
+        return error.to_dict() if error is not None else None
+
+    def _initialize(self, values: Dict[str, Any]) -> None:
+        schema, selected_values = self._build_values(values)
+        self._baseline_values = dict(selected_values)
+        self._memory.remember_many(selected_values)
+        self._apply(schema, selected_values)
+
+    def _set_value(self, path: str, value: Any) -> None:
+        if self._schema is None:
+            raise RuntimeError("Interactive session has not been initialized")
+
+        current_parameters = _parameters(self._schema)
+        current_paths = [parameter.path for parameter in current_parameters]
+        if path not in current_paths:
+            raise ValueError(f"Cannot set unreachable parameter: {path}")
+
+        self._memory.remember_many(self._draft_values)
+        self._memory.remember(path, value)
+
+        prefix_values: Dict[str, Any] = {}
+        for parameter in current_parameters:
+            if parameter.path == path:
+                prefix_values[path] = value
+                break
+            if parameter.path in self._draft_values:
+                prefix_values[parameter.path] = self._draft_values[parameter.path]
+
+        try:
+            schema, selected_values = self._build_values(prefix_values)
+        except Exception as exc:
+            self._draft_values = dict(prefix_values)
+            self._draft_error = InteractiveError(kind="exploration", message=str(exc))
+            if self.auto_apply:
+                self._applied_error = self._draft_error
+            return
+
+        self._draft_error = None
+        if self.auto_apply:
+            try:
+                self._apply(schema, selected_values)
+            except Exception as exc:
+                self._schema = schema
+                self._draft_values = dict(selected_values)
+                self._applied_values = dict(selected_values)
+                self._applied_error = InteractiveError(kind="instantiation", message=str(exc))
+            return
+
+        self._schema = schema
+        self._draft_values = dict(selected_values)
+
+    def _reset(self) -> None:
+        self._memory = BranchChoiceMemory()
+        schema, selected_values = self._build_values(dict(self._baseline_values))
+        self._memory.remember_many(selected_values)
+        self._draft_error = None
+        self._applied_error = None
+        self._apply(schema, selected_values)
+
+    def _apply_current_draft(self) -> None:
+        if self._schema is None:
+            raise RuntimeError("Interactive session has not been initialized")
+        if self._draft_error is not None:
+            return
+        try:
+            self._apply(self._schema, self._draft_values)
+        except Exception as exc:
+            self._applied_error = InteractiveError(kind="instantiation", message=str(exc))
+
+    def _build_values(self, seed_values: Dict[str, Any]) -> tuple[ConfigSchema, Dict[str, Any]]:
+        values = dict(seed_values)
+        while True:
+            schema = self._explore(values)
+            missing = next((parameter for parameter in _parameters(schema) if parameter.path not in values), None)
+            if missing is None:
+                return schema, values
+
+            found, value = self._memory.latest_compatible(missing)
+            values[missing.path] = value if found else missing.selected_value
+
+    def _explore(self, values: Dict[str, Any]) -> ConfigSchema:
+        schema = explore(
+            self.func,
+            values=values,
+            args=self.args,
+            kwargs=self._kwargs,
+            on_unknown=self.on_unknown,
+            return_info=True,
+        )
+        if schema is None:
+            raise RuntimeError("explore(..., return_info=True) did not return a schema")
+        return schema
+
+    def _apply(self, schema: ConfigSchema, selected_values: Dict[str, Any]) -> None:
+        output = instantiate_with_params(
+            self.func,
+            values=selected_values,
+            args=self.args,
+            kwargs=self._kwargs,
+            on_unknown=self.on_unknown,
+        )
+
+        self._schema = schema
+        self._draft_values = dict(selected_values)
+        self._applied_values = dict(selected_values)
+        self._value = output.value
+        self._params = dict(output.params)
+        self._draft_error = None
+        self._applied_error = None
+
+
+class InteractiveResult(Generic[T]):
+    def __init__(self, session: InteractiveSession[T]):
+        self._session = session
+        self._views: list[Any] = []
+
+    @property
+    def value(self) -> T:
+        return self._session.value
+
+    @property
+    def params(self) -> Dict[str, Any]:
+        return self._session.params
+
+    @property
+    def snapshot(self) -> Dict[str, Any]:
+        return self._session.snapshot
+
+    def dispatch(self, action: Mapping[str, Any]) -> Dict[str, Any]:
+        snapshot = self._session.dispatch(action)
+        self._sync_views(snapshot)
+        return snapshot
+
+    def interact(self) -> Any:
+        from .widget import HypsterInteractWidget
+
+        widget = HypsterInteractWidget(self)
+        self._views.append(widget)
+        return widget
+
+    def _sync_views(self, snapshot: Dict[str, Any]) -> None:
+        for view in self._views:
+            view.snapshot = snapshot
+
+    def _ipython_display_(self) -> None:
+        from IPython.display import display
+
+        display(self.interact())
+
+
+def interact(
+    func: ConfigFunc[T],
+    *,
+    values: Optional[Mapping[str, Any]] = None,
+    args: Tuple[Any, ...] = (),
+    kwargs: Optional[Dict[str, Any]] = None,
+    on_unknown: UnknownPolicy = "raise",
+    auto_apply: bool = True,
+) -> InteractiveResult[T]:
+    session: InteractiveSession[T] = InteractiveSession(
+        func=func,
+        values=values,
+        args=args,
+        kwargs=kwargs,
+        on_unknown=on_unknown,
+        auto_apply=auto_apply,
+    )
+    return InteractiveResult(session)

--- a/src/hypster/interactive/session.py
+++ b/src/hypster/interactive/session.py
@@ -78,7 +78,7 @@ class InteractiveSession(Generic[T]):
             "schema": self._schema.to_dict() if self._schema is not None else None,
             "draft_values": dict(self._draft_values),
             "applied_values": dict(self._applied_values),
-            "selected_params": dict(self._params),
+            "selected_params": None if self._applied_error is not None else dict(self._params),
             "mode": {"auto_apply": self.auto_apply},
             "status": self._status(),
             "error": self._snapshot_error(),
@@ -139,12 +139,13 @@ class InteractiveSession(Generic[T]):
         try:
             schema, selected_values = self._build_values(prefix_values)
         except Exception as exc:
-            self._draft_values = dict(prefix_values)
+            self._draft_values = {**self._draft_values, **prefix_values}
             self._draft_error = InteractiveError(kind="exploration", message=str(exc))
             if self.auto_apply:
                 self._applied_error = self._draft_error
             return
 
+        self._memory.remember_many(selected_values)
         self._draft_error = None
         if self.auto_apply:
             try:
@@ -161,11 +162,26 @@ class InteractiveSession(Generic[T]):
 
     def _reset(self) -> None:
         self._memory = BranchChoiceMemory()
-        schema, selected_values = self._build_values(dict(self._baseline_values))
+        try:
+            schema, selected_values = self._build_values(dict(self._baseline_values))
+        except Exception as exc:
+            baseline_values = dict(self._baseline_values)
+            self._draft_values = baseline_values
+            self._applied_values = baseline_values
+            self._draft_error = InteractiveError(kind="exploration", message=str(exc))
+            self._applied_error = self._draft_error
+            return
+
         self._memory.remember_many(selected_values)
         self._draft_error = None
         self._applied_error = None
-        self._apply(schema, selected_values)
+        try:
+            self._apply(schema, selected_values)
+        except Exception as exc:
+            self._schema = schema
+            self._draft_values = dict(selected_values)
+            self._applied_values = dict(selected_values)
+            self._applied_error = InteractiveError(kind="instantiation", message=str(exc))
 
     def _apply_current_draft(self) -> None:
         if self._schema is None:

--- a/src/hypster/interactive/session.py
+++ b/src/hypster/interactive/session.py
@@ -29,6 +29,16 @@ def _flatten_parameter(parameter: ParameterInfo) -> list[ParameterInfo]:
     return parameters
 
 
+def _context_for(parameters: list[ParameterInfo], values: Mapping[str, Any], path: str) -> Dict[str, Any]:
+    context: Dict[str, Any] = {}
+    for parameter in parameters:
+        if parameter.path == path:
+            return context
+        if parameter.path in values:
+            context[parameter.path] = values[parameter.path]
+    return context
+
+
 @dataclass
 class InteractiveError:
     kind: str
@@ -113,7 +123,7 @@ class InteractiveSession(Generic[T]):
     def _initialize(self, values: Dict[str, Any]) -> None:
         schema, selected_values = self._build_values(values)
         self._baseline_values = dict(selected_values)
-        self._memory.remember_many(selected_values)
+        self._memory.remember_many(_parameters(schema), selected_values)
         self._apply(schema, selected_values)
 
     def _set_value(self, path: str, value: Any) -> None:
@@ -125,8 +135,7 @@ class InteractiveSession(Generic[T]):
         if path not in current_paths:
             raise ValueError(f"Cannot set unreachable parameter: {path}")
 
-        self._memory.remember_many(self._draft_values)
-        self._memory.remember(path, value)
+        self._memory.remember_many(current_parameters, self._draft_values)
 
         prefix_values: Dict[str, Any] = {}
         for parameter in current_parameters:
@@ -135,6 +144,9 @@ class InteractiveSession(Generic[T]):
                 break
             if parameter.path in self._draft_values:
                 prefix_values[parameter.path] = self._draft_values[parameter.path]
+
+        current_parameter = next(parameter for parameter in current_parameters if parameter.path == path)
+        self._memory.remember(current_parameter, value, _context_for(current_parameters, prefix_values, path))
 
         try:
             schema, selected_values = self._build_values(prefix_values)
@@ -145,7 +157,7 @@ class InteractiveSession(Generic[T]):
                 self._applied_error = self._draft_error
             return
 
-        self._memory.remember_many(selected_values)
+        self._memory.remember_many(_parameters(schema), selected_values)
         self._draft_error = None
         if self.auto_apply:
             try:
@@ -172,7 +184,7 @@ class InteractiveSession(Generic[T]):
             self._applied_error = self._draft_error
             return
 
-        self._memory.remember_many(selected_values)
+        self._memory.remember_many(_parameters(schema), selected_values)
         self._draft_error = None
         self._applied_error = None
         try:
@@ -197,11 +209,12 @@ class InteractiveSession(Generic[T]):
         values = dict(seed_values)
         while True:
             schema = self._explore(values)
-            missing = next((parameter for parameter in _parameters(schema) if parameter.path not in values), None)
+            parameters = _parameters(schema)
+            missing = next((parameter for parameter in parameters if parameter.path not in values), None)
             if missing is None:
                 return schema, values
 
-            found, value = self._memory.latest_compatible(missing)
+            found, value = self._memory.latest_compatible(missing, _context_for(parameters, values, missing.path))
             values[missing.path] = value if found else missing.selected_value
 
     def _explore(self, values: Dict[str, Any]) -> ConfigSchema:

--- a/src/hypster/interactive/session.py
+++ b/src/hypster/interactive/session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, Mapping, Optional, Tuple, TypeVar
 
@@ -10,6 +11,17 @@ from hypster.utils import normalize_values
 from .branch_memory import BranchChoiceMemory
 
 T = TypeVar("T")
+
+_VIZ_EXTRA_ERROR = (
+    "Hypster interactive widgets require the visualization extra. "
+    'Install it with `uv add "hypster[viz]"` or `pip install "hypster[viz]"`, '
+    "then restart the notebook kernel."
+)
+
+
+def _ensure_viz_extra() -> None:
+    if importlib.util.find_spec("anywidget") is None:
+        raise RuntimeError(_VIZ_EXTRA_ERROR)
 
 
 def _parameters(schema: ConfigSchema) -> list[ParameterInfo]:
@@ -296,6 +308,7 @@ def interact(
     on_unknown: UnknownPolicy = "raise",
     auto_apply: bool = True,
 ) -> InteractiveResult[T]:
+    _ensure_viz_extra()
     session: InteractiveSession[T] = InteractiveSession(
         func=func,
         values=values,

--- a/src/hypster/interactive/widget.py
+++ b/src/hypster/interactive/widget.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Dict
 
@@ -14,7 +15,7 @@ class HypsterInteractWidget(anywidget.AnyWidget):
     _css = Path(__file__).parent / "interact.css"
 
     snapshot = traitlets.Dict().tag(sync=True)
-    action = traitlets.Dict(default_value={}).tag(sync=True)
+    action = traitlets.Dict().tag(sync=True)
 
     def __init__(self, result: InteractiveResult[Any]):
         super().__init__(snapshot=result.snapshot)
@@ -25,4 +26,50 @@ class HypsterInteractWidget(anywidget.AnyWidget):
         action = change.get("new")
         if not action:
             return
-        self._result.dispatch(action)
+        self._result.dispatch(_decode_action(action))
+
+
+def _decode_action(action: Dict[str, Any]) -> Dict[str, Any]:
+    if action.get("type") != "set_value" or "encoded_value" not in action:
+        return action
+
+    decoded = dict(action)
+    decoded["value"] = _decode_value(decoded.pop("encoded_value"))
+    return decoded
+
+
+def _decode_value(encoded_value: Any) -> Any:
+    if not isinstance(encoded_value, dict):
+        return encoded_value
+
+    kind = encoded_value.get("kind")
+    raw_value = encoded_value.get("value")
+    if raw_value is None:
+        return None
+
+    if kind == "int":
+        if raw_value == "":
+            return None
+        try:
+            return int(raw_value)
+        except (TypeError, ValueError):
+            return raw_value
+
+    if kind == "float":
+        if raw_value == "":
+            return None
+        try:
+            return float(raw_value)
+        except (TypeError, ValueError):
+            return raw_value
+
+    if isinstance(kind, str) and kind.startswith("multi_"):
+        if raw_value == "":
+            return []
+        try:
+            value = json.loads(raw_value)
+        except (TypeError, json.JSONDecodeError):
+            return raw_value
+        return value if isinstance(value, list) else raw_value
+
+    return raw_value

--- a/src/hypster/interactive/widget.py
+++ b/src/hypster/interactive/widget.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import anywidget
+import traitlets
+
+from .session import InteractiveResult
+
+
+class HypsterInteractWidget(anywidget.AnyWidget):
+    _esm = Path(__file__).parent / "interact.js"
+    _css = Path(__file__).parent / "interact.css"
+
+    snapshot = traitlets.Dict().tag(sync=True)
+    action = traitlets.Dict(default_value={}).tag(sync=True)
+
+    def __init__(self, result: InteractiveResult[Any]):
+        super().__init__(snapshot=result.snapshot)
+        self._result = result
+        self.observe(self._handle_action, names="action")
+
+    def _handle_action(self, change: Dict[str, Any]) -> None:
+        action = change.get("new")
+        if not action:
+            return
+        self._result.dispatch(action)

--- a/src/hypster/interactive/widget.py
+++ b/src/hypster/interactive/widget.py
@@ -9,6 +9,19 @@ import traitlets
 
 from .session import InteractiveResult
 
+_BACKGROUND_SHIM = """<style>
+.cell-output-ipywidget-background,
+.jp-OutputArea,
+.jp-OutputArea-output,
+.cell-output,
+.output,
+.output_area,
+.vscode-cell-output,
+.widget-subarea {
+  background-color: transparent !important;
+}
+</style>"""
+
 
 class HypsterInteractWidget(anywidget.AnyWidget):
     _esm = Path(__file__).parent / "interact.js"
@@ -27,6 +40,13 @@ class HypsterInteractWidget(anywidget.AnyWidget):
         if not action:
             return
         self._result.dispatch(_decode_action(action))
+
+    def _ipython_display_(self) -> None:
+        from IPython.display import HTML, display
+
+        display(HTML(_BACKGROUND_SHIM))
+        data, metadata = super()._repr_mimebundle_()
+        display(data, metadata=metadata, raw=True)
 
 
 def _decode_action(action: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -63,6 +63,7 @@ def test_explore_returns_schema_info_and_defaults() -> None:
     }
     assert info.to_dict() == {
         "name": "config",
+        "display_label": "Config",
         "parameters": [
             {
                 "name": "batching",
@@ -121,6 +122,7 @@ def test_explore_includes_descriptions_and_display_labels() -> None:
     group = schema["parameters"][0]
     top_k = group["children"][0]
 
+    assert schema["display_label"] == "Config"
     assert group["display_label"] == "Retrieval"
     assert group["description"] == "Retrieval settings used before generation."
     assert top_k["display_label"] == "Top K"
@@ -259,6 +261,7 @@ def test_explore_to_dict_is_json_serializable() -> None:
     assert info is not None
     assert info.to_dict() == {
         "name": "config",
+        "display_label": "Config",
         "parameters": [
             {
                 "name": "provider",

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -73,6 +73,8 @@ def test_explore_returns_schema_info_and_defaults() -> None:
                 "options": ["single", "split"],
                 "minimum": None,
                 "maximum": None,
+                "description": None,
+                "display_label": "Batching",
                 "children": [],
             },
             {
@@ -84,10 +86,45 @@ def test_explore_returns_schema_info_and_defaults() -> None:
                 "options": None,
                 "minimum": 0.0,
                 "maximum": 2.0,
+                "description": None,
+                "display_label": "Temperature",
                 "children": [],
             },
         ],
     }
+
+
+def test_explore_includes_descriptions_and_display_labels() -> None:
+    def retrieval(hp: HP) -> Dict[str, Any]:
+        top_k = hp.int(
+            8,
+            name="top_k",
+            min=1,
+            max=20,
+            description="Number of documents to return.",
+        )
+        return {"top_k": top_k}
+
+    def config(hp: HP) -> Dict[str, Any]:
+        return {
+            "retrieval": hp.nest(
+                retrieval,
+                name="retrieval",
+                description="Retrieval settings used before generation.",
+            )
+        }
+
+    info = explore(config, return_info=True)
+
+    assert info is not None
+    schema = info.to_dict()
+    group = schema["parameters"][0]
+    top_k = group["children"][0]
+
+    assert group["display_label"] == "Retrieval"
+    assert group["description"] == "Retrieval settings used before generation."
+    assert top_k["display_label"] == "Top K"
+    assert top_k["description"] == "Number of documents to return."
 
 
 def test_explore_tracks_nested_defaults_with_prefixed_paths() -> None:
@@ -232,6 +269,8 @@ def test_explore_to_dict_is_json_serializable() -> None:
                 "options": ["openai", "gemini"],
                 "minimum": None,
                 "maximum": None,
+                "description": None,
+                "display_label": "Provider",
                 "children": [],
             }
         ],

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -349,3 +349,24 @@ def test_interact_multiple_widget_views_share_session_updates() -> None:
     assert first.snapshot["selected_params"] == {"count": 4}
     assert second.snapshot["selected_params"] == {"count": 4}
     assert result.value == {"count": 4}
+
+
+def test_interact_widget_display_includes_vscode_background_shim(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[Any, Dict[str, Any]]] = []
+
+    def fake_display(obj: Any = None, **kwargs: Any) -> None:
+        calls.append((obj, kwargs))
+
+    def config(hp: HP) -> Dict[str, int]:
+        return {"count": hp.int(1, name="count", min=1, max=5)}
+
+    monkeypatch.setattr("IPython.display.display", fake_display)
+
+    widget = interact(config).interact()
+    widget._ipython_display_()
+
+    assert len(calls) == 2
+    assert "cell-output-ipywidget-background" in calls[0][0].data
+    assert "vscode-cell-output" in calls[0][0].data
+    assert calls[1][1]["raw"] is True
+    assert "application/vnd.jupyter.widget-view+json" in calls[1][0]

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -7,6 +7,16 @@ import pytest
 from hypster import HP, instantiate_with_params, interact
 
 
+def test_interact_requires_viz_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    def config(hp: HP) -> Dict[str, int]:
+        return {"count": hp.int(1, name="count", min=1, max=5)}
+
+    monkeypatch.setattr("hypster.interactive.session.importlib.util.find_spec", lambda name: None)
+
+    with pytest.raises(RuntimeError, match=r"hypster\[viz\]"):
+        interact(config)
+
+
 def test_interact_returns_live_result_matching_instantiate_with_params() -> None:
     def openai(hp: HP) -> Dict[str, Any]:
         return {

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -85,6 +85,62 @@ def test_interact_remembers_latest_compatible_branch_choice() -> None:
     assert result.params == {"provider": "gemini", "model": "pro"}
 
 
+def test_interact_separates_same_path_values_by_branch_context() -> None:
+    def config(hp: HP) -> Dict[str, Any]:
+        mode = hp.select(["a", "b"], name="mode", default="a")
+        if mode == "a":
+            n = hp.int(0, name="n", min=0, max=10)
+        else:
+            n = hp.int(0, name="n", min=0, max=10)
+        return {"mode": mode, "n": n}
+
+    result = interact(config)
+
+    result.dispatch({"type": "set_value", "path": "n", "value": 7})
+    result.dispatch({"type": "set_value", "path": "mode", "value": "b"})
+
+    assert result.params == {"mode": "b", "n": 0}
+
+    result.dispatch({"type": "set_value", "path": "n", "value": 3})
+    result.dispatch({"type": "set_value", "path": "mode", "value": "a"})
+
+    assert result.params == {"mode": "a", "n": 7}
+
+    result.dispatch({"type": "set_value", "path": "mode", "value": "b"})
+
+    assert result.params == {"mode": "b", "n": 3}
+
+
+def test_interact_updates_same_path_numeric_bounds_by_branch_context() -> None:
+    def config(hp: HP) -> Dict[str, int]:
+        a = hp.select([2, 3], name="a", default=3)
+        if a == 2:
+            n = hp.int(0, name="n", min=0, max=3)
+        else:
+            n = hp.int(0, name="n", min=0, max=10)
+        return {"a": a, "n": n}
+
+    result = interact(config)
+
+    result.dispatch({"type": "set_value", "path": "n", "value": 8})
+    snapshot = result.dispatch({"type": "set_value", "path": "a", "value": 2})
+    n_parameter = snapshot["schema"]["parameters"][1]
+
+    assert snapshot["status"] == "applied"
+    assert n_parameter["minimum"] == 0
+    assert n_parameter["maximum"] == 3
+    assert result.params == {"a": 2, "n": 0}
+
+    result.dispatch({"type": "set_value", "path": "n", "value": 2})
+    result.dispatch({"type": "set_value", "path": "a", "value": 3})
+
+    assert result.params == {"a": 3, "n": 8}
+
+    result.dispatch({"type": "set_value", "path": "a", "value": 2})
+
+    assert result.params == {"a": 2, "n": 2}
+
+
 def test_interact_reset_restores_baseline_and_clears_later_branch_memory() -> None:
     def config(hp: HP) -> Dict[str, str]:
         provider = hp.select(["openai", "gemini"], name="provider", default="openai")

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from hypster import HP, instantiate_with_params, interact
+
+
+def test_interact_returns_live_result_matching_instantiate_with_params() -> None:
+    def openai(hp: HP) -> Dict[str, Any]:
+        return {
+            "model": hp.select(["gpt-4o-mini", "gpt-4.1"], name="model", default="gpt-4o-mini"),
+            "temperature": hp.float(0.2, name="temperature", min=0.0, max=2.0),
+        }
+
+    def config(hp: HP) -> Dict[str, Any]:
+        provider = hp.select(["gemini", "openai"], name="provider", default="gemini")
+        if provider == "openai":
+            llm = hp.nest(openai, name="openai")
+        else:
+            llm = {"model": hp.select(["flash-lite", "pro"], name="model", default="flash-lite")}
+        return {"provider": provider, "llm": llm}
+
+    result = interact(config, values={"provider": "openai", "openai.temperature": 0.7})
+    expected = instantiate_with_params(config, values={"provider": "openai", "openai.temperature": 0.7})
+
+    assert result.value == expected.value
+    assert result.params == expected.params
+
+    params = result.params
+    params["provider"] = "gemini"
+
+    assert result.params == expected.params
+
+
+def test_interact_action_updates_value_and_params() -> None:
+    def openai(hp: HP) -> Dict[str, Any]:
+        return {
+            "model": hp.select(["gpt-4o-mini", "gpt-4.1"], name="model", default="gpt-4o-mini"),
+            "temperature": hp.float(0.2, name="temperature", min=0.0, max=2.0),
+        }
+
+    def config(hp: HP) -> Dict[str, Any]:
+        provider = hp.select(["gemini", "openai"], name="provider", default="gemini")
+        if provider == "openai":
+            llm = hp.nest(openai, name="openai")
+        else:
+            llm = {"model": hp.select(["flash-lite", "pro"], name="model", default="flash-lite")}
+        return {"provider": provider, "llm": llm}
+
+    result = interact(config)
+
+    snapshot = result.dispatch({"type": "set_value", "path": "provider", "value": "openai"})
+
+    assert result.value == {
+        "provider": "openai",
+        "llm": {"model": "gpt-4o-mini", "temperature": 0.2},
+    }
+    assert result.params == {
+        "provider": "openai",
+        "openai.model": "gpt-4o-mini",
+        "openai.temperature": 0.2,
+    }
+    assert snapshot["draft_values"] == result.params
+
+
+def test_interact_remembers_latest_compatible_branch_choice() -> None:
+    def config(hp: HP) -> Dict[str, str]:
+        provider = hp.select(["openai", "gemini"], name="provider", default="openai")
+        if provider == "gemini":
+            model = hp.select(["flash-lite", "pro"], name="model", default="flash-lite")
+        else:
+            model = hp.select(["gpt-4o-mini", "gpt-4.1"], name="model", default="gpt-4o-mini")
+        return {"provider": provider, "model": model}
+
+    result = interact(config)
+
+    result.dispatch({"type": "set_value", "path": "provider", "value": "gemini"})
+    result.dispatch({"type": "set_value", "path": "model", "value": "pro"})
+    result.dispatch({"type": "set_value", "path": "provider", "value": "openai"})
+    result.dispatch({"type": "set_value", "path": "provider", "value": "gemini"})
+
+    assert result.value == {"provider": "gemini", "model": "pro"}
+    assert result.params == {"provider": "gemini", "model": "pro"}
+
+
+def test_interact_reset_restores_baseline_and_clears_later_branch_memory() -> None:
+    def config(hp: HP) -> Dict[str, str]:
+        provider = hp.select(["openai", "gemini"], name="provider", default="openai")
+        if provider == "gemini":
+            model = hp.select(["flash-lite", "pro"], name="model", default="flash-lite")
+        else:
+            model = hp.select(["gpt-4o-mini", "gpt-4.1"], name="model", default="gpt-4o-mini")
+        return {"provider": provider, "model": model}
+
+    result = interact(config)
+
+    result.dispatch({"type": "set_value", "path": "provider", "value": "gemini"})
+    result.dispatch({"type": "set_value", "path": "model", "value": "pro"})
+    result.dispatch({"type": "set_value", "path": "provider", "value": "openai"})
+
+    snapshot = result.dispatch({"type": "reset"})
+
+    assert result.value == {"provider": "openai", "model": "gpt-4o-mini"}
+    assert snapshot["selected_params"] == {"provider": "openai", "model": "gpt-4o-mini"}
+
+    result.dispatch({"type": "set_value", "path": "provider", "value": "gemini"})
+
+    assert result.value == {"provider": "gemini", "model": "flash-lite"}
+
+
+def test_interact_manual_apply_keeps_value_on_last_applied_state_until_apply() -> None:
+    def config(hp: HP) -> Dict[str, int]:
+        return {"count": hp.int(1, name="count", min=1, max=5)}
+
+    result = interact(config, auto_apply=False)
+
+    snapshot = result.dispatch({"type": "set_value", "path": "count", "value": 3})
+
+    assert result.value == {"count": 1}
+    assert result.params == {"count": 1}
+    assert snapshot["draft_values"] == {"count": 3}
+    assert snapshot["applied_values"] == {"count": 1}
+    assert snapshot["status"] == "pending"
+
+    snapshot = result.dispatch({"type": "apply"})
+
+    assert result.value == {"count": 3}
+    assert result.params == {"count": 3}
+    assert snapshot["status"] == "applied"
+
+
+def test_interact_immediate_apply_exposes_errors_until_fixed() -> None:
+    def config(hp: HP) -> Dict[str, int]:
+        return {"count": hp.int(1, name="count", min=1, max=5)}
+
+    result = interact(config)
+
+    snapshot = result.dispatch({"type": "set_value", "path": "count", "value": 9})
+
+    assert snapshot["status"] == "error"
+    assert snapshot["error"]["kind"] == "exploration"
+    assert "exceeds maximum bound" in snapshot["error"]["message"]
+    with pytest.raises(RuntimeError, match="exceeds maximum bound"):
+        result.value
+    with pytest.raises(RuntimeError, match="exceeds maximum bound"):
+        result.params
+
+    snapshot = result.dispatch({"type": "set_value", "path": "count", "value": 4})
+
+    assert snapshot["status"] == "applied"
+    assert snapshot["error"] is None
+    assert result.value == {"count": 4}
+    assert result.params == {"count": 4}
+
+
+def test_interact_widget_view_dispatches_actions_to_same_session() -> None:
+    def config(hp: HP) -> Dict[str, int]:
+        return {"count": hp.int(1, name="count", min=1, max=5)}
+
+    result = interact(config)
+    widget = result.interact()
+
+    widget.action = {"id": "test-action", "type": "set_value", "path": "count", "value": 2}
+
+    assert widget.snapshot["selected_params"] == {"count": 2}
+    assert result.value == {"count": 2}
+
+
+def test_interact_multiple_widget_views_share_session_updates() -> None:
+    def config(hp: HP) -> Dict[str, int]:
+        return {"count": hp.int(1, name="count", min=1, max=5)}
+
+    result = interact(config)
+    first = result.interact()
+    second = result.interact()
+
+    first.action = {"id": "test-action", "type": "set_value", "path": "count", "value": 4}
+
+    assert first.snapshot["selected_params"] == {"count": 4}
+    assert second.snapshot["selected_params"] == {"count": 4}
+    assert result.value == {"count": 4}

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -131,6 +131,23 @@ def test_interact_manual_apply_keeps_value_on_last_applied_state_until_apply() -
     assert snapshot["status"] == "applied"
 
 
+def test_interact_manual_apply_preserves_sibling_drafts_after_exploration_error() -> None:
+    def config(hp: HP) -> Dict[str, int]:
+        return {
+            "count": hp.int(1, name="count", min=1, max=5),
+            "width": hp.int(2, name="width", min=1, max=5),
+        }
+
+    result = interact(config, auto_apply=False)
+
+    result.dispatch({"type": "set_value", "path": "width", "value": 4})
+    snapshot = result.dispatch({"type": "set_value", "path": "count", "value": 9})
+
+    assert snapshot["status"] == "draft_error"
+    assert snapshot["draft_values"] == {"count": 9, "width": 4}
+    assert result.value == {"count": 1, "width": 2}
+
+
 def test_interact_immediate_apply_exposes_errors_until_fixed() -> None:
     def config(hp: HP) -> Dict[str, int]:
         return {"count": hp.int(1, name="count", min=1, max=5)}
@@ -142,6 +159,9 @@ def test_interact_immediate_apply_exposes_errors_until_fixed() -> None:
     assert snapshot["status"] == "error"
     assert snapshot["error"]["kind"] == "exploration"
     assert "exceeds maximum bound" in snapshot["error"]["message"]
+    assert snapshot["draft_values"] == {"count": 9}
+    assert snapshot["applied_values"] == {"count": 1}
+    assert snapshot["selected_params"] is None
     with pytest.raises(RuntimeError, match="exceeds maximum bound"):
         result.value
     with pytest.raises(RuntimeError, match="exceeds maximum bound"):
@@ -155,6 +175,50 @@ def test_interact_immediate_apply_exposes_errors_until_fixed() -> None:
     assert result.params == {"count": 4}
 
 
+def test_interact_reset_reports_errors_without_stale_value() -> None:
+    state = {"fail": False}
+
+    def config(hp: HP) -> Dict[str, int]:
+        count = hp.int(1, name="count", min=1, max=5)
+        if state["fail"]:
+            raise RuntimeError("reset failed")
+        return {"count": count}
+
+    result = interact(config)
+    result.dispatch({"type": "set_value", "path": "count", "value": 3})
+
+    state["fail"] = True
+    snapshot = result.dispatch({"type": "reset"})
+
+    assert snapshot["status"] == "error"
+    assert snapshot["error"] == {"kind": "exploration", "message": "reset failed"}
+    assert snapshot["selected_params"] is None
+    with pytest.raises(RuntimeError, match="reset failed"):
+        result.value
+
+
+def test_interact_branch_memory_rejects_incompatible_multi_value_history() -> None:
+    def config(hp: HP) -> Dict[str, Any]:
+        mode = hp.select(["a", "b"], name="mode", default="a")
+        if mode == "a":
+            values = hp.multi_int([1], name="values", min=0, max=5)
+            return {"mode": mode, "values": values}
+        return {"mode": mode, "enabled": hp.bool(True, name="enabled")}
+
+    result = interact(config)
+
+    snapshot = result.dispatch({"type": "set_value", "path": "values", "value": [99]})
+
+    assert snapshot["status"] == "error"
+
+    result.dispatch({"type": "set_value", "path": "mode", "value": "b"})
+    snapshot = result.dispatch({"type": "set_value", "path": "mode", "value": "a"})
+
+    assert snapshot["status"] == "applied"
+    assert result.value == {"mode": "a", "values": [1]}
+    assert result.params == {"mode": "a", "values": [1]}
+
+
 def test_interact_widget_view_dispatches_actions_to_same_session() -> None:
     def config(hp: HP) -> Dict[str, int]:
         return {"count": hp.int(1, name="count", min=1, max=5)}
@@ -166,6 +230,44 @@ def test_interact_widget_view_dispatches_actions_to_same_session() -> None:
 
     assert widget.snapshot["selected_params"] == {"count": 2}
     assert result.value == {"count": 2}
+
+
+def test_interact_widget_decodes_numeric_transport_values() -> None:
+    def child(hp: HP) -> Dict[str, float]:
+        return {"temperature": hp.float(0.5, name="temperature", min=0.0, max=2.0)}
+
+    def config(hp: HP) -> Dict[str, Any]:
+        return {"child": hp.nest(child, name="child")}
+
+    result = interact(config)
+    widget = result.interact()
+
+    widget.action = {
+        "id": "test-action",
+        "type": "set_value",
+        "path": "child.temperature",
+        "encoded_value": {"kind": "float", "value": "1"},
+    }
+
+    assert result.params == {"child.temperature": 1.0}
+    assert isinstance(result.params["child.temperature"], float)
+
+
+def test_interact_widget_decodes_empty_multi_value_transport_as_empty_list() -> None:
+    def config(hp: HP) -> Dict[str, list[int]]:
+        return {"values": hp.multi_int([1, 2], name="values", min=0, max=5)}
+
+    result = interact(config)
+    widget = result.interact()
+
+    widget.action = {
+        "id": "test-action",
+        "type": "set_value",
+        "path": "values",
+        "encoded_value": {"kind": "multi_int", "value": ""},
+    }
+
+    assert result.params == {"values": []}
 
 
 def test_interact_multiple_widget_views_share_session_updates() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -388,7 +388,7 @@ wheels = [
 
 [[package]]
 name = "hypster"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,20 @@ wheels = [
 ]
 
 [[package]]
+name = "anywidget"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipywidgets" },
+    { name = "psygnal" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/31/0491d707c674b34267f55d96d6a7148e55e7b6718a271686232cf295fbe2/anywidget-0.11.0.tar.gz", hash = "sha256:6695fbef9449cf8c27f421b96c5837aa37f909ec1f60cfa33add333e1b70b169", size = 426999, upload-time = "2026-04-27T23:42:09.576Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/c2/8fec8e8e2eb920cc2280f569144080cd58622a2eda83bfa4c0c354a63264/anywidget-0.11.0-py3-none-any.whl", hash = "sha256:c574d9acc6503ad27b37a9acea48f957a8ba7c9c9876cfcb37898931c098ce9d", size = 317341, upload-time = "2026-04-27T23:42:08.356Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -327,7 +341,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/38/3f/9859f655d11901e7b2996c6e3d33e0caa9a1d4572c3bc61ed0faa64b2f4c/greenlet-3.3.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9bc885b89709d901859cf95179ec9f6bb67a3d2bb1f0e88456461bd4b7f8fd0d", size = 277747, upload-time = "2026-02-20T20:16:21.325Z" },
     { url = "https://files.pythonhosted.org/packages/fb/07/cb284a8b5c6498dbd7cba35d31380bb123d7dceaa7907f606c8ff5993cbf/greenlet-3.3.2-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b568183cf65b94919be4438dc28416b234b678c608cafac8874dfeeb2a9bbe13", size = 579202, upload-time = "2026-02-20T20:47:28.955Z" },
     { url = "https://files.pythonhosted.org/packages/ed/45/67922992b3a152f726163b19f890a85129a992f39607a2a53155de3448b8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:527fec58dc9f90efd594b9b700662ed3fb2493c2122067ac9c740d98080a620e", size = 590620, upload-time = "2026-02-20T20:55:55.581Z" },
-    { url = "https://files.pythonhosted.org/packages/03/5f/6e2a7d80c353587751ef3d44bb947f0565ec008a2e0927821c007e96d3a7/greenlet-3.3.2-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508c7f01f1791fbc8e011bd508f6794cb95397fdb198a46cb6635eb5b78d85a7", size = 602132, upload-time = "2026-02-20T21:02:43.261Z" },
     { url = "https://files.pythonhosted.org/packages/ad/55/9f1ebb5a825215fadcc0f7d5073f6e79e3007e3282b14b22d6aba7ca6cb8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad0c8917dd42a819fe77e6bdfcb84e3379c0de956469301d9fd36427a1ca501f", size = 591729, upload-time = "2026-02-20T20:20:58.395Z" },
     { url = "https://files.pythonhosted.org/packages/24/b4/21f5455773d37f94b866eb3cf5caed88d6cea6dd2c6e1f9c34f463cba3ec/greenlet-3.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:97245cc10e5515dbc8c3104b2928f7f02b6813002770cfaffaf9a6e0fc2b94ef", size = 1551946, upload-time = "2026-02-20T20:49:31.102Z" },
     { url = "https://files.pythonhosted.org/packages/00/68/91f061a926abead128fe1a87f0b453ccf07368666bd59ffa46016627a930/greenlet-3.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8c1fdd7d1b309ff0da81d60a9688a8bd044ac4e18b250320a96fc68d31c209ca", size = 1618494, upload-time = "2026-02-20T20:21:06.541Z" },
@@ -335,7 +348,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -344,7 +356,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -353,7 +364,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -362,7 +372,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -371,7 +380,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -385,6 +393,7 @@ source = { editable = "." }
 
 [package.optional-dependencies]
 jupyter = [
+    { name = "anywidget" },
     { name = "ipywidgets" },
 ]
 optuna = [
@@ -393,6 +402,7 @@ optuna = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "anywidget" },
     { name = "coverage", extra = ["toml"] },
     { name = "ipywidgets" },
     { name = "mypy" },
@@ -416,6 +426,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anywidget", marker = "extra == 'jupyter'", specifier = ">=0.9.0" },
     { name = "ipywidgets", marker = "extra == 'jupyter'", specifier = ">=8.0.0" },
     { name = "optuna", marker = "extra == 'optuna'", specifier = ">=3.6" },
 ]
@@ -423,6 +434,7 @@ provides-extras = ["jupyter", "optuna"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "anywidget", specifier = ">=0.9.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.0" },
     { name = "ipywidgets", specifier = ">=8.0.0" },
     { name = "mypy", specifier = ">=0.950" },
@@ -1116,6 +1128,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psygnal"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/79/20c3e23e75272e9ddf018097cf872ab088bccba978888472656629efa4a3/psygnal-0.15.1.tar.gz", hash = "sha256:f64f62dee2306fc1c22050a59b6c6cdad126e04b0cf50e393ff858a1da719096", size = 123147, upload-time = "2026-01-04T16:38:41.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/44/ab13cb6147d010258826a43e574ad94599af0de29df13795fff9efee656c/psygnal-0.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ee55e3997f796fd84d4fdbd829bb1b19d323e087c43d072744604a3016c8851", size = 587322, upload-time = "2026-01-04T16:38:04.827Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a2/68c042a607ca613e9450dfee99cc5c2a4d10d95392fb1de2ba932dd0a605/psygnal-0.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:912bcf110bfe7b4aa121d24987b6a58afb967ff090a049dad136eaf3cbcc7bea", size = 576207, upload-time = "2026-01-04T16:38:06.183Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/86/123c7b169ad32994a0cd801cd1f11c1a2be84555807e9c8a8a4682c67a9f/psygnal-0.15.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2e860c11fe075fd80c93a24081c577ef7ec5c9da41f0e75990aa4cccf3f79cf", size = 864261, upload-time = "2026-01-04T16:38:07.895Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f1/886cec7bec2f27fe453cfa32bfcaac08a83aab2a04895af68f93e1c493b8/psygnal-0.15.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d5b8bebcf99699ef50b6ef572868a490f6d191dc4466e5bd9818ca27e17cd581", size = 872582, upload-time = "2026-01-04T16:38:09.745Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a3/da972a05568ee8a9dc6c6567bee2c0cc5af8c681baebcb9fdbbf3cceb4f7/psygnal-0.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:06e0a90490e1205620d97ac52fbbe3282a22b126a26d02b3e1196bb46de16c7a", size = 411043, upload-time = "2026-01-04T16:38:11.588Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a7/69495410025cc4298765545ce3b8c635cd4c8d3a362b7fbbc15b80e9fc8f/psygnal-0.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1adc41515f648696990964433f1e25d8dfd306813a3645366c85e01986ba57a0", size = 581002, upload-time = "2026-01-04T16:38:12.753Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1f/19a8126ccf3cd3974ba5d08a435a049b666961d90f5848ba83599d7a29de/psygnal-0.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:38ff18455b2ac73d4e8eea82ef298ce904b52e4dfdc603a24380c9c440e37519", size = 567775, upload-time = "2026-01-04T16:38:14.04Z" },
+    { url = "https://files.pythonhosted.org/packages/54/c5/b1348880d603edb82128a721397a1ddcf3dfcf5384fe5689db6e471118ae/psygnal-0.15.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c923c322eeefb1140886927cfe7bda7c32341087e290e812b9c69a624ab72d54", size = 855961, upload-time = "2026-01-04T16:38:15.612Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/42/3da2d6f3583bd1a849f7faa2fd3492b14bfda05012519ceaea5992658af0/psygnal-0.15.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2714ddaa41ea3134c0ee91cebd5fb11a88f254ea1d5948806ab0ad5f8be603d5", size = 862721, upload-time = "2026-01-04T16:38:17.059Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/14/6fc7e97fdecf7e8c5c105684bab784920312a3259800d8b53e3cf8783f42/psygnal-0.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:877516056a5a383427a647fff2fad5179eaa3e12de2c083c273e748435414aef", size = 415696, upload-time = "2026-01-04T16:38:18.355Z" },
+    { url = "https://files.pythonhosted.org/packages/76/65/b7bbca96bc477aa9ac2264e5907b2f4ccfcd1319f776dd1f35eec06cc2f4/psygnal-0.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8d56f0f35eaf4a21f660de76885222faf9e8c7112454528d3394d464f3d4d1a3", size = 598340, upload-time = "2026-01-04T16:38:19.752Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/56577465a1b42a5e6780bb5fab53fb68f8bfd72f0131ed397576529af724/psygnal-0.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0febcf757a1323d9b8bd75735ee3569213d8110012a7bf0f478e85c5ab459fc6", size = 575311, upload-time = "2026-01-04T16:38:21.137Z" },
+    { url = "https://files.pythonhosted.org/packages/79/81/f642ac08104049383076f83480ed412c9626e068769a1c34873c595bec0e/psygnal-0.15.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b5e4837dfbfa4974dabe0795e32be9aadcd87603adf734738ce1114f72238a05", size = 889770, upload-time = "2026-01-04T16:38:22.629Z" },
+    { url = "https://files.pythonhosted.org/packages/de/43/e571fa40b72780abed080ef829e5ad98017b6fe48d28c15a2404e006b676/psygnal-0.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:07b4c4e03bbf4e8cad7e25f4fbc1ba9575fb9c3d14991bc7edfeb8b09c8d6d54", size = 881105, upload-time = "2026-01-04T16:38:23.896Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/ef3ab825eb08eaecbbceeeb56383694fe64ce399dbfd1d0767bb85688785/psygnal-0.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:4f0ce91b9c18e92281bf2c3fc4bb4e808d90f0b023d0a37b302d354188520338", size = 418969, upload-time = "2026-01-04T16:38:25.731Z" },
+    { url = "https://files.pythonhosted.org/packages/46/21/5a142165d27063abf5921807d3c3d973f5d44ab414a13b210839a43ead4d/psygnal-0.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2087aadc9404f007f79c2899e329932869e362c50de58b90631c5f49b4768cc5", size = 596768, upload-time = "2026-01-04T16:38:27.053Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/25/c1712931d61c118691e73daf29ef708c679ea9ba187c797dd5deee360411/psygnal-0.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f3bf68ca42569dfdce20c6cf915d34b78b9e3ddddacb9f78728224fda6946b4", size = 574808, upload-time = "2026-01-04T16:38:28.779Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/4f/3593e5adb88a188c798604aed95fbc1479f30230e7f51e8f2c770e6a3832/psygnal-0.15.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e9fca977f5335deea39aed22e31d9795983e4f243e59a7d3c4105793adb7693d", size = 885616, upload-time = "2026-01-04T16:38:30.081Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4c/14779ed4c3a1d71fa1a9a87ecfb184ad3335dd64681067f77c1c47b14ae9/psygnal-0.15.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0c85b7d05b92ccbec47c75ab8a5545eda462e81a492c82424aba5ab81a3ad89d", size = 876516, upload-time = "2026-01-04T16:38:31.422Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/bc/4f771e3cdcde4db4023dbf36d6f0aab44e02b9de719353c22954b655e2ff/psygnal-0.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:ac0e693b29e0a429e97315a52313321855bef6140e9975b7ae78b4d93c8fbb42", size = 419172, upload-time = "2026-01-04T16:38:32.82Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2e/975bd61727578d88df62797f78390965ca7905780cf01eb59cb095a13638/psygnal-0.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:803fc33c4280c822c6f4b22e6c3ea7c4483e190f3cc69e69350098b3799476f3", size = 595706, upload-time = "2026-01-04T16:38:34.139Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/55/e487f1d91497eb75e86c3fdfef69a21b1cab24d023383dd7648b08797d6a/psygnal-0.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4f53b4b83355b0a785b745987fd04e59bbf169a9028ed81a68ca7e05fb76d458", size = 575133, upload-time = "2026-01-04T16:38:35.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2f/f286355accd0e68d3eef52e63c8b9ab6ba33ec3107177719a036b3319657/psygnal-0.15.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bcbca12190f5aa65c1f8fb04a81fa6f4463c5f5dde25cd74c3a56ceff6f37b02", size = 889565, upload-time = "2026-01-04T16:38:37.003Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/dc/40c6026c88d7f9220ecc913afe0501045a512c9b82f9b7e036bb089dc287/psygnal-0.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1ac399566852fe4354ce26a1acbe12319232e8c2b615fe5ad1e114c547095cf6", size = 880863, upload-time = "2026-01-04T16:38:38.381Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/85/b4f45ec3057c473b5622fc002b3a636a698c34d3a0917a064ff5247f1984/psygnal-0.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:d3a03055f331ce91d44581c71edb79938ccc133a94af2ce7ad3a18fa57ac7be5", size = 423654, upload-time = "2026-01-04T16:38:39.7Z" },
+    { url = "https://files.pythonhosted.org/packages/46/49/7742544684bee728ec123515d2694cee859aa2a705951a461230b00f18cc/psygnal-0.15.1-py3-none-any.whl", hash = "sha256:4221140e633e45b076953c64bcb9b41a744833527f9a037c1ca98bc270798cbf", size = 90638, upload-time = "2026-01-04T16:38:40.841Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -395,6 +395,7 @@ source = { editable = "." }
 jupyter = [
     { name = "anywidget" },
     { name = "ipywidgets" },
+    { name = "jupyterlab-widgets" },
 ]
 optuna = [
     { name = "optuna" },
@@ -405,6 +406,7 @@ dev = [
     { name = "anywidget" },
     { name = "coverage", extra = ["toml"] },
     { name = "ipywidgets" },
+    { name = "jupyterlab-widgets" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -428,6 +430,7 @@ test = [
 requires-dist = [
     { name = "anywidget", marker = "extra == 'jupyter'", specifier = ">=0.9.0" },
     { name = "ipywidgets", marker = "extra == 'jupyter'", specifier = ">=8.0.0" },
+    { name = "jupyterlab-widgets", marker = "extra == 'jupyter'", specifier = ">=3.0.0" },
     { name = "optuna", marker = "extra == 'optuna'", specifier = ">=3.6" },
 ]
 provides-extras = ["jupyter", "optuna"]
@@ -437,6 +440,7 @@ dev = [
     { name = "anywidget", specifier = ">=0.9.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.0" },
     { name = "ipywidgets", specifier = ">=8.0.0" },
+    { name = "jupyterlab-widgets", specifier = ">=3.0.0" },
     { name = "mypy", specifier = ">=0.950" },
     { name = "pre-commit", specifier = ">=3.0" },
     { name = "pytest", specifier = ">=6.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -392,11 +392,6 @@ version = "0.5.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
-jupyter = [
-    { name = "anywidget" },
-    { name = "ipywidgets" },
-    { name = "jupyterlab-widgets" },
-]
 optuna = [
     { name = "optuna" },
 ]
@@ -433,15 +428,12 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anywidget", marker = "extra == 'jupyter'", specifier = ">=0.9.0" },
     { name = "anywidget", marker = "extra == 'viz'", specifier = ">=0.9.0" },
-    { name = "ipywidgets", marker = "extra == 'jupyter'", specifier = ">=8.0.0" },
     { name = "ipywidgets", marker = "extra == 'viz'", specifier = ">=8.0.0" },
-    { name = "jupyterlab-widgets", marker = "extra == 'jupyter'", specifier = ">=3.0.0" },
     { name = "jupyterlab-widgets", marker = "extra == 'viz'", specifier = ">=3.0.0" },
     { name = "optuna", marker = "extra == 'optuna'", specifier = ">=3.6" },
 ]
-provides-extras = ["jupyter", "viz", "optuna"]
+provides-extras = ["viz", "optuna"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -400,6 +400,11 @@ jupyter = [
 optuna = [
     { name = "optuna" },
 ]
+viz = [
+    { name = "anywidget" },
+    { name = "ipywidgets" },
+    { name = "jupyterlab-widgets" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -429,11 +434,14 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "anywidget", marker = "extra == 'jupyter'", specifier = ">=0.9.0" },
+    { name = "anywidget", marker = "extra == 'viz'", specifier = ">=0.9.0" },
     { name = "ipywidgets", marker = "extra == 'jupyter'", specifier = ">=8.0.0" },
+    { name = "ipywidgets", marker = "extra == 'viz'", specifier = ">=8.0.0" },
     { name = "jupyterlab-widgets", marker = "extra == 'jupyter'", specifier = ">=3.0.0" },
+    { name = "jupyterlab-widgets", marker = "extra == 'viz'", specifier = ">=3.0.0" },
     { name = "optuna", marker = "extra == 'optuna'", specifier = ">=3.6" },
 ]
-provides-extras = ["jupyter", "optuna"]
+provides-extras = ["jupyter", "viz", "optuna"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Add `interact()` and `InteractiveResult` for live notebook instantiation with `.value`, `.params`, `.snapshot`, and reusable `.interact()` views.
- Add a minimal anywidget renderer with vanilla JS/CSS, nested groups, descriptions, humanized labels, branch memory, auto/manual apply, and explicit error snapshots.
- Harden reviewer-found edge cases around multi-select transport, numeric/list value decoding, invalid draft snapshots, reset errors, and incompatible branch-memory replay.
- Release as `0.5.0` with CHANGELOG and docs updates for the Jupyter extra.

## Before / After
Before:
```python
# Users had to instantiate directly, then separately inspect/replay params.
model = instantiate(model_cfg, values={"provider": "openai"})
schema = explore(model_cfg, values={"provider": "openai"}, return_info=True)
```

After:
```python
from hypster import interact

result = interact(model_cfg)
# tweak the widget in Jupyter
model = result.value
params = result.params
result.interact()  # another live view of the same session
```

Before widget transport:
```text
<select> coerced option values to strings, and multi_select changes could arrive as a single option index.
```

After widget transport:
```text
select values round-trip through JSON-backed option metadata, numeric controls use typed widget transport,
and multi-value drafts preserve clear error state without exposing stale selected params.
```

## Review Notes
- Ran one Claude Skeptic adversarial reviewer. Accepted and fixed the concrete findings for multi-select transport, draft preservation on errors, reset failure state, empty multi-value decoding, and `crypto.randomUUID()` fallback.
- Rejected the initial invalid `values=` construction finding because invalid seeds should fail like `explore()` / `instantiate()` rather than creating a recoverable widget session.
- Rejected the manual-mode applied-error finding because recovery intentionally happens through an explicit Apply action.

## Verification
- `uv run pytest -q` -> 93 passed
- `uv run ruff check .` -> passed
- `uv run mypy src` -> passed
- `git diff --check` -> passed

Closes #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jupyter interact() returns a live result (.value, .params, .snapshot, .interact()); file-backed vanilla JS renderer with scoped CSS; branch-choice memory; humanized display labels and optional parameter descriptions; support for auto_apply=False staging.

* **Bug Fixes**
  * Better notebook round-tripping and error reporting, preserved non-string select values, correct multi-select empty/non-empty handling, explicit draft/applied/current snapshot status, reset no longer leaks stale values.

* **Documentation**
  * Expanded interactive guide, ADR, glossary, and installation notes for Jupyter renderer.

* **Tests**
  * New tests covering interact flows, branch memory, widget transport and decoding.

* **Chores**
  * Version bumped to 0.5.0; jupyter extra updated to include widget runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypster/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->