### PR TITLE
Schedule weekly dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+multi-ecosystem-groups:
+  weekly-dependencies:
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+      timezone: "Etc/UTC"
+    labels:
+      - "dependencies"
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "weekly-dependencies"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "weekly-dependencies"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Add a Dependabot config that batches `uv` and GitHub Actions updates into one weekly multi-ecosystem group.
- Schedule the weekly check for Monday 02:00 UTC with a 7-day cooldown for new releases.
- Pair it with the Codex app automation `hypster-dependency-pr-curator`, which is scheduled separately to run afterward and prepare curated dependency PRs.

## Before / After
Before:
```yaml
# no .github/dependabot.yml
```

After:
```yaml
multi-ecosystem-groups:
  weekly-dependencies:
    schedule:
      interval: "weekly"
      day: "monday"
      time: "02:00"
      timezone: "Etc/UTC"

updates:
  - package-ecosystem: "uv"
  - package-ecosystem: "github-actions"
```

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml')"`\n- `uv run pre-commit run --files .github/dependabot.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency management configuration to enable automated update checks for project dependencies on a weekly schedule.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypster/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->