### PR TITLE
[codex] Avoid metadata lookup during import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Agent Notes
+
+## Version Handling
+
+- `hypster.__version__` is intentionally defined in `src/hypster/_version.py` instead of using `importlib.metadata` at import time.
+- When changing `[project].version` in `pyproject.toml`, update `src/hypster/_version.py` in the same change.
+- Keep `src/hypster/__init__.py` free of eager `importlib.metadata` imports; they significantly slow down `import hypster`.
+- Run `uv run pytest tests/test_version.py` after version-related changes.

--- a/src/hypster/__init__.py
+++ b/src/hypster/__init__.py
@@ -1,18 +1,9 @@
 """Hypster v2 - Explicit, typed Python configuration management."""
 
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
-
+from ._version import __version__
 from .core import ConfigFunc, InstantiationOutput, instantiate, instantiate_with_params
 from .explore import explore
 from .hp import HP
-
-try:
-    # Resolve version from installed package metadata; __name__ == "hypster" at package top-level
-    __version__ = _pkg_version(__name__)
-except PackageNotFoundError:  # During editable/source runs before install
-    __version__ = "0.0.0"
-
 
 __all__ = [
     "HP",

--- a/src/hypster/_version.py
+++ b/src/hypster/_version.py
@@ -1,0 +1,3 @@
+"""Package version."""
+
+__version__ = "0.4.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+import hypster
+
+
+def _read_pyproject_version() -> str:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    in_project_section = False
+
+    for raw_line in pyproject_path.read_text().splitlines():
+        line = raw_line.strip()
+        if line == "[project]":
+            in_project_section = True
+            continue
+        if line.startswith("[") and in_project_section:
+            break
+        if in_project_section and line.startswith("version"):
+            _, value = line.split("=", 1)
+            return value.strip().strip('"')
+
+    raise AssertionError("Could not find [project].version in pyproject.toml")
+
+
+def test_package_version_matches_pyproject():
+    assert hypster.__version__ == _read_pyproject_version()


### PR DESCRIPTION
## Summary

Removes the eager `importlib.metadata` lookup from `import hypster` by moving the package version into a lightweight `src/hypster/_version.py` module. Adds a test guardrail to keep `_version.py` synced with `[project].version` in `pyproject.toml`, plus an `AGENTS.md` note so future agents do not reintroduce the import-time metadata cost.

## Why

Profiling showed most of the top-level import cost came from resolving `__version__` through `importlib.metadata`, which pulls in a fairly large stdlib dependency graph before Hypster's own API is usable.

## Before / After

Before:

```python
from importlib.metadata import PackageNotFoundError
from importlib.metadata import version as _pkg_version

try:
    __version__ = _pkg_version(__name__)
except PackageNotFoundError:
    __version__ = "0.0.0"
```

After:

```python
from ._version import __version__
```

## Import Timing

Fresh subprocess benchmark on this branch:

```text
empty interpreter    median=  15.57 ms
import hypster       median=  35.97 ms
```

Earlier baseline measured `import hypster` at roughly 52 ms median, so this removes the eager metadata overhead while keeping `hypster.__version__ == "0.4.0"`.

## Validation

```text
uv run pytest tests/test_version.py tests/test_integrations_imports.py
2 passed
```

The commit hook also ran `ruff`, `ruff-format`, whitespace/end-of-file checks, large-file check, and `mypy`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added agent notes documenting version management procedures, including synchronization requirements and validation steps for version-related updates.

* **Refactor**
  * Simplified version resolution mechanism for improved reliability and consistency.

* **Tests**
  * Added automated validation test to ensure package version remains consistent across all version declarations within the project.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypster/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->