### PR TITLE
[codex] Fix validation and HPO edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-05-24
+
+### Fixed
+- Reject boolean values for numeric hyperparameters instead of treating `True`/`False` as integers.
+- Apply non-strict float coercion consistently for top-level and nested parameter paths.
+- Treat nested scope values such as `values={"child": ...}` as unknown unless they target a concrete child parameter.
+- Raise on unknown explicit `hp.nest(..., values=...)` child overrides instead of silently ignoring them.
+- Allow `hp.select([], allow_none=True)` to default to `None`, matching its error guidance.
+- Compute `HpoInt(include_max=False)` ranges correctly when `step` does not evenly divide the interval.
+- Reject unsupported Optuna HPO spec fields instead of silently ignoring them.
+- Validate HPO nested override values before returning them from `suggest_values()`.
+- Return helpful configuration signature errors for keyword-only `hp` parameters and callable objects.
+
 ## [0.5.0] - 2026-05-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hypster"
-version = "0.5.0"
+version = "0.5.1"
 description = "A flexible configuration system for Python projects"
 authors = [
     {name = "Gilad Rubin", email = "me@giladrubin.com"}

--- a/src/hypster/_version.py
+++ b/src/hypster/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/hypster/core.py
+++ b/src/hypster/core.py
@@ -107,7 +107,8 @@ def _run_config(
     try:
         result = func(hp, *args, **kwargs)
         called_params = hp.called_params - original_called_params
-        _handle_unknown_parameters(normalized_values, called_params, on_unknown)
+        leaf_params = called_params - hp.nested_scope_paths
+        _handle_unknown_parameters(normalized_values, leaf_params, on_unknown)
         return result
     except HPCallError as e:
         raise ValueError(str(e)) from e

--- a/src/hypster/explore.py
+++ b/src/hypster/explore.py
@@ -250,7 +250,8 @@ def explore(
         raise ValueError(str(e)) from e
 
     called_params = tracer.called_params - original_called_params
-    _handle_unknown_parameters(normalized_values, called_params, on_unknown)
+    leaf_params = called_params - tracer.nested_scope_paths
+    _handle_unknown_parameters(normalized_values, leaf_params, on_unknown)
 
     schema = tracer.build_schema(getattr(func, "__name__", func.__class__.__name__))
 

--- a/src/hypster/hp.py
+++ b/src/hypster/hp.py
@@ -73,6 +73,7 @@ class HP:
         self.namespace_stack: List[str] = []  # For nested name prefixes
         self.called_params: set[str] = set()  # Track called parameter names
         self.nested_scopes: set[str] = set()  # Track names that have been nested
+        self.nested_scope_paths: set[str] = set()  # Track nest/group paths separately from parameter leaves
 
     def _get_full_param_path(self, name: str) -> str:
         """Get full parameter path including namespace stack."""
@@ -319,7 +320,7 @@ class HP:
             )
             return option_map.get(validated_key, validated_key) if is_mapping else validated_key
         else:
-            if actual_default is None and default is _NO_DEFAULT and not option_keys:
+            if actual_default is None and default is _NO_DEFAULT and not option_keys and not allow_none:
                 raise HPCallError(
                     full_path,
                     "select has no options and no default. "
@@ -541,9 +542,11 @@ class HP:
                 nested_key = key[len(prefix) :]
                 nested_values[nested_key] = value
 
+        explicit_values = normalize_values(values) if values else {}
+
         # Merge with explicit values if provided
-        if values:
-            nested_values.update(normalize_values(values))
+        if explicit_values:
+            nested_values.update(explicit_values)
 
         # Create new HP instance for nested call with namespace
         self._record_nest(path=full_path, name=name, description=description)
@@ -551,10 +554,12 @@ class HP:
         nested_hp = self.__class__(nested_values, parameter_tracker=self.parameter_tracker)
         nested_hp.namespace_stack = self.namespace_stack + [name]
         nested_hp.called_params = self.called_params  # Share called_params tracking
+        nested_hp.nested_scope_paths = self.nested_scope_paths
 
         # Mark that we've nested under this name
         self.nested_scopes.add(name)
         self.called_params.add(full_path)
+        self.nested_scope_paths.add(full_path)
 
         # Prepare arguments
         kwargs = kwargs or {}
@@ -562,14 +567,12 @@ class HP:
         # Call the nested function
         result = child(nested_hp, *args, **kwargs)
 
-        # Track nested parameters in parent's called_params
-        nested_params = list(nested_hp.called_params)  # Create a copy to avoid iteration issues
-        for param in nested_params:
-            if "." in param:
-                self.called_params.add(param)
-            else:
-                full_nested_param = f"{full_path}.{param}"
-                self.called_params.add(full_nested_param)
+        if explicit_values:
+            from .core import _handle_unknown_parameters
+
+            prefixed_explicit_values = {f"{full_path}.{key}": value for key, value in explicit_values.items()}
+            leaf_params = self.called_params - self.nested_scope_paths
+            _handle_unknown_parameters(prefixed_explicit_values, leaf_params, "raise")
 
         return result
 

--- a/src/hypster/hp_calls.py
+++ b/src/hypster/hp_calls.py
@@ -54,6 +54,8 @@ class IntValidator(ParameterValidator):
     """Validates int parameters with optional type conversion."""
 
     def validate_value(self, value: Any, param_path: str, strict: bool = False) -> int:
+        if isinstance(value, bool):
+            raise HPCallError(param_path, f"expected int but got bool ({value})")
         if isinstance(value, float):
             if strict:
                 raise HPCallError(param_path, f"expected int but got float ({value}). Use an integer value.")
@@ -73,8 +75,10 @@ class FloatValidator(ParameterValidator):
     """Validates float parameters with optional type conversion."""
 
     def validate_value(self, value: Any, param_path: str, strict: bool = False) -> float:
+        if isinstance(value, bool):
+            raise HPCallError(param_path, f"expected float but got bool ({value})")
         if isinstance(value, int):
-            if strict or "." in param_path:
+            if strict:
                 raise HPCallError(
                     param_path,
                     f"expected float but got int ({value}). Please provide a float value like {float(value)}",

--- a/src/hypster/hpo/optuna.py
+++ b/src/hypster/hpo/optuna.py
@@ -9,8 +9,65 @@ except Exception:  # pragma: no cover
     _optuna = None
 
 from .._sentinels import NO_DEFAULT as _NO_DEFAULT
+from ..core import _handle_unknown_parameters
+from ..hp_calls import FloatValidator, IntValidator
 from ..utils import normalize_values, validate_identifier_name, validate_select_choice
 from .types import HpoCategorical, HpoFloat, HpoInt
+
+
+def _exclusive_high_for_int(low: int, high: int, step: int | None) -> int:
+    actual_step = step or 1
+    if actual_step <= 0:
+        raise ValueError("HpoInt(step=...) must be positive.")
+    if high <= low:
+        raise ValueError("HpoInt(include_max=False) leaves no valid integer values below max.")
+    return low + ((high - low - 1) // actual_step) * actual_step
+
+
+def _validate_int_spec(full: str, hpo_spec: HpoInt | None) -> None:
+    if hpo_spec is None:
+        return
+    if hpo_spec.base != 10.0:
+        raise ValueError(f"Parameter '{full}': HpoInt(base=...) is not supported by the Optuna suggest_int adapter.")
+
+
+def _float_log_flag(full: str, hpo_spec: HpoFloat | None) -> bool:
+    if hpo_spec is None:
+        return False
+    if hpo_spec.base != 10.0:
+        raise ValueError(
+            f"Parameter '{full}': HpoFloat(base=...) is not supported by the Optuna suggest_float adapter."
+        )
+    if hpo_spec.center is not None or hpo_spec.spread is not None:
+        raise ValueError(
+            f"Parameter '{full}': HpoFloat(center=..., spread=...) is only meaningful for normal/lognormal "
+            "distributions, which are not supported by the Optuna suggest_float adapter."
+        )
+    if hpo_spec.distribution in {"normal", "lognormal"}:
+        raise ValueError(
+            f"Parameter '{full}': HpoFloat(distribution={hpo_spec.distribution!r}) is not supported by the "
+            "Optuna suggest_float adapter."
+        )
+    if hpo_spec.distribution == "uniform":
+        return False
+    if hpo_spec.distribution == "loguniform":
+        return True
+    return hpo_spec.scale == "log"
+
+
+def _validate_categorical_spec(full: str, hpo_spec: HpoCategorical | None) -> None:
+    if hpo_spec is None:
+        return
+    if hpo_spec.ordered:
+        raise ValueError(
+            f"Parameter '{full}': HpoCategorical(ordered=True) is not supported by the Optuna "
+            "suggest_categorical adapter."
+        )
+    if hpo_spec.weights is not None:
+        raise ValueError(
+            f"Parameter '{full}': HpoCategorical(weights=...) is not supported by the Optuna "
+            "suggest_categorical adapter."
+        )
 
 
 class _HPProxy:
@@ -43,6 +100,7 @@ class _HPProxy:
         hpo_spec: HpoInt | None = None,
     ) -> int:
         full = self._full(name)
+        _validate_int_spec(full, hpo_spec)
         if allow_none:
             raise ValueError(
                 f"Parameter '{full}': allow_none=True is not supported for HPO numeric suggestions yet.\n\n"
@@ -58,7 +116,9 @@ class _HPProxy:
                 raise ValueError(
                     f"Parameter '{full}': None overrides are not supported for HPO numeric suggestions yet."
                 )
-            val = int(self.overrides[full])
+            validator = IntValidator()
+            val = validator.validate_value(self.overrides[full], full, strict=strict)
+            validator.validate_bounds(val, min, max, full)
             self.collector[full] = val
             return val
         low = default if min is None else min
@@ -66,7 +126,7 @@ class _HPProxy:
         step = hpo_spec.step if hpo_spec else None
         log = (hpo_spec.scale == "log") if hpo_spec else False
         if hpo_spec and not hpo_spec.include_max and high is not None:
-            high = high - (step or 1)
+            high = _exclusive_high_for_int(low, high, step)
         val = self.trial.suggest_int(full, low, high, step=step, log=log)
         self.collector[full] = val
         return val
@@ -84,6 +144,7 @@ class _HPProxy:
         hpo_spec: HpoFloat | None = None,
     ) -> float:
         full = self._full(name)
+        log = _float_log_flag(full, hpo_spec)
         if allow_none:
             raise ValueError(
                 f"Parameter '{full}': allow_none=True is not supported for HPO numeric suggestions yet.\n\n"
@@ -99,13 +160,14 @@ class _HPProxy:
                 raise ValueError(
                     f"Parameter '{full}': None overrides are not supported for HPO numeric suggestions yet."
                 )
-            val = float(self.overrides[full])
+            validator = FloatValidator()
+            val = validator.validate_value(self.overrides[full], full, strict=strict)
+            validator.validate_bounds(val, min, max, full)
             self.collector[full] = val
             return val
         low = default if min is None else min
         high = default if max is None else max
         step = hpo_spec.step if hpo_spec else None
-        log = (hpo_spec.scale == "log") if hpo_spec else False
         val = self.trial.suggest_float(full, low, high, step=step, log=log)
         self.collector[full] = val
         return val
@@ -122,6 +184,7 @@ class _HPProxy:
         hpo_spec: HpoCategorical | None = None,
     ) -> Any:
         full = self._full(name)
+        _validate_categorical_spec(full, hpo_spec)
         if isinstance(options, Mapping):
             keys = list(options.keys())
         else:
@@ -168,13 +231,18 @@ class _HPProxy:
     ) -> Any:
         validate_identifier_name(name, kind="nest name")
         overrides = dict(self.overrides)
+        prefixed_values = {}
         if values:
             flat = normalize_values(values)
             for k, v in flat.items():
-                overrides[f"{self._full(name)}.{k}"] = v
+                prefixed_key = f"{self._full(name)}.{k}"
+                overrides[prefixed_key] = v
+                prefixed_values[prefixed_key] = v
         nested = _HPProxy(self.trial, self.collector, ns=self.ns + [name], overrides=overrides)
         kwargs = kwargs or {}
-        return child(nested, *args, **kwargs)
+        result = child(nested, *args, **kwargs)
+        _handle_unknown_parameters(prefixed_values, set(self.collector), "raise")
+        return result
 
 
 def suggest_values(trial: Any, *, config, args: tuple = (), kwargs: Dict[str, Any] | None = None) -> Dict[str, Any]:

--- a/src/hypster/utils.py
+++ b/src/hypster/utils.py
@@ -34,6 +34,10 @@ def validate_config_func_signature(func: Callable) -> None:
     _validate_config_func_signature_cached(func)
 
 
+def _callable_display_name(func: Callable) -> str:
+    return getattr(func, "__name__", func.__class__.__name__)
+
+
 @lru_cache(maxsize=1024)
 def _validate_config_func_signature_cached(func: Callable) -> None:
     """Cached signature validation for repeat executions of the same config."""
@@ -42,20 +46,25 @@ def _validate_config_func_signature_cached(func: Callable) -> None:
 
 def _validate_config_func_signature_uncached(func: Callable) -> None:
     """Validate a config function signature without assuming hashability."""
+    func_name = _callable_display_name(func)
     try:
         sig = inspect.signature(func)
         params = list(sig.parameters.values())
 
         if not params:
             raise ValueError(
-                f"Configuration function '{func.__name__}' must have 'hp: HP' as first parameter. "
-                f"Got: {func.__name__}() - no parameters"
+                f"Configuration function '{func_name}' must have 'hp: HP' as first parameter. "
+                f"Got: {func_name}() - no parameters"
             )
 
         first_param = params[0]
         if first_param.name != "hp":
             raise ValueError(
-                f"Configuration function '{func.__name__}' first param must be named 'hp'. Got: {first_param.name}"
+                f"Configuration function '{func_name}' first param must be named 'hp'. Got: {first_param.name}"
+            )
+        if first_param.kind is inspect.Parameter.KEYWORD_ONLY:
+            raise ValueError(
+                f"Configuration function '{func_name}' first param 'hp' must be positional so Hypster can pass it."
             )
 
         # Check type annotation if present
@@ -64,14 +73,14 @@ def _validate_config_func_signature_uncached(func: Callable) -> None:
             annotation_str = str(first_param.annotation)
             if "HP" not in annotation_str:
                 raise ValueError(
-                    f"Configuration function '{func.__name__}' first parameter must be typed as 'hp: HP'. "
+                    f"Configuration function '{func_name}' first parameter must be typed as 'hp: HP'. "
                     f"Got: hp: {annotation_str}"
                 )
 
     except Exception as e:
         if isinstance(e, ValueError):
             raise
-        raise ValueError(f"Error validating configuration function '{func.__name__}': {str(e)}")
+        raise ValueError(f"Error validating configuration function '{func_name}': {str(e)}")
 
 
 def validate_identifier_name(name: Any, *, kind: str = "name") -> str:

--- a/tests/test_basic_parameters.py
+++ b/tests/test_basic_parameters.py
@@ -160,3 +160,28 @@ def test_none_requires_allow_none_for_scalar_params() -> None:
 
     with pytest.raises(ValueError, match="allow_none=True"):
         instantiate(none_override, values={"temperature": None})
+
+
+def test_numeric_parameters_reject_bool_values() -> None:
+    """Boolean values should not be treated as numeric values."""
+
+    def config(hp: HP) -> Dict[str, object]:
+        return {
+            "depth": hp.int(1, name="depth"),
+            "strict_depth": hp.int(1, name="strict_depth", strict=True),
+            "temperature": hp.float(0.1, name="temperature"),
+            "depths": hp.multi_int([1], name="depths"),
+            "temperatures": hp.multi_float([0.1], name="temperatures"),
+        }
+
+    invalid_values = [
+        {"depth": True},
+        {"strict_depth": True},
+        {"temperature": False},
+        {"depths": [True]},
+        {"temperatures": [False]},
+    ]
+
+    for values in invalid_values:
+        with pytest.raises(ValueError, match="expected .* but got bool"):
+            instantiate(config, values=values)

--- a/tests/test_function_signature.py
+++ b/tests/test_function_signature.py
@@ -44,3 +44,25 @@ def test_extra_args_allowed() -> None:
 
     result = instantiate(config, kwargs={"multiplier": 3})
     assert result == 30
+
+
+def test_keyword_only_hp_is_rejected_during_signature_validation() -> None:
+    calls = []
+
+    def bad_config(*, hp: HP) -> int:
+        calls.append("executed")
+        return hp.int(10, name="value")
+
+    with pytest.raises(ValueError, match="positional"):
+        instantiate(bad_config)
+
+    assert calls == []
+
+
+def test_callable_object_signature_errors_use_class_name() -> None:
+    class BadConfig:
+        def __call__(self) -> int:
+            return 10
+
+    with pytest.raises(ValueError, match="BadConfig"):
+        instantiate(BadConfig())

--- a/tests/test_hpo_optuna_edge.py
+++ b/tests/test_hpo_optuna_edge.py
@@ -2,7 +2,7 @@ import pytest
 
 from hypster import HP
 from hypster.hpo.optuna import suggest_values
-from hypster.hpo.types import HpoInt
+from hypster.hpo.types import HpoCategorical, HpoFloat, HpoInt
 
 
 class TrialSpy:
@@ -34,6 +34,18 @@ def test_include_max_reduces_high():
     assert high == 8
 
 
+def test_include_max_false_keeps_largest_valid_stepped_value_below_max():
+    def config(hp: HP):
+        return hp.int(0, name="n", min=0, max=10, hpo_spec=HpoInt(step=3, include_max=False))
+
+    t = TrialSpy()
+    values = suggest_values(t, config=config)
+
+    assert values["n"] == 0
+    name, low, high, step, log = t.calls[0]
+    assert (name, low, high, step, log) == ("n", 0, 9, 3, False)
+
+
 def test_hpo_proxy_rejects_invalid_names_and_nullable_numeric_params():
     def bad_name(hp: HP):
         return hp.int(1, name="bad-name")
@@ -58,3 +70,53 @@ def test_hpo_proxy_rejects_complex_select_choices_with_dict_guidance():
 
     with pytest.raises(ValueError, match="Use dict-backed select"):
         suggest_values(CategoricalTrial(), config=config)
+
+
+def test_hpo_proxy_rejects_unsupported_optuna_spec_fields_instead_of_ignoring_them():
+    def int_with_custom_log_base(hp: HP):
+        return hp.int(1, name="depth", min=1, max=16, hpo_spec=HpoInt(scale="log", base=2.0))
+
+    with pytest.raises(ValueError, match="base"):
+        suggest_values(TrialSpy(), config=int_with_custom_log_base)
+
+    def normal_float(hp: HP):
+        return hp.float(
+            1.0,
+            name="lr",
+            min=0.001,
+            max=1.0,
+            hpo_spec=HpoFloat(distribution="normal", center=0.1, spread=0.01),
+        )
+
+    with pytest.raises(ValueError, match="normal"):
+        suggest_values(TrialSpy(), config=normal_float)
+
+    def weighted_categorical(hp: HP):
+        return hp.select(["a", "b"], name="choice", hpo_spec=HpoCategorical(weights=[0.9, 0.1]))
+
+    with pytest.raises(ValueError, match="weights"):
+        suggest_values(TrialSpy(), config=weighted_categorical)
+
+
+def test_hpo_nested_overrides_are_validated_like_instantiation_values():
+    def config(hp: HP):
+        return hp.nest(
+            lambda hp: hp.int(0, name="depth", min=0, max=10, hpo_spec=HpoInt()),
+            name="tree",
+            values={"depth": 999},
+        )
+
+    with pytest.raises(ValueError, match="exceeds maximum bound 10"):
+        suggest_values(TrialSpy(), config=config)
+
+
+def test_hpo_nested_overrides_raise_for_unknown_child_parameters():
+    def config(hp: HP):
+        return hp.nest(
+            lambda hp: hp.int(0, name="depth", min=0, max=10, hpo_spec=HpoInt()),
+            name="tree",
+            values={"typo": 3},
+        )
+
+    with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
+        suggest_values(TrialSpy(), config=config)

--- a/tests/test_more_coverage.py
+++ b/tests/test_more_coverage.py
@@ -4,13 +4,22 @@ from hypster import HP, instantiate
 from hypster.hp_calls import ParameterValidator
 
 
-def test_float_strict_nested_path_error():
+def test_nested_float_accepts_int_when_not_strict():
     def cfg(hp: HP):
-        return {"x": hp.nest(lambda hp: hp.float(1.0, name="lr"), name="model")}
+        def child(hp: HP):
+            return {
+                "lr": hp.float(1.0, name="lr"),
+                "lrs": hp.multi_float([1.0], name="lrs"),
+            }
 
-    # int value at nested path should trigger FloatValidator branch with "." in path
-    with pytest.raises(ValueError, match="expected float but got int"):
-        instantiate(cfg, values={"model.lr": 1})
+        return {"x": hp.nest(child, name="model")}
+
+    assert instantiate(cfg, values={"model.lr": 1, "model.lrs": [2]}) == {
+        "x": {
+            "lr": 1.0,
+            "lrs": [2.0],
+        }
+    }
 
 
 def test_select_multi_non_list_error():

--- a/tests/test_nesting.py
+++ b/tests/test_nesting.py
@@ -4,7 +4,8 @@ from typing import Any, Dict
 
 import pytest
 
-from hypster import HP, instantiate
+from hypster import HP, instantiate, instantiate_with_params
+from hypster.explore import explore
 
 
 def test_basic_nesting() -> None:
@@ -104,3 +105,34 @@ def test_nested_values_keys_must_be_identifier_segments() -> None:
 
     with pytest.raises(ValueError, match="nested values key"):
         instantiate(parent, values={"child": {"x.y": 100}})
+
+
+def test_nested_scope_value_is_not_a_parameter_leaf() -> None:
+    def child(hp: HP) -> Dict[str, int]:
+        return {"x": hp.int(10, name="x")}
+
+    def parent(hp: HP) -> Dict[str, int]:
+        return hp.nest(child, name="child")
+
+    with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
+        instantiate(parent, values={"child": 123})
+
+    with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
+        instantiate_with_params(parent, values={"child": 123})
+
+    with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
+        explore(parent, values={"child": 123}, return_info=True)
+
+
+def test_explicit_nested_values_raise_for_unknown_child_parameters() -> None:
+    def child(hp: HP) -> Dict[str, int]:
+        return {"x": hp.int(10, name="x")}
+
+    def parent(hp: HP) -> Dict[str, int]:
+        return hp.nest(child, name="child", values={"typo": 100})
+
+    with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
+        instantiate(parent)
+
+    with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
+        explore(parent, return_info=True)

--- a/tests/test_select_parameters.py
+++ b/tests/test_select_parameters.py
@@ -142,6 +142,13 @@ def test_select_none_choice_requires_allow_none() -> None:
         instantiate(missing_allow_none)
 
 
+def test_select_with_no_options_can_default_to_none_when_nullable() -> None:
+    def config(hp: HP) -> object:
+        return hp.select([], name="choice", allow_none=True)
+
+    assert instantiate(config) is None
+
+
 def test_select_rejects_complex_list_options_with_dict_guidance() -> None:
     def config(hp: HP) -> object:
         return hp.select([{"layers": 2}, {"layers": 4}], name="model")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -42,14 +42,14 @@ def test_type_mismatch_with_context() -> None:
     """Test type mismatch errors include full path context."""
 
     def optimizer(hp: HP) -> Dict[str, float]:
-        lr = hp.float(0.1, name="lr")
+        lr = hp.float(0.1, name="lr", strict=True)
         return {"lr": lr}
 
     def config(hp: HP) -> Dict[str, Dict[str, float]]:
         opt = hp.nest(optimizer, name="optimizer")
         return {"optimizer": opt}
 
-    # Integer provided for float in nested context
+    # Integer provided for strict float in nested context
     with pytest.raises(ValueError, match="Parameter 'optimizer.lr': expected float but got int"):
         instantiate(config, values={"optimizer.lr": 1})
 

--- a/uv.lock
+++ b/uv.lock
@@ -388,7 +388,7 @@ wheels = [
 
 [[package]]
 name = "hypster"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Fixes the validation/HPO bug sweep from the Hypster bug hunt:

- Rejects booleans for numeric parameters and makes non-strict float coercion consistent for nested paths.
- Treats nested scope values as groups, not parameter leaves, and validates explicit `hp.nest(..., values=...)` overrides.
- Lets `hp.select([], allow_none=True)` default to `None`.
- Fixes Optuna `HpoInt(include_max=False)` stepped ranges.
- Rejects unsupported Optuna HPO spec fields instead of silently ignoring them.
- Validates HPO nested overrides before `suggest_values()` returns.
- Improves config signature validation for keyword-only `hp` and callable object errors.
- Bumps package version to `0.5.1`.

## Docs Follow-Up

`DOCS_BUGFIX_GUIDE.md` is intentionally local-only and untracked. It includes the docs-pass note that `explore()` executes the config function to discover the active branch, so constructors, API calls, resource initialization, and other side effects in reached code paths can run during exploration.

## Before / After

```python
# Before
instantiate(config, values={"depth": True})
# => True

# After
instantiate(config, values={"depth": True})
# => ValueError: expected int but got bool
```

```python
# Before
instantiate(parent, values={"child": 123})
# => silently ignored

# After
instantiate(parent, values={"child": 123})
# => ValueError: Unknown or unreachable parameters
```

```python
# Before
suggest_values(trial, config=bad_hpo_override)
# => {"tree.depth": 999}; instantiate later fails

# After
suggest_values(trial, config=bad_hpo_override)
# => ValueError before returning invalid values
```

## Validation

- `uv run pytest tests/test_version.py`
- `uv run pytest` (`108 passed`)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/hypster`
