### PR TITLE
[codex] Update docs model examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,15 +110,32 @@ from hypster.hpo.types import HpoFloat, HpoInt
 
 
 def model_cfg(hp: HP):
-    family = hp.select(["linear", "forest"], name="family", default="forest", options_only=True)
+    family = hp.select(
+        ["linear", "forest"],
+        name="family",
+        default="forest",
+        options_only=True,
+    )
     if family == "linear":
         return {
             "family": family,
-            "alpha": hp.float(0.1, name="alpha", min=1e-4, max=10.0, hpo_spec=HpoFloat(scale="log")),
+            "alpha": hp.float(
+                0.1,
+                name="alpha",
+                min=1e-4,
+                max=10.0,
+                hpo_spec=HpoFloat(scale="log"),
+            ),
         }
     return {
         "family": family,
-        "n_estimators": hp.int(200, name="n_estimators", min=50, max=1000, hpo_spec=HpoInt(step=50)),
+        "n_estimators": hp.int(
+            200,
+            name="n_estimators",
+            min=50,
+            max=1000,
+            hpo_spec=HpoInt(step=50),
+        ),
     }
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Hypster configs are pure Python functions, not a separate DSL. You can use norma
 
 ## First Example
 
+{% code overflow="wrap" %}
 ```python
 from dataclasses import dataclass
 from hypster import HP, explore, instantiate_with_params
@@ -68,6 +69,7 @@ run = instantiate_with_params(
 print(run.value)
 print(run.params)
 ```
+{% endcode %}
 
 The output value is the typed runtime object you use in your application. The `params` sidecar is the replayable record of every parameter Hypster selected on that run, including defaults.
 
@@ -83,15 +85,19 @@ The output value is the typed runtime object you use in your application. The `p
 
 ## Install
 
+{% code overflow="wrap" %}
 ```bash
 uv add hypster
 ```
+{% endcode %}
 
 For Optuna support:
 
+{% code overflow="wrap" %}
 ```bash
 uv add 'hypster[optuna]'
 ```
+{% endcode %}
 
 ## Where To Go Next
 

--- a/docs/adr/0001-strict-unknown-values.md
+++ b/docs/adr/0001-strict-unknown-values.md
@@ -11,6 +11,7 @@ Hypster treats `values` as a reproducibility surface, so unknown or unreachable 
 
 ## Example
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
 
@@ -23,5 +24,6 @@ def config(hp: HP):
 instantiate(config, values={"branch": "b", "x": 10})
 # ValueError: Unknown or unreachable parameters
 ```
+{% endcode %}
 
 `x` is a real parameter, but it is not reachable on the selected branch. Raising by default prevents a run from looking as though it used `x=10` when that value had no effect.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -4,6 +4,7 @@ Use these examples as copyable shapes for real projects. Each page focuses on on
 
 Hypster config functions are plain Python functions:
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP
 
@@ -11,6 +12,7 @@ def config(hp: HP):
     mode = hp.select(["fast", "accurate"], name="mode", default="fast")
     return {"mode": mode}
 ```
+{% endcode %}
 
 The same function can serve several jobs:
 
@@ -33,6 +35,7 @@ The same function can serve several jobs:
 
 ## A Small End-to-End Pattern
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, explore, instantiate_with_params
 
@@ -56,6 +59,7 @@ run = instantiate_with_params(
 assert run.value == {"stage": "full", "sample_rows": 250_000}
 assert run.params == {"stage": "full", "sample_rows": 250_000}
 ```
+{% endcode %}
 
 {% hint style="info" %}
 Hypster raises when `values=` includes unknown parameters or parameters from a branch that was not reached. That default protects replayability. Use `explore(config, values=...)` to inspect the branch you are about to run.

--- a/docs/examples/ai-workflows.md
+++ b/docs/examples/ai-workflows.md
@@ -4,6 +4,7 @@ Hypster is useful when an AI workflow needs to switch providers, retrieval modes
 
 ## Provider Configs
 
+{% code overflow="wrap" %}
 ```python
 from dataclasses import dataclass
 from hypster import HP, explore, instantiate_with_params
@@ -18,7 +19,12 @@ class ProviderConfig:
 def openai_config(hp: HP) -> ProviderConfig:
     return ProviderConfig(
         provider="openai",
-        model=hp.select(["gpt-4o-mini", "gpt-4.1"], name="model", default="gpt-4o-mini", options_only=True),
+        model=hp.select(
+            ["gpt-5.4-mini", "gpt-5.5"],
+            name="model",
+            default="gpt-5.4-mini",
+            options_only=True,
+        ),
         temperature=hp.float(0.2, name="temperature", min=0.0, max=2.0),
         max_tokens=hp.int(1024, name="max_tokens", min=1, max=16_384),
     )
@@ -26,16 +32,23 @@ def openai_config(hp: HP) -> ProviderConfig:
 def gemini_config(hp: HP) -> ProviderConfig:
     return ProviderConfig(
         provider="gemini",
-        model=hp.select(["flash-lite", "pro"], name="model", default="flash-lite", options_only=True),
+        model=hp.select(
+            ["gemini-3.5-flash", "gemini-3.1-pro-preview"],
+            name="model",
+            default="gemini-3.5-flash",
+            options_only=True,
+        ),
         temperature=hp.float(0.3, name="temperature", min=0.0, max=2.0),
         max_tokens=hp.int(2048, name="max_tokens", min=1, max=16_384),
     )
 ```
+{% endcode %}
 
 ## RAG And Output Settings
 
 Use dict-backed `select` when the runtime value is complex. The parameter records the simple key, while your app receives the mapped object.
 
+{% code overflow="wrap" %}
 ```python
 def retrieval_config(hp: HP):
     retriever = hp.select(
@@ -61,9 +74,11 @@ def output_config(hp: HP):
         "system_prompt": hp.text("Answer with concise, sourced reasoning.", name="system_prompt"),
     }
 ```
+{% endcode %}
 
 ## Compose The Workflow
 
+{% code overflow="wrap" %}
 ```python
 def qa_workflow_config(hp: HP):
     provider = hp.select(["openai", "gemini"], name="provider", default="openai", options_only=True)
@@ -80,9 +95,11 @@ def qa_workflow_config(hp: HP):
         "output": hp.nest(output_config, name="output"),
     }
 ```
+{% endcode %}
 
 ## Explore And Replay
 
+{% code overflow="wrap" %}
 ```python
 explore(
     qa_workflow_config,
@@ -93,7 +110,7 @@ run = instantiate_with_params(
     qa_workflow_config,
     values={
         "provider": "gemini",
-        "gemini.model": "pro",
+        "gemini.model": "gemini-3.1-pro-preview",
         "gemini.temperature": 0.1,
         "retrieval.retriever": "vector",
         "output.format": "markdown",
@@ -101,15 +118,17 @@ run = instantiate_with_params(
 )
 
 assert run.params["provider"] == "gemini"
-assert run.params["gemini.model"] == "pro"
+assert run.params["gemini.model"] == "gemini-3.1-pro-preview"
 assert run.params["retrieval.retriever"] == "vector"
 assert run.value["retrieval"]["retriever"]["kind"] == "dense"
 ```
+{% endcode %}
 
 ## Branch Safety
 
 This raises by default because `openai.temperature` is unreachable when the `gemini` branch is selected:
 
+{% code overflow="wrap" %}
 ```python
 from hypster import instantiate
 
@@ -118,5 +137,6 @@ instantiate(
     values={"provider": "gemini", "openai.temperature": 0.7},
 )
 ```
+{% endcode %}
 
 Run `explore(qa_workflow_config, values={"provider": "gemini"})` before instantiation to inspect the reachable parameter paths for that branch.

--- a/docs/examples/data-processing.md
+++ b/docs/examples/data-processing.md
@@ -4,6 +4,7 @@ Data pipelines often mix environment choices, schema decisions, cleaning rules, 
 
 ## Configure The Pipeline
 
+{% code overflow="wrap" %}
 ```python
 from dataclasses import dataclass
 from hypster import HP, explore, instantiate
@@ -65,9 +66,11 @@ def data_pipeline_config(hp: HP):
         "export": hp.nest(export_config, name="export"),
     }
 ```
+{% endcode %}
 
 ## Explore A Production Branch
 
+{% code overflow="wrap" %}
 ```python
 explore(
     data_pipeline_config,
@@ -78,9 +81,11 @@ explore(
     },
 )
 ```
+{% endcode %}
 
 ## Instantiate A Run
 
+{% code overflow="wrap" %}
 ```python
 cfg = instantiate(
     data_pipeline_config,
@@ -100,6 +105,7 @@ assert cfg["mode"] == "full"
 assert cfg["input"].path.startswith("s3://")
 assert cfg["cleaning"].fill_missing_numeric == 0.0
 ```
+{% endcode %}
 
 ## Why This Shape Works
 

--- a/docs/examples/experiment-tracking.md
+++ b/docs/examples/experiment-tracking.md
@@ -4,6 +4,7 @@ Use `instantiate_with_params()` when you need both the runtime object and the ex
 
 ## Capture The Value And Params
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate, instantiate_with_params
 
@@ -44,13 +45,16 @@ assert run.params == {
 }
 assert instantiate(model_config, values=run.params) == run.value
 ```
+{% endcode %}
 
 ## Log Params In Your Tracker
 
+{% code overflow="wrap" %}
 ```python
 def log_to_tracker(tracker, run):
     for path, value in run.params.items():
         tracker.log_param(path, value)
 ```
+{% endcode %}
 
 The important detail is that `run.params` contains defaulted values as well as user overrides. That makes it suitable for exact replay.

--- a/docs/examples/interactive-ui.md
+++ b/docs/examples/interactive-ui.md
@@ -6,6 +6,7 @@ The public schema hook is `explore(config, return_info=True)`: it returns metada
 
 ## Turn A Config Into Field Metadata
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, explore, instantiate
 
@@ -36,11 +37,13 @@ fields = flatten_parameters(schema.to_dict()["parameters"])
 for field in fields:
     print(field["path"], field["kind"], field["selected_value"])
 ```
+{% endcode %}
 
 ## Feed UI State Back Into Hypster
 
 Your UI state should be a dictionary whose keys are Hypster parameter paths:
 
+{% code overflow="wrap" %}
 ```python
 ui_values = {
     "provider": "remote",
@@ -56,6 +59,7 @@ assert schema.defaults()["provider"] == "local"
 assert cfg["provider"] == "remote"
 assert cfg["timeout"] == 30.0
 ```
+{% endcode %}
 
 ## Control Mapping
 
@@ -73,6 +77,7 @@ assert cfg["timeout"] == 30.0
 
 This is the adapter shape. It assumes you already installed Streamlit and are running inside a Streamlit app.
 
+{% code overflow="wrap" %}
 ```python
 def render_field(st, field):
     path = field["path"]
@@ -93,5 +98,6 @@ def render_field(st, field):
 
     raise ValueError(f"Unsupported field kind: {kind}")
 ```
+{% endcode %}
 
 For conditional UIs, rerun `explore(config, values=current_ui_values, return_info=True)` whenever a branch-selecting value changes. That keeps the rendered fields aligned with the active branch.

--- a/docs/examples/machine-learning.md
+++ b/docs/examples/machine-learning.md
@@ -4,6 +4,7 @@ This example shows the recommended ML shape: each Hypster config returns an init
 
 ## Define Model Factories
 
+{% code overflow="wrap" %}
 ```python
 from sklearn.base import ClassifierMixin
 from sklearn.ensemble import RandomForestClassifier
@@ -34,9 +35,11 @@ def forest_model(hp: HP) -> RandomForestClassifier:
         random_state=random_state,
     )
 ```
+{% endcode %}
 
 ## Choose The Active Model
 
+{% code overflow="wrap" %}
 ```python
 def classifier_config(hp: HP) -> ClassifierMixin:
     model_family = hp.select(["logistic", "forest"], name="model_family", default="forest", options_only=True)
@@ -46,11 +49,13 @@ def classifier_config(hp: HP) -> ClassifierMixin:
 
     return hp.nest(forest_model, name="forest")
 ```
+{% endcode %}
 
 The config returns a ready-to-use classifier, not a dictionary that must be assembled later.
 
 ## Explore And Instantiate
 
+{% code overflow="wrap" %}
 ```python
 explore(classifier_config)
 
@@ -66,9 +71,11 @@ run = instantiate_with_params(
 model = run.value
 params = run.params
 ```
+{% endcode %}
 
 Expected selected params:
 
+{% code overflow="wrap" %}
 ```python
 {
     "model_family": "forest",
@@ -78,6 +85,7 @@ Expected selected params:
     "forest.random_state": 42,
 }
 ```
+{% endcode %}
 
 Use `model.fit(X_train, y_train)` in your training code after instantiation. Keep training itself outside the config function so `explore()`, HPO, and UI generation stay fast.
 
@@ -85,6 +93,7 @@ Use `model.fit(X_train, y_train)` in your training code after instantiation. Kee
 
 For larger experiments, nest preprocessing, training, and model configs under one parent. Each nested config owns one part of the workflow, while the selected params remain a flat replayable dictionary.
 
+{% code overflow="wrap" %}
 ```python
 from dataclasses import dataclass
 
@@ -150,6 +159,7 @@ assert isinstance(run.value.model, RandomForestClassifier)
 assert run.params["preprocessing.scaler"] == "robust"
 assert run.params["model.forest.n_estimators"] == 500
 ```
+{% endcode %}
 
 Use `run.value.preprocessing` to build your feature transformer, `run.value.model` as the initialized estimator, and `run.params` as the exact experiment record.
 
@@ -157,6 +167,7 @@ Use `run.value.preprocessing` to build your feature transformer, `run.value.mode
 
 Add `hpo_spec=` where search semantics matter. Normal instantiation ignores these specs; the Optuna adapter consumes them.
 
+{% code overflow="wrap" %}
 ```python
 from hypster.hpo.types import HpoFloat, HpoInt
 
@@ -193,5 +204,6 @@ def regularized_logistic(hp: HP) -> LogisticRegression:
 
     return LogisticRegression(C=C, max_iter=1000)
 ```
+{% endcode %}
 
 See [Perform Hyperparameter Optimization](../how-to/perform-hyperparameter-optimization.md) for the Optuna objective pattern.

--- a/docs/examples/nested-workflows.md
+++ b/docs/examples/nested-workflows.md
@@ -4,6 +4,7 @@ Use `hp.nest()` to split a large workflow into smaller config functions. Nested 
 
 ## A Deeply Nested Training Workflow
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, explore, instantiate
 
@@ -35,9 +36,11 @@ def experiment_config(hp: HP):
     trainer = hp.nest(trainer_config, name="trainer", kwargs={"epochs_default": 20})
     return {"dataset": dataset, "trainer": trainer}
 ```
+{% endcode %}
 
 ## Override Nested Values
 
+{% code overflow="wrap" %}
 ```python
 cfg = instantiate(
     experiment_config,
@@ -52,9 +55,11 @@ cfg = instantiate(
 assert cfg["trainer"]["optimizer"]["algorithm"] == "sgd"
 assert cfg["trainer"]["optimizer"]["momentum"] == 0.95
 ```
+{% endcode %}
 
 The same values can be expressed as nested dictionaries:
 
+{% code overflow="wrap" %}
 ```python
 cfg = instantiate(
     experiment_config,
@@ -70,16 +75,19 @@ cfg = instantiate(
     },
 )
 ```
+{% endcode %}
 
 Do not provide both spellings for the same final parameter path. Hypster raises duplicate-path errors so logs and replays stay unambiguous.
 
 ## Explore A Nested Branch
 
+{% code overflow="wrap" %}
 ```python
 explore(
     experiment_config,
     values={"trainer.optimizer.algorithm": "sgd"},
 )
 ```
+{% endcode %}
 
 The printed tree includes only the active optimizer branch, so you can see that `momentum` is reachable and `beta1` is not.

--- a/docs/getting-started/defining-a-configuration-space.md
+++ b/docs/getting-started/defining-a-configuration-space.md
@@ -2,12 +2,14 @@
 
 A Hypster configuration space is an ordinary Python function whose first argument is named `hp`. It is not a DSL or a separate config file format: use normal Python control flow, lists, helper functions, imports, dataclasses, and object construction.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP
 
 def config(hp: HP):
     ...
 ```
+{% endcode %}
 
 `hp` must be the first positional parameter; keyword-only `hp` is rejected before the config executes. The `hp: HP` annotation is recommended, but unannotated config functions are still valid.
 
@@ -19,6 +21,7 @@ Because Hypster discovers available parameters by running this function, keep co
 
 Use `hp.*` calls for values that should be visible, overrideable, replayable, searchable, or rendered in a UI.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP
 
@@ -33,6 +36,7 @@ def llm_config(hp: HP):
         "max_tokens": max_tokens,
     }
 ```
+{% endcode %}
 
 Every public parameter needs an explicit `name=...`. Names must be valid Python identifiers, so use `batch_size`, not `batch-size` or `model.learning_rate`.
 
@@ -40,6 +44,7 @@ Every public parameter needs an explicit `name=...`. Names must be valid Python 
 
 Hypster is define-by-run. Only parameters touched by the active branch are selected for that run.
 
+{% code overflow="wrap" %}
 ```python
 def model_config(hp: HP):
     family = hp.select(["linear", "forest"], name="family", default="forest", options_only=True)
@@ -56,6 +61,7 @@ def model_config(hp: HP):
         "max_depth": hp.int(None, name="max_depth", min=1, max=100, allow_none=True),
     }
 ```
+{% endcode %}
 
 If `family="linear"`, `n_estimators` and `max_depth` are unreachable. Hypster raises if you pass values for inactive branches.
 
@@ -65,6 +71,7 @@ This define-by-run model is what makes normal Python branches work: Hypster runs
 
 Split large configs into smaller functions and compose them with `hp.nest()`.
 
+{% code overflow="wrap" %}
 ```python
 def optimizer_config(hp: HP):
     return {
@@ -78,17 +85,21 @@ def training_config(hp: HP):
         "optimizer": hp.nest(optimizer_config, name="optimizer"),
     }
 ```
+{% endcode %}
 
 Nested parameters use dotted paths in `values=`:
 
+{% code overflow="wrap" %}
 ```python
 {"optimizer.learning_rate": 0.01}
 ```
+{% endcode %}
 
 ## Use Dict-Backed Selects For Complex Values
 
 Select choices must be logging-safe scalars. If the runtime value is complex, map a simple key to it:
 
+{% code overflow="wrap" %}
 ```python
 def architecture_config(hp: HP):
     return hp.select(
@@ -101,6 +112,7 @@ def architecture_config(hp: HP):
         options_only=True,
     )
 ```
+{% endcode %}
 
 Your config receives the mapped dictionary, while `instantiate_with_params()` records the key. Add `options_only=True` when values outside the mapping should be rejected.
 
@@ -108,6 +120,7 @@ Your config receives the mapped dictionary, while `instantiate_with_params()` re
 
 It is often best to let a config return the initialized object your application will use:
 
+{% code overflow="wrap" %}
 ```python
 from sklearn.ensemble import RandomForestClassifier
 from hypster import HP
@@ -122,6 +135,7 @@ def classifier_config(hp: HP) -> RandomForestClassifier:
         random_state=42,
     )
 ```
+{% endcode %}
 
 {% hint style="info" %}
 Initialized in-memory objects are a good fit when construction is cheap. For SDK clients, remote retrievers, loaded indexes, database handles, training jobs, or writes, return lightweight settings and build the side-effectful object after `instantiate()`. See [Best Practices](../in-depth/basic-best-practices.md).

--- a/docs/getting-started/exploring-a-configuration-space.md
+++ b/docs/getting-started/exploring-a-configuration-space.md
@@ -6,6 +6,7 @@ That execution should be cheap and safe. Keep side effects, paid API calls, data
 
 ## Print The Parameter Tree
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, explore
 
@@ -33,9 +34,11 @@ def app_config(hp: HP):
 
 explore(app_config)
 ```
+{% endcode %}
 
 Expected output:
 
+{% code overflow="wrap" %}
 ```text
 app_config
 ├── backend: select = "local"  (options: ["local", "remote"])
@@ -43,20 +46,24 @@ app_config
     ├── threads: int = 4  (1-64)
     └── cache: bool = True
 ```
+{% endcode %}
 
 ## Explore A Different Conditional Branch
 
 Pass `values=` to choose a branch before tracing it:
 
+{% code overflow="wrap" %}
 ```python
 explore(
     app_config,
     values={"backend": "remote", "remote.timeout": 30.0},
 )
 ```
+{% endcode %}
 
 Expected output:
 
+{% code overflow="wrap" %}
 ```text
 app_config
 ├── backend: select = "remote"  (options: ["local", "remote"])
@@ -64,22 +71,26 @@ app_config
     ├── endpoint: text = "https://api.example.com"
     └── timeout: float = 30.0  (0.1-120.0)
 ```
+{% endcode %}
 
 ## Get Structured Metadata
 
 Use `return_info=True` when you want to inspect the schema in code:
 
+{% code overflow="wrap" %}
 ```python
 info = explore(app_config, return_info=True)
 
 print(info.defaults())
 print(info.to_dict())
 ```
+{% endcode %}
 
 For programmatic inspection before instantiation, use `schema = explore(config, return_info=True)` and read `schema.to_dict()["parameters"]`. Use plain `explore(config)` when a printed tree is enough.
 
 `defaults()` returns a flat dictionary of the active branch's default parameter values:
 
+{% code overflow="wrap" %}
 ```python
 {
     "backend": "local",
@@ -87,6 +98,7 @@ For programmatic inspection before instantiation, use `schema = explore(config, 
     "local.cache": True,
 }
 ```
+{% endcode %}
 
 ## When To Use `explore()` vs `instantiate()`
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,61 +4,78 @@ Hypster's core package has no runtime dependencies and supports Python 3.10, 3.1
 
 ## Install With uv
 
+{% code overflow="wrap" %}
 ```bash
 uv add hypster
 ```
+{% endcode %}
 
 Install Optuna support when you want hyperparameter optimization:
 
+{% code overflow="wrap" %}
 ```bash
 uv add "hypster[optuna]"
 ```
+{% endcode %}
 
 Install the notebook visualization extra when you want Hypster's interactive instantiation UI:
 
+{% code overflow="wrap" %}
 ```bash
 uv add "hypster[viz]"
 ```
+{% endcode %}
 
 The `viz` extra installs `anywidget`, `ipywidgets`, and `jupyterlab_widgets` for Jupyter Notebook, JupyterLab, and VS Code notebooks.
 
 If you are starting a notebook project from scratch, install the notebook frontend and Hypster widget runtime together:
 
+{% code overflow="wrap" %}
 ```bash
 uv add "hypster[viz]" jupyterlab
 ```
+{% endcode %}
 
 ## Install With pip
 
 Check that `python` points at a supported interpreter first:
 
+{% code overflow="wrap" %}
 ```bash
 python --version
 ```
+{% endcode %}
 
 Hypster supports Python 3.10, 3.11, and 3.12.
 
+{% code overflow="wrap" %}
 ```bash
 pip install hypster
 ```
+{% endcode %}
 
 Optional extras:
 
+{% code overflow="wrap" %}
 ```bash
 pip install "hypster[optuna]"
 pip install "hypster[viz]"
 ```
+{% endcode %}
 
 For a new JupyterLab environment:
 
+{% code overflow="wrap" %}
 ```bash
 python -m pip install "hypster[viz]" jupyterlab
 ```
+{% endcode %}
 
 ## Verify The Install
 
 Run a smoke test in the same environment where your project runs:
 
+{% code overflow="wrap" %}
 ```python
 from dataclasses import dataclass
 
@@ -82,54 +99,67 @@ explore(config)
 settings = instantiate(config, values={"batch_size": 64})
 assert settings.batch_size == 64
 ```
+{% endcode %}
 
 Expected tree:
 
+{% code overflow="wrap" %}
 ```text
 config
 ├── path: text = 'data/train.csv'
 └── batch_size: int = 32  (min: 1)
 ```
+{% endcode %}
 
 ## Check The Version
 
 With uv:
 
+{% code overflow="wrap" %}
 ```bash
 uv run python -c "import hypster; print(hypster.__version__)"
 ```
+{% endcode %}
 
 With pip or a manually managed interpreter:
 
+{% code overflow="wrap" %}
 ```bash
 python -c "import hypster; print(hypster.__version__)"
 ```
+{% endcode %}
 
 Inside Python:
 
+{% code overflow="wrap" %}
 ```python
 import hypster
 
 print(hypster.__version__)
 ```
+{% endcode %}
 
 ## Development Setup
 
+{% code overflow="wrap" %}
 ```bash
 git clone https://github.com/gilad-rubin/hypster.git
 cd hypster
 uv sync --all-extras --dev
 uv run pytest
 ```
+{% endcode %}
 
 Hypster's maintainer tooling lives in local `uv` dependency groups rather than a published `dev` extra, so a `pip`-based setup installs runtime extras and maintainer tools separately:
 
+{% code overflow="wrap" %}
 ```bash
 git clone https://github.com/gilad-rubin/hypster.git
 cd hypster
 python -m pip install -e ".[viz,optuna]"
 python -m pip install pytest pytest-cov "coverage[toml]" ruff mypy pre-commit pytest-codspeed
 ```
+{% endcode %}
 
 Adjust the extras in the first command if you only need a subset of the optional runtime integrations.
 
@@ -137,25 +167,32 @@ Adjust the extras in the first command if you only need a subset of the optional
 
 If `import hypster` fails, check that your package manager installed Hypster into the interpreter running your code:
 
+{% code overflow="wrap" %}
 ```bash
 python -m pip show hypster
 python -c "import hypster; print(hypster.__version__)"
 ```
+{% endcode %}
 
 If Optuna imports fail, install the optional extra:
 
+{% code overflow="wrap" %}
 ```bash
 python -m pip install "hypster[optuna]"
 ```
+{% endcode %}
 
 If `interact()` says the visualization extra is missing, install the notebook widget extra and restart the notebook kernel:
 
+{% code overflow="wrap" %}
 ```bash
 python -m pip install "hypster[viz]"
 ```
+{% endcode %}
 
 For notebook UI issues, make sure your notebook frontend is installed:
 
+{% code overflow="wrap" %}
 ```bash
 # JupyterLab
 uv add jupyterlab
@@ -163,13 +200,16 @@ uv add jupyterlab
 # Classic Jupyter Notebook
 uv add notebook
 ```
+{% endcode %}
 
 With pip:
 
+{% code overflow="wrap" %}
 ```bash
 python -m pip install -U jupyterlab
 python -m pip install -U notebook
 ```
+{% endcode %}
 
 In VS Code notebooks, the Jupyter extension may ask to enable downloads for `anywidget` support files the first time the widget renders. Accept that prompt, then rerun the cell.
 

--- a/docs/getting-started/instantiating-a-configuration-space.md
+++ b/docs/getting-started/instantiating-a-configuration-space.md
@@ -2,6 +2,7 @@
 
 Use `instantiate()` to execute a config function and get its returned runtime value.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
 
@@ -16,6 +17,7 @@ def model_config(hp: HP):
 cfg = instantiate(model_config, values={"family": "forest", "n_estimators": 500})
 assert cfg == {"family": "forest", "n_estimators": 500}
 ```
+{% endcode %}
 
 If you want to inspect a branch before running it, use [`explore()`](exploring-a-configuration-space.md).
 
@@ -23,6 +25,7 @@ If you want to inspect a branch before running it, use [`explore()`](exploring-a
 
 Use `instantiate_with_params()` when you need a replayable record for experiment tracking tools such as MLflow, Weights & Biases, or a database table. The returned `params` dictionary includes every reachable `hp.*` parameter on that run, including defaults the user did not override.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate, instantiate_with_params
 
@@ -39,6 +42,7 @@ assert run.params == {"provider": "openai", "temperature": 0.2}
 replayed = instantiate(llm_config, values=run.params)
 assert replayed == run.value
 ```
+{% endcode %}
 
 `instantiate_with_params()` accepts the same `values`, `args`, `kwargs`, and `on_unknown` arguments as `instantiate()`. It does not change what your config returns; it adds a sidecar for logging and replay.
 
@@ -46,6 +50,7 @@ assert replayed == run.value
 
 Unknown or conditionally unreachable values raise by default:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(model_config, values={"n_trees": 200})
 # ValueError: Unknown or unreachable parameters:
@@ -54,17 +59,21 @@ instantiate(model_config, values={"n_trees": 200})
 # Run explore(config, values=...) to inspect the active branch.
 # Nested dict values are interpreted as parameter paths; use dict-backed select keys for objects.
 ```
+{% endcode %}
 
 Use `on_unknown="warn"` or `on_unknown="ignore"` only when you intentionally want softer handling:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(model_config, values={"n_trees": 200}, on_unknown="warn")
 ```
+{% endcode %}
 
 ## Dotted Keys vs Nested Dicts
 
 Nested values can be provided with dotted keys or nested dictionaries:
 
+{% code overflow="wrap" %}
 ```python
 def child_config(hp: HP):
     return {"x": hp.int(1, name="x")}
@@ -75,6 +84,7 @@ def parent_config(hp: HP):
 assert instantiate(parent_config, values={"child.x": 10}) == {"child": {"x": 10}}
 assert instantiate(parent_config, values={"child": {"x": 10}}) == {"child": {"x": 10}}
 ```
+{% endcode %}
 
 Do not provide both forms for the same final path in the same call. Hypster raises duplicate-path errors to keep logs unambiguous. The nested scope name itself is not a leaf parameter, so `values={"child": 10}` raises as unknown or unreachable.
 
@@ -84,6 +94,7 @@ See [Values & Overrides](../in-depth/values-and-overrides.md) for more examples.
 
 `None` is an explicit value in Hypster, not a marker for "not selected". Use `allow_none=True` when `None` is part of a parameter's domain:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     max_depth = hp.int(None, name="max_depth", allow_none=True)
@@ -95,11 +106,13 @@ def config(hp: HP):
     )
     return {"max_depth": max_depth, "thinking_level": thinking_level}
 ```
+{% endcode %}
 
 Nullable elements are supported for `multi_select(..., allow_none=True)`. They are not supported for `multi_int`, `multi_float`, `multi_text`, or `multi_bool`; those calls raise with guidance if `allow_none=True` is passed.
 
 Nullable choices are captured and replayed like any other selected parameter:
 
+{% code overflow="wrap" %}
 ```python
 from hypster import instantiate_with_params
 
@@ -109,11 +122,13 @@ assert run.value == {"max_depth": None, "thinking_level": None}
 assert run.params["thinking_level"] is None
 assert instantiate(config, values=run.params) == run.value
 ```
+{% endcode %}
 
 ## Passing Args/Kwargs To Nested Configs
 
 When using `hp.nest`, you can pass `args=` and `kwargs=` to the child function.
 
+{% code overflow="wrap" %}
 ```python
 def child(hp: HP, multiplier: int, offset: int = 0) -> int:
     base = hp.int(5, name="base")
@@ -127,3 +142,4 @@ def parent(hp: HP):
 result = instantiate(parent)
 assert result == {"calc1": 10, "calc2": 25}
 ```
+{% endcode %}

--- a/docs/getting-started/interactive-instantiation-ui.md
+++ b/docs/getting-started/interactive-instantiation-ui.md
@@ -6,20 +6,25 @@ Use `interact()` in a notebook when you want to instantiate a configuration thro
 
 Install the notebook renderer with the visualization extra:
 
+{% code overflow="wrap" %}
 ```bash
 uv add "hypster[viz]"
 ```
+{% endcode %}
 
 or:
 
+{% code overflow="wrap" %}
 ```bash
 pip install "hypster[viz]"
 ```
+{% endcode %}
 
 The `viz` extra installs the widget runtime needed by Jupyter Notebook, JupyterLab, and VS Code notebooks. In VS Code, the Jupyter extension may ask to enable downloads for `anywidget` support files the first time a widget is displayed. Accept that prompt, then rerun the cell.
 
 ## Start An Interaction
 
+{% code overflow="wrap" %}
 ```python
 from dataclasses import dataclass
 
@@ -42,9 +47,19 @@ def model_config(hp: HP) -> ModelSettings:
         description="Chooses which provider branch is active.",
     )
     if provider == "anthropic":
-        model = hp.select(["claude-haiku", "claude-sonnet"], name="model")
+        model = hp.select(
+            ["claude-sonnet-4-6", "claude-opus-4-7"],
+            name="model",
+            default="claude-sonnet-4-6",
+            options_only=True,
+        )
     else:
-        model = hp.select(["gpt-4o-mini", "gpt-4.1"], name="model")
+        model = hp.select(
+            ["gpt-5.4-mini", "gpt-5.5"],
+            name="model",
+            default="gpt-5.4-mini",
+            options_only=True,
+        )
 
     return ModelSettings(
         provider=provider,
@@ -56,13 +71,16 @@ def model_config(hp: HP) -> ModelSettings:
 
 result = interact(model_config)
 ```
+{% endcode %}
 
 `interact()` returns an interactive result handle, not the raw configured object. After changing the widget, read the current applied object and replayable selected params from Python:
 
+{% code overflow="wrap" %}
 ```python
 settings = result.value
 params = result.params
 ```
+{% endcode %}
 
 `result.value` has the same type as the config function return value. In this example it is a `ModelSettings` instance.
 
@@ -74,9 +92,11 @@ By default, widget changes apply immediately. Valid changes update `result.value
 
 Use manual apply mode when you want to stage widget edits before updating the applied result:
 
+{% code overflow="wrap" %}
 ```python
 result = interact(model_config, auto_apply=False)
 ```
+{% endcode %}
 
 In manual mode, the UI continues to explore draft values so dependent controls stay current, but `result.value` and `result.params` keep returning the last applied state until Apply succeeds.
 
@@ -95,14 +115,18 @@ If a widget selection is invalid, the UI shows the current error. In auto-apply 
 
 Call `result.interact()` to render another live view of the same interaction:
 
+{% code overflow="wrap" %}
 ```python
 result.interact()
 ```
+{% endcode %}
 
 To start a fresh session from a previous selection, pass selected params explicitly:
 
+{% code overflow="wrap" %}
 ```python
 result2 = interact(model_config, values=result.params)
 ```
+{% endcode %}
 
 For framework-specific UIs outside notebooks, use the schema returned by `explore(..., return_info=True)`. See [Build an Interactive UI](../how-to/build-an-interactive-ui.md).

--- a/docs/getting-started/selecting-output-variables.md
+++ b/docs/getting-started/selecting-output-variables.md
@@ -22,6 +22,7 @@ Hypster config functions return exactly what you decide to return. There is no f
 
 ## Return A Dict
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
 
@@ -33,9 +34,11 @@ def config(hp: HP):
 cfg = instantiate(config, values={"model_name": "large"})
 assert cfg == {"model_name": "large", "batch_size": 32}
 ```
+{% endcode %}
 
 ## Return A Dataclass
 
+{% code overflow="wrap" %}
 ```python
 from dataclasses import dataclass
 from hypster import HP, instantiate
@@ -55,11 +58,13 @@ cfg = instantiate(config, values={"batch_size": 64})
 assert cfg.batch_size == 64
 assert cfg == TrainingConfig(batch_size=64, learning_rate=0.001)
 ```
+{% endcode %}
 
 ## Return Initialized Runtime Objects
 
 One common Hypster style is to make the config a typed factory for the object your application will use.
 
+{% code overflow="wrap" %}
 ```python
 from sklearn.ensemble import RandomForestClassifier
 from hypster import HP, instantiate
@@ -78,11 +83,13 @@ def classifier_config(hp: HP) -> RandomForestClassifier:
 
 model = instantiate(classifier_config, values={"n_estimators": 500})
 ```
+{% endcode %}
 
 The return type annotation helps readers, IDEs, and downstream code understand what instantiation produces.
 
 Use dict-backed `select` when a parameter should log a simple key but return a more complex runtime value:
 
+{% code overflow="wrap" %}
 ```python
 architecture = hp.select(
     {
@@ -93,11 +100,13 @@ architecture = hp.select(
     default="small",
 )
 ```
+{% endcode %}
 
 ## Use hp.collect
 
 `hp.collect()` helps gather local variables while excluding `hp`, private names, and anything you explicitly exclude.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP
 
@@ -107,9 +116,11 @@ def config(hp: HP):
     helper = "not returned"
     return hp.collect(locals(), exclude=["helper"])
 ```
+{% endcode %}
 
 Use `include=[...]` when you want to whitelist outputs:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     batch_size = hp.int(32, name="batch_size")
@@ -117,6 +128,7 @@ def config(hp: HP):
     debug_label = "local"
     return hp.collect(locals(), include=["batch_size", "learning_rate"])
 ```
+{% endcode %}
 
 ## Keep Expensive Side Effects Outside Configs
 

--- a/docs/how-to/build-an-interactive-ui.md
+++ b/docs/how-to/build-an-interactive-ui.md
@@ -8,6 +8,7 @@ Use `explore(config, return_info=True)` to discover fields, render controls in y
 
 ## 1. Get A Schema
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, explore
 
@@ -53,9 +54,11 @@ def search_config(hp: HP):
 schema = explore(search_config, return_info=True)
 metadata = schema.to_dict()
 ```
+{% endcode %}
 
 ## 2. Flatten Field Metadata
 
+{% code overflow="wrap" %}
 ```python
 def flatten_fields(parameters):
     for parameter in parameters:
@@ -66,11 +69,13 @@ def flatten_fields(parameters):
 
 fields = list(flatten_fields(metadata["parameters"]))
 ```
+{% endcode %}
 
 Each field has `path`, `kind`, `default_value`, `selected_value`, optional `options`, optional `minimum`, and optional `maximum`.
 
 Schema metadata is JSON-serializable. After exploring the vector branch with values such as `{"backend": "vector", "features": ["cache", None], "retrieval.index": "embeddings-v3", "retrieval.top_k": 12, "retrieval.score_threshold": 0.35}`, the payload looks like this shape:
 
+{% code overflow="wrap" %}
 ```python
 {
     "name": "search_config",
@@ -158,6 +163,7 @@ Schema metadata is JSON-serializable. After exploring the vector branch with val
     ],
 }
 ```
+{% endcode %}
 
 For dict-backed selects, `options` contains the replayable keys, not the mapped runtime objects.
 
@@ -165,6 +171,7 @@ For dict-backed selects, `options` contains the replayable keys, not the mapped 
 
 Map field kinds to controls in your UI framework:
 
+{% code overflow="wrap" %}
 ```python
 def control_spec(field):
     if field["kind"] == "select":
@@ -186,11 +193,13 @@ def control_spec(field):
 
 controls = {field["path"]: control_spec(field) for field in fields}
 ```
+{% endcode %}
 
 ## 4. Recompute Conditional Branches
 
 When a branch-selecting field changes, call `explore()` again with current UI values:
 
+{% code overflow="wrap" %}
 ```python
 ui_values = {"backend": "vector"}
 schema = explore(search_config, values=ui_values, return_info=True)
@@ -204,9 +213,11 @@ assert [field["path"] for field in fields] == [
     "features",
 ]
 ```
+{% endcode %}
 
 Custom UIs should submit only paths present in the latest schema. A robust branch-change loop is:
 
+{% code overflow="wrap" %}
 ```python
 def reachable_paths(schema):
     return {field["path"] for field in flatten_fields(schema.to_dict()["parameters"])}
@@ -218,6 +229,7 @@ def refresh_schema(config, current_values):
     schema = explore(config, values=pruned_values, return_info=True)
     return schema, pruned_values
 ```
+{% endcode %}
 
 If your UI remembers draft values per branch, keep that memory outside the submitted `values=` dictionary. Before calling `instantiate()`, remove stale paths from inactive branches.
 
@@ -225,6 +237,7 @@ Use `on_unknown="ignore"` only for this schema-refresh pruning pass. For the fin
 
 ## 5. Instantiate From UI State
 
+{% code overflow="wrap" %}
 ```python
 from hypster import instantiate
 
@@ -240,9 +253,11 @@ cfg = instantiate(search_config, values=ui_values)
 assert cfg["backend"] == "vector"
 assert cfg["retrieval"]["top_k"] == 12
 ```
+{% endcode %}
 
 ## 6. Submit And Show Errors
 
+{% code overflow="wrap" %}
 ```python
 from hypster import instantiate
 
@@ -253,6 +268,7 @@ except ValueError as exc:
 else:
     run_search(cfg)
 ```
+{% endcode %}
 
 If you intentionally allow old UI payloads while users are editing, use `on_unknown="warn"` and capture warnings near the form. Keep final run submissions strict unless you have a migration path for ignored fields.
 

--- a/docs/how-to/capture-replayable-params.md
+++ b/docs/how-to/capture-replayable-params.md
@@ -4,6 +4,7 @@ Use `instantiate_with_params()` when a run needs a durable parameter record.
 
 ## Capture Params
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate, instantiate_with_params
 
@@ -30,16 +31,20 @@ assert run.params == {
     "max_pages": 6,
 }
 ```
+{% endcode %}
 
 ## Replay Later
 
+{% code overflow="wrap" %}
 ```python
 replayed = instantiate(report_config, values=run.params)
 assert replayed == run.value
 ```
+{% endcode %}
 
 Captured params include defaults, so replay does not silently pick up later default changes:
 
+{% code overflow="wrap" %}
 ```python
 def old_config(hp: HP):
     return {"batch_size": hp.int(64, name="batch_size")}
@@ -55,11 +60,13 @@ def new_config(hp: HP):
 
 assert instantiate(new_config, values=old_run.params) == {"batch_size": 64}
 ```
+{% endcode %}
 
 ## Store Params As JSON
 
 `run.params` only contains values selected by `hp.*` calls. It is intended to be JSON-friendly when your parameter values are JSON-friendly.
 
+{% code overflow="wrap" %}
 ```python
 import json
 
@@ -68,11 +75,13 @@ restored_params = json.loads(payload)
 
 assert instantiate(report_config, values=restored_params) == run.value
 ```
+{% endcode %}
 
 ## Complex Runtime Objects
 
 Use dict-backed `select` when a runtime choice is a complex object. The params record the simple key, not the complex mapped value.
 
+{% code overflow="wrap" %}
 ```python
 def model_config(hp: HP):
     return hp.select(
@@ -89,3 +98,4 @@ run = instantiate_with_params(model_config, values={"model": "large"})
 assert run.value == {"layers": 4, "units": [256, 128]}
 assert run.params == {"model": "large"}
 ```
+{% endcode %}

--- a/docs/how-to/compose-nested-configs.md
+++ b/docs/how-to/compose-nested-configs.md
@@ -4,6 +4,7 @@ Use this guide when one workflow should be assembled from reusable smaller confi
 
 ## Start With Child Configs
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, explore, instantiate
 
@@ -18,9 +19,11 @@ def encoder_config(hp: HP):
     hidden_size = 384 if size == "small" else 768
     return {"size": size, "hidden_size": hidden_size}
 ```
+{% endcode %}
 
 ## Nest Them In A Parent
 
+{% code overflow="wrap" %}
 ```python
 def embedding_pipeline(hp: HP):
     return {
@@ -29,9 +32,11 @@ def embedding_pipeline(hp: HP):
         "normalize": hp.bool(True, name="normalize"),
     }
 ```
+{% endcode %}
 
 ## Override Nested Values
 
+{% code overflow="wrap" %}
 ```python
 cfg = instantiate(
     embedding_pipeline,
@@ -44,9 +49,11 @@ cfg = instantiate(
 
 assert cfg["encoder"]["hidden_size"] == 768
 ```
+{% endcode %}
 
 Nested dictionaries are equivalent:
 
+{% code overflow="wrap" %}
 ```python
 cfg = instantiate(
     embedding_pipeline,
@@ -57,6 +64,7 @@ cfg = instantiate(
     },
 )
 ```
+{% endcode %}
 
 The nested scope name is a prefix, not a leaf value. `values={"tokenizer": "wordpiece"}` raises as unknown because it does not target `tokenizer.kind`.
 
@@ -64,6 +72,7 @@ When you pass child-local values through `hp.nest(child, name="child", values=..
 
 ## Pass Args And Kwargs To Children
 
+{% code overflow="wrap" %}
 ```python
 def sampler_config(hp: HP, default_batch_size: int):
     return {
@@ -77,11 +86,14 @@ def training_config(hp: HP):
         "eval": hp.nest(sampler_config, name="eval", kwargs={"default_batch_size": 256}),
     }
 ```
+{% endcode %}
 
 ## Inspect Branches Before Running
 
+{% code overflow="wrap" %}
 ```python
 explore(embedding_pipeline, values={"encoder.size": "base"})
 ```
+{% endcode %}
 
 If an override points at a parameter that is not reached on the active branch, Hypster raises by default. That keeps `values=` safe to log and replay.

--- a/docs/how-to/create-a-replayable-config.md
+++ b/docs/how-to/create-a-replayable-config.md
@@ -6,6 +6,7 @@ The config is a normal Python function. Keep it cheap and side-effect-free so `e
 
 ## 1. Define A Typed Config
 
+{% code overflow="wrap" %}
 ```python
 from dataclasses import dataclass
 
@@ -26,26 +27,32 @@ def data_config(hp: HP) -> DataLoadSettings:
         shuffle=hp.bool(True, name="shuffle"),
     )
 ```
+{% endcode %}
 
 ## 2. Inspect The Parameters
 
 Print the active tree when you want a quick human check:
 
+{% code overflow="wrap" %}
 ```python
 from hypster import explore
 
 explore(data_config)
 ```
+{% endcode %}
 
 Use structured metadata when another tool needs to render fields:
 
+{% code overflow="wrap" %}
 ```python
 schema = explore(data_config, return_info=True)
 fields = schema.to_dict()["parameters"]
 ```
+{% endcode %}
 
 ## 3. Instantiate With Overrides
 
+{% code overflow="wrap" %}
 ```python
 from hypster import instantiate
 
@@ -57,9 +64,11 @@ assert settings == DataLoadSettings(
     shuffle=True,
 )
 ```
+{% endcode %}
 
 ## 4. Capture Params For Replay
 
+{% code overflow="wrap" %}
 ```python
 from hypster import instantiate_with_params
 
@@ -72,9 +81,11 @@ assert run.params == {
     "shuffle": True,
 }
 ```
+{% endcode %}
 
 ## 5. Store And Replay
 
+{% code overflow="wrap" %}
 ```python
 import json
 
@@ -84,5 +95,6 @@ restored_params = json.loads(payload)
 replayed = instantiate(data_config, values=restored_params)
 assert replayed == run.value
 ```
+{% endcode %}
 
 Because `run.params` includes defaulted values, replay does not silently change if the config's defaults are edited later.

--- a/docs/how-to/perform-hyperparameter-optimization.md
+++ b/docs/how-to/perform-hyperparameter-optimization.md
@@ -4,18 +4,23 @@ Use this guide when you want Optuna to sample values for the active branch of a 
 
 ## Install Optuna Support
 
+{% code overflow="wrap" %}
 ```bash
 uv add 'hypster[optuna]'
 ```
+{% endcode %}
 
 or:
 
+{% code overflow="wrap" %}
 ```bash
 pip install 'hypster[optuna]'
 ```
+{% endcode %}
 
 ## Define A Searchable Config
 
+{% code overflow="wrap" %}
 ```python
 from dataclasses import dataclass
 from hypster import HP, instantiate_with_params
@@ -49,9 +54,11 @@ def model_config(hp: HP) -> ModelConfig:
     max_depth = hp.int(12, name="max_depth", min=2, max=64, hpo_spec=HpoInt(scale="log"))
     return ModelConfig(family=family, params={"n_estimators": n_estimators, "max_depth": max_depth})
 ```
+{% endcode %}
 
 ## Use It In An Objective
 
+{% code overflow="wrap" %}
 ```python
 import optuna
 from hypster.hpo.optuna import suggest_values
@@ -71,11 +78,13 @@ def objective(trial: optuna.Trial) -> float:
 study = optuna.create_study(direction="maximize")
 study.optimize(objective, n_trials=30)
 ```
+{% endcode %}
 
 ## Fix Part Of The Search
 
 Wrap the config when you want a fixed branch. This keeps Optuna from sampling parameters that will later become unreachable.
 
+{% code overflow="wrap" %}
 ```python
 def forest_only_config(hp: HP) -> ModelConfig:
     n_estimators = hp.int(
@@ -93,6 +102,7 @@ def objective(trial: optuna.Trial) -> float:
     run = instantiate_with_params(forest_only_config, values=values)
     return train_and_score(run.value)
 ```
+{% endcode %}
 
 Prefer encoding fixed branches in the config itself when possible. It keeps the search space smaller and the replay payload cleaner.
 
@@ -114,6 +124,7 @@ The Optuna adapter does not expand `multi_*` calls into a search space. Keep `mu
 
 Use categorical booleans for per-feature include/exclude decisions:
 
+{% code overflow="wrap" %}
 ```python
 def feature_config(hp: HP) -> list[str]:
     features = []
@@ -125,20 +136,24 @@ def feature_config(hp: HP) -> list[str]:
         features.append("days_active")
     return features
 ```
+{% endcode %}
 
 Use `hp.select([False, True], ...)` here rather than `hp.bool(...)` because the Optuna adapter samples categorical `select` calls, not boolean HP calls.
 
 Use fixed slots when position matters:
 
+{% code overflow="wrap" %}
 ```python
 def top_features_config(hp: HP) -> list[str]:
     first = hp.select(["age", "income", "days_active"], name="feature_1", options_only=True)
     second = hp.select(["age", "income", "days_active"], name="feature_2", options_only=True)
     return [first, second]
 ```
+{% endcode %}
 
 Use dict-backed categorical presets for finite feature subsets:
 
+{% code overflow="wrap" %}
 ```python
 def preset_features_config(hp: HP) -> list[str]:
     return hp.select(
@@ -152,3 +167,4 @@ def preset_features_config(hp: HP) -> list[str]:
         options_only=True,
     )
 ```
+{% endcode %}

--- a/docs/in-depth/basic-best-practices.md
+++ b/docs/in-depth/basic-best-practices.md
@@ -12,6 +12,7 @@ The implication is that Hypster discovers the available parameters by running yo
 
 A strong Hypster pattern is to make each config function a typed factory for the object the caller needs:
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP
 from sklearn.ensemble import RandomForestClassifier
@@ -26,6 +27,7 @@ def classifier_config(hp: HP) -> RandomForestClassifier:
         random_state=42,
     )
 ```
+{% endcode %}
 
 Use a return type annotation for config functions whenever the output is a meaningful object. It makes the config easier to read, test, and compose with `hp.nest()`.
 
@@ -52,9 +54,11 @@ Use this boundary when deciding what a config should return:
 
 Every `hp.*` call needs a stable `name=`. Names become the keys in `values=`, `explore()` output, and `instantiate_with_params().params`.
 
+{% code overflow="wrap" %}
 ```python
 hp.float(0.001, name="learning_rate")
 ```
+{% endcode %}
 
 Use Python identifier-style names:
 
@@ -67,6 +71,7 @@ Let `hp.nest()` create dotted paths.
 
 Branch when downstream structure changes:
 
+{% code overflow="wrap" %}
 ```python
 def model_config(hp: HP):
     family = hp.select(["linear", "forest"], name="family", default="forest", options_only=True)
@@ -76,6 +81,7 @@ def model_config(hp: HP):
 
     return {"n_estimators": hp.int(200, name="n_estimators", min=10)}
 ```
+{% endcode %}
 
 Avoid carrying irrelevant parameters for inactive branches. Branch-aware configs make experiment logs cleaner and HPO search spaces smaller.
 
@@ -83,6 +89,7 @@ Avoid carrying irrelevant parameters for inactive branches. Branch-aware configs
 
 Select keys should be simple and replayable. Map those keys to complex runtime values:
 
+{% code overflow="wrap" %}
 ```python
 tokenizer = hp.select(
     {
@@ -93,6 +100,7 @@ tokenizer = hp.select(
     default="wordpiece",
 )
 ```
+{% endcode %}
 
 This keeps `params={"tokenizer": "wordpiece"}` while your app receives the mapped dictionary when that branch is selected.
 
@@ -100,28 +108,35 @@ This keeps `params={"tokenizer": "wordpiece"}` while your app receives the mappe
 
 By default, `select` allows custom scalar values outside the listed options. Use `options_only=True` when the option list is closed:
 
+{% code overflow="wrap" %}
 ```python
 provider = hp.select(["openai", "gemini"], name="provider", default="openai", options_only=True)
 ```
+{% endcode %}
 
 ## Use `allow_none=True` Deliberately
 
 `None` is a real value, not an unspecified value. Mark it explicitly:
 
+{% code overflow="wrap" %}
 ```python
 max_depth = hp.int(None, name="max_depth", allow_none=True)
 ```
+{% endcode %}
 
 For nullable choices, you can put `None` directly in the options:
 
+{% code overflow="wrap" %}
 ```python
 tokenizer = hp.select([None, "basic"], name="tokenizer", default=None, allow_none=True)
 ```
+{% endcode %}
 
 ## Use Numeric Coercion Deliberately
 
 Hypster safely coerces common numeric inputs by default. Integral floats can be used for integer parameters, and integers can be used for float parameters:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     return {
@@ -132,9 +147,11 @@ def config(hp: HP):
 instantiate(config, values={"epochs": 20.0, "lr": 1})
 # => {"epochs": 20, "lr": 1.0}
 ```
+{% endcode %}
 
 Use `strict=True` when the input type itself matters:
 
+{% code overflow="wrap" %}
 ```python
 def strict_config(hp: HP):
     return {
@@ -142,6 +159,7 @@ def strict_config(hp: HP):
         "lr": hp.float(0.1, name="lr", strict=True),
     }
 ```
+{% endcode %}
 
 `True` and `False` are rejected by numeric parameters. Use `hp.bool()` for boolean choices.
 
@@ -149,10 +167,12 @@ def strict_config(hp: HP):
 
 Use `instantiate_with_params()` for experiments, UI submissions, scheduled jobs, and production runs:
 
+{% code overflow="wrap" %}
 ```python
 run = instantiate_with_params(config, values={"learning_rate": 0.01})
 # tracker.log_params(run.params)
 ```
+{% endcode %}
 
 The params include defaults as well as explicit overrides, so later replay does not depend on changing defaults.
 
@@ -160,9 +180,11 @@ The params include defaults as well as explicit overrides, so later replay does 
 
 When overriding a branch, inspect it first:
 
+{% code overflow="wrap" %}
 ```python
 explore(config, values={"provider": "gemini"})
 ```
+{% endcode %}
 
 This prevents stale values from inactive branches from leaking into logs.
 
@@ -170,11 +192,13 @@ This prevents stale values from inactive branches from leaking into logs.
 
 Return what the caller needs. A small return surface makes configs easier to test and less likely to couple unrelated workflow stages.
 
+{% code overflow="wrap" %}
 ```python
 return {
     "model": model,
     "optimizer": optimizer,
 }
 ```
+{% endcode %}
 
 Use `hp.collect(locals(), include=[...])` when that makes the return explicit and concise.

--- a/docs/in-depth/hp-call-types/bool-and-multi-bool.md
+++ b/docs/in-depth/hp-call-types/bool-and-multi-bool.md
@@ -4,13 +4,16 @@ Use `hp.bool()` for one boolean and `hp.multi_bool()` for a list of booleans.
 
 ## Signatures
 
+{% code overflow="wrap" %}
 ```python
 hp.bool(default, *, name, allow_none=False)
 hp.multi_bool(default, *, name, allow_none=False)
 ```
+{% endcode %}
 
 ## Single Boolean
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
 
@@ -23,6 +26,7 @@ def config(hp: HP):
 cfg = instantiate(config, values={"stream": False})
 assert cfg == {"stream": False, "use_cache": True}
 ```
+{% endcode %}
 
 `hp.bool` requires actual booleans. Strings such as `"true"` are rejected.
 
@@ -30,6 +34,7 @@ assert cfg == {"stream": False, "use_cache": True}
 
 Use `allow_none=True` for tri-state values:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     return hp.bool(None, name="stream", allow_none=True)
@@ -37,14 +42,17 @@ def config(hp: HP):
 assert instantiate(config) is None
 assert instantiate(config, values={"stream": True}) is True
 ```
+{% endcode %}
 
 ## Multiple Booleans
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     return hp.multi_bool([True, False, True], name="feature_flags")
 
 assert instantiate(config, values={"feature_flags": [False, False, True]}) == [False, False, True]
 ```
+{% endcode %}
 
 Nullable elements are not supported for `multi_bool`. Use `multi_select(..., allow_none=True)` for nullable categorical lists.

--- a/docs/in-depth/hp-call-types/int-and-multi-int.md
+++ b/docs/in-depth/hp-call-types/int-and-multi-int.md
@@ -4,17 +4,20 @@ Use `hp.int`, `hp.float`, `hp.multi_int`, and `hp.multi_float` for numeric param
 
 ## Signatures
 
+{% code overflow="wrap" %}
 ```python
 hp.int(default, *, name, min=None, max=None, strict=False, allow_none=False, hpo_spec=None)
 hp.float(default, *, name, min=None, max=None, strict=False, allow_none=False, hpo_spec=None)
 hp.multi_int(default, *, name, min=None, max=None, strict=False, allow_none=False)
 hp.multi_float(default, *, name, min=None, max=None, strict=False, allow_none=False)
 ```
+{% endcode %}
 
 `hpo_spec` is ignored by normal instantiation and consumed by the Optuna adapter.
 
 ## Bounds
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
 
@@ -30,6 +33,7 @@ cfg = instantiate(
     values={"learning_rate": 0.01, "batch_size": 128, "layers": [512, 256]},
 )
 ```
+{% endcode %}
 
 Values outside bounds raise.
 
@@ -45,6 +49,7 @@ This behavior is the same for top-level parameters and nested paths.
 
 The policy is defined for Python numeric scalars. If a data library gives you NumPy, pandas, or framework-specific scalar objects, convert them to plain `int` or `float` values before passing them through `values=`.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
 
@@ -59,9 +64,11 @@ assert instantiate(config, values={"epochs": 20.0, "lr": 1}) == {
     "lr": 1.0,
 }
 ```
+{% endcode %}
 
 Precision-losing integer conversions are rejected:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     return hp.int(10, name="epochs")
@@ -69,9 +76,11 @@ def config(hp: HP):
 instantiate(config, values={"epochs": 20.5})
 # ValueError: float 20.5 would lose precision when converted to int
 ```
+{% endcode %}
 
 Bool values are rejected for numeric parameters:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     return {
@@ -82,6 +91,7 @@ def config(hp: HP):
 instantiate(config, values={"epochs": True})
 # ValueError: expected int but got bool
 ```
+{% endcode %}
 
 ## Strict Numeric Types
 
@@ -90,6 +100,7 @@ With `strict=True`:
 * `hp.int` and `hp.multi_int` accept real integers only, excluding bool.
 * `hp.float` and `hp.multi_float` accept real floats only, excluding integers and bool.
 
+{% code overflow="wrap" %}
 ```python
 def strict_config(hp: HP):
     return {
@@ -103,11 +114,13 @@ instantiate(strict_config, values={"epochs": 20.0})
 instantiate(strict_config, values={"lr": 1})
 # ValueError: expected float but got int
 ```
+{% endcode %}
 
 ## Nullable Numeric Values
 
 Use `allow_none=True` when `None` is an intentional scalar value:
 
+{% code overflow="wrap" %}
 ```python
 def tree_config(hp: HP):
     return {
@@ -120,11 +133,13 @@ assert instantiate(tree_config, values={"dropout": None}) == {
     "dropout": None,
 }
 ```
+{% endcode %}
 
 Nullable elements are not supported for `multi_int` or `multi_float`. Use `multi_select(..., allow_none=True)` for nullable categorical lists.
 
 ## HPO Specs
 
+{% code overflow="wrap" %}
 ```python
 from hypster.hpo.types import HpoFloat, HpoInt
 
@@ -146,3 +161,4 @@ def search_config(hp: HP):
         ),
     }
 ```
+{% endcode %}

--- a/docs/in-depth/hp-call-types/select-and-multi-select.md
+++ b/docs/in-depth/hp-call-types/select-and-multi-select.md
@@ -6,26 +6,37 @@ Selected choices are part of Hypster's reproducibility surface. They are what `i
 
 ## Signatures
 
+{% code overflow="wrap" %}
 ```python
 hp.select(options, *, name, default=NO_DEFAULT, options_only=False, allow_none=False, hpo_spec=None)
 hp.multi_select(options, *, name, default=None, options_only=False, allow_none=False)
 ```
+{% endcode %}
 
 ## List Form
 
 Use list form when the logged choice and returned value are the same simple value:
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
 
 def config(hp: HP):
-    model = hp.select(["haiku", "sonnet"], name="model", default="haiku")
+    model = hp.select(
+        ["claude-haiku-4-5", "claude-sonnet-4-6"],
+        name="model",
+        default="claude-haiku-4-5",
+    )
     features = hp.multi_select(["cache", "trace"], name="features", default=["cache"])
     return {"model": model, "features": features}
 
-instantiate(config, values={"model": "sonnet", "features": ["cache", "trace"]})
-# => {"model": "sonnet", "features": ["cache", "trace"]}
+instantiate(
+    config,
+    values={"model": "claude-sonnet-4-6", "features": ["cache", "trace"]},
+)
+# => {"model": "claude-sonnet-4-6", "features": ["cache", "trace"]}
 ```
+{% endcode %}
 
 List-form choices must be logging-safe scalar values: `None`, `bool`, `int`, `float`, or `str`. If you need a complex object, use dictionary form.
 
@@ -33,6 +44,7 @@ List-form choices must be logging-safe scalar values: `None`, `bool`, `int`, `fl
 
 Use dictionary form when a simple logged key should return a different value. The key is logged and replayed; the mapped value is returned from the config.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate_with_params
 
@@ -52,9 +64,11 @@ run = instantiate_with_params(config, values={"model": "large"})
 assert run.value == {"model": {"layers": 4, "units": [256, 128]}}
 assert run.params == {"model": "large"}
 ```
+{% endcode %}
 
 Use `options_only=True` with dictionary form when the logged keys are a closed enum:
 
+{% code overflow="wrap" %}
 ```python
 def strict_config(hp: HP):
     model = hp.select(
@@ -73,6 +87,7 @@ run = instantiate_with_params(strict_config, values={"model": "large"})
 assert run.value == {"model": {"layers": 4}}
 assert run.params == {"model": "large"}
 ```
+{% endcode %}
 
 Dictionary form is the recommended way to return:
 
@@ -80,6 +95,7 @@ Dictionary form is the recommended way to return:
 * dictionaries, lists, tuples, or dataclasses
 * long provider/model IDs behind short aliases
 
+{% code overflow="wrap" %}
 ```python
 architecture = hp.select(
     {
@@ -90,6 +106,7 @@ architecture = hp.select(
     default="small",
 )
 ```
+{% endcode %}
 
 For nullable choices, you can use `None` directly in list-form options with `allow_none=True`.
 
@@ -97,6 +114,7 @@ For nullable choices, you can use `None` directly in list-form options with `all
 
 If `None` itself is a selectable choice or override, mark the parameter as nullable with `allow_none=True`:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     thinking_level = hp.select(
@@ -113,6 +131,7 @@ def config(hp: HP):
     )
     return {"thinking_level": thinking_level, "features": features}
 ```
+{% endcode %}
 
 Without `allow_none=True`, `None` defaults, choices, and overrides raise with guidance.
 
@@ -120,12 +139,14 @@ Without `allow_none=True`, `None` defaults, choices, and overrides raise with gu
 
 An empty option list can default to `None` when the parameter is explicitly nullable:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     return hp.select([], name="choice", allow_none=True)
 
 assert instantiate(config) is None
 ```
+{% endcode %}
 
 Without `allow_none=True`, an empty option list with no explicit default raises because Hypster has no safe value to select.
 
@@ -133,22 +154,30 @@ Without `allow_none=True`, an empty option list with no explicit default raises 
 
 By default, `options_only=False`, so callers may provide a custom choice outside the declared options:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
-    return hp.select(["haiku", "sonnet"], name="model")
+    return hp.select(["claude-haiku-4-5", "claude-sonnet-4-6"], name="model")
 
-assert instantiate(config, values={"model": "opus"}) == "opus"
+assert instantiate(config, values={"model": "claude-opus-4-7"}) == "claude-opus-4-7"
 ```
+{% endcode %}
 
 Custom choices must still be logging-safe scalar values. Use `options_only=True` to reject anything outside the declared options:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
-    return hp.select(["haiku", "sonnet"], name="model", options_only=True)
+    return hp.select(
+        ["claude-haiku-4-5", "claude-sonnet-4-6"],
+        name="model",
+        options_only=True,
+    )
 
-instantiate(config, values={"model": "opus"})
-# ValueError: 'opus' not in allowed options
+instantiate(config, values={"model": "claude-opus-4-7"})
+# ValueError: 'claude-opus-4-7' not in allowed options
 ```
+{% endcode %}
 
 ## Names
 

--- a/docs/in-depth/hp-call-types/text-and-multi-text.md
+++ b/docs/in-depth/hp-call-types/text-and-multi-text.md
@@ -4,19 +4,22 @@ Use `hp.text()` for one string and `hp.multi_text()` for a list of strings.
 
 ## Signatures
 
+{% code overflow="wrap" %}
 ```python
 hp.text(default, *, name, allow_none=False)
 hp.multi_text(default, *, name, allow_none=False)
 ```
+{% endcode %}
 
 ## Single Text Values
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
 
 def llm_config(hp: HP):
     return {
-        "model_name": hp.text("gpt-4o-mini", name="model_name"),
+        "model_name": hp.text("gpt-5.4-mini", name="model_name"),
         "system_prompt": hp.text("Answer concisely.", name="system_prompt"),
     }
 
@@ -27,20 +30,24 @@ cfg = instantiate(
 
 assert cfg["system_prompt"] == "Answer with citations."
 ```
+{% endcode %}
 
 ## Nullable Text
 
 Use `allow_none=True` when `None` is an intentional text value:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     return hp.text(None, name="system_prompt", allow_none=True)
 
 assert instantiate(config) is None
 ```
+{% endcode %}
 
 ## Multiple Text Values
 
+{% code overflow="wrap" %}
 ```python
 def generation_config(hp: HP):
     return {
@@ -55,5 +62,6 @@ cfg = instantiate(
 
 assert cfg["stop_sequences"] == ["STOP", "DONE"]
 ```
+{% endcode %}
 
 Nullable elements are not supported for `multi_text`; use `multi_select(..., allow_none=True)` for nullable categorical lists.

--- a/docs/in-depth/nest.md
+++ b/docs/in-depth/nest.md
@@ -4,6 +4,7 @@
 
 ## Basic Nesting
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
 
@@ -22,9 +23,11 @@ def training_config(hp: HP):
 cfg = instantiate(training_config, values={"optimizer.learning_rate": 0.01})
 assert cfg["optimizer"]["learning_rate"] == 0.01
 ```
+{% endcode %}
 
 ## Signature
 
+{% code overflow="wrap" %}
 ```python
 hp.nest(
     child,
@@ -35,6 +38,7 @@ hp.nest(
     kwargs=None,
 )
 ```
+{% endcode %}
 
 | Argument | Meaning |
 | --- | --- |
@@ -48,6 +52,7 @@ hp.nest(
 
 `values=` inside `hp.nest()` is local to the child and is merged after parent-provided values for that child. Use it when the parent intentionally fixes or supplies child defaults.
 
+{% code overflow="wrap" %}
 ```python
 def parent(hp: HP):
     return hp.nest(
@@ -59,9 +64,11 @@ def parent(hp: HP):
 assert instantiate(parent)["learning_rate"] == 0.005
 assert instantiate(parent, values={"optimizer.learning_rate": 0.02})["learning_rate"] == 0.005
 ```
+{% endcode %}
 
 Think of this as a parent-fixed child value: the parent is choosing what the child sees. If you want callers to override the child value, leave `values=` off the `hp.nest()` call and put the default in the child parameter:
 
+{% code overflow="wrap" %}
 ```python
 def overridable_parent(hp: HP):
     return hp.nest(optimizer_config, name="optimizer")
@@ -69,9 +76,11 @@ def overridable_parent(hp: HP):
 cfg = instantiate(overridable_parent, values={"optimizer.learning_rate": 0.02})
 assert cfg["learning_rate"] == 0.02
 ```
+{% endcode %}
 
 Explicit child values are validated after the child config runs. Unknown or unreachable child keys raise instead of being ignored:
 
+{% code overflow="wrap" %}
 ```python
 def parent_with_typo(hp: HP):
     return hp.nest(optimizer_config, name="optimizer", values={"learnig_rate": 0.005})
@@ -79,11 +88,13 @@ def parent_with_typo(hp: HP):
 instantiate(parent_with_typo)
 # ValueError: Unknown or unreachable parameters
 ```
+{% endcode %}
 
 Use child-local `values=` for parent-owned policy, test fixtures, or internal composition defaults that should win over caller-provided nested values.
 
 ## Args And Kwargs
 
+{% code overflow="wrap" %}
 ```python
 def sampler_config(hp: HP, default_batch_size: int):
     return {
@@ -97,11 +108,13 @@ def data_config(hp: HP):
         "eval": hp.nest(sampler_config, name="eval", kwargs={"default_batch_size": 256}),
     }
 ```
+{% endcode %}
 
 ## Conditional Nesting
 
 You can choose which child config to run:
 
+{% code overflow="wrap" %}
 ```python
 def local_config(hp: HP):
     return {"threads": hp.int(4, name="threads", min=1)}
@@ -119,18 +132,23 @@ def app_config(hp: HP):
 
     return {"backend": backend, "settings": settings}
 ```
+{% endcode %}
 
 This value is valid:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(app_config, values={"backend": "remote", "remote.endpoint": "https://staging.example.com"})
 ```
+{% endcode %}
 
 This value raises by default because `local.threads` is unreachable on the `remote` branch:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(app_config, values={"backend": "remote", "local.threads": 8})
 ```
+{% endcode %}
 
 ## Name Collisions
 

--- a/docs/in-depth/performing-hyperparameter-optimization.md
+++ b/docs/in-depth/performing-hyperparameter-optimization.md
@@ -18,6 +18,7 @@ Because the config is executed normally, conditionals work naturally. If Optuna 
 
 Use `hpo_spec=` to document search semantics where the parameter is defined:
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP
 from hypster.hpo.types import HpoFloat, HpoInt
@@ -40,6 +41,7 @@ def config(hp: HP):
         ),
     }
 ```
+{% endcode %}
 
 Normal `instantiate()` ignores `hpo_spec`; the Optuna adapter consumes it.
 
@@ -69,6 +71,7 @@ Nested HPO paths behave like normal nested values. Explicit child-local override
 
 Nullable numeric HPO parameters are not supported directly. Model the nullable choice as a categorical branch:
 
+{% code overflow="wrap" %}
 ```python
 def tree_config(hp: HP):
     depth_mode = hp.select(["unlimited", "bounded"], name="depth_mode", default="bounded", options_only=True)
@@ -78,6 +81,7 @@ def tree_config(hp: HP):
 
     return {"max_depth": hp.int(12, name="max_depth", min=1, max=64)}
 ```
+{% endcode %}
 
 ## Exact API
 

--- a/docs/in-depth/values-and-overrides.md
+++ b/docs/in-depth/values-and-overrides.md
@@ -2,6 +2,7 @@
 
 `values=` is the dictionary you pass to `instantiate()`, `instantiate_with_params()`, or `explore()` to select concrete parameter values.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
 
@@ -14,9 +15,11 @@ def child(hp: HP):
 def parent(hp: HP):
     return {"child": hp.nest(child, name="child")}
 ```
+{% endcode %}
 
 ## Top-Level Values
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     return {"batch_size": hp.int(32, name="batch_size")}
@@ -24,24 +27,29 @@ def config(hp: HP):
 instantiate(config, values={"batch_size": 64})
 # => {"batch_size": 64}
 ```
+{% endcode %}
 
 ## Dotted Keys
 
 Use dotted keys for nested parameters:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(parent, values={"child.x": 15})
 # => {"child": {"x": 15, "y": 20}}
 ```
+{% endcode %}
 
 ## Nested Dictionaries
 
 Nested dictionaries are normalized to the same dotted paths:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(parent, values={"child": {"x": 25}})
 # => {"child": {"x": 25, "y": 20}}
 ```
+{% endcode %}
 
 You can mix dotted keys and nested dictionaries as long as each final parameter path appears once.
 
@@ -49,22 +57,27 @@ You can mix dotted keys and nested dictionaries as long as each final parameter 
 
 A nested scope name is a prefix for child parameters, not a parameter leaf by itself. These forms are valid because they target `child.x`:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(parent, values={"child.x": 15})
 instantiate(parent, values={"child": {"x": 15}})
 ```
+{% endcode %}
 
 This raises because `child` is a scope, not a selectable parameter:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(parent, values={"child": 123})
 # ValueError: Unknown or unreachable parameters
 ```
+{% endcode %}
 
 ## Duplicate Paths
 
 This raises because both entries target `child.x`:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(
     parent,
@@ -75,6 +88,7 @@ instantiate(
 )
 # ValueError: Duplicate value for 'child.x'
 ```
+{% endcode %}
 
 Hypster raises even when the duplicate values are identical. A single canonical path keeps experiment logs and replay payloads unambiguous.
 
@@ -82,6 +96,7 @@ Hypster raises even when the duplicate values are identical. A single canonical 
 
 Only parameters touched by the active branch may appear in `values=`.
 
+{% code overflow="wrap" %}
 ```python
 def model_config(hp: HP):
     family = hp.select(["linear", "forest"], name="family", default="linear", options_only=True)
@@ -94,6 +109,7 @@ def model_config(hp: HP):
 instantiate(model_config, values={"family": "linear", "n_estimators": 500})
 # ValueError: Unknown or unreachable parameters
 ```
+{% endcode %}
 
 Use `explore(model_config, values={"family": "forest"})` to inspect the branch before instantiating it.
 
@@ -113,6 +129,7 @@ Prefer the default for experiments and production replay. Softer policies are us
 
 Nested dictionaries inside `values=` are interpreted as nested parameter paths. If you need a select option whose runtime value is a dictionary, use dict-backed `select`:
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     return hp.select(
@@ -127,5 +144,6 @@ def config(hp: HP):
 instantiate(config, values={"model": "large"})
 # => {"layers": 4}
 ```
+{% endcode %}
 
 Do not pass `values={"model": {"layers": 4}}`; Hypster will treat that as a nested parameter path.

--- a/docs/integrations/hamilton.md
+++ b/docs/integrations/hamilton.md
@@ -8,6 +8,7 @@ Hamilton and Hypster can be used together by keeping graph construction and para
 
 ## Shape
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate_with_params
 
@@ -26,11 +27,13 @@ run = instantiate_with_params(
 # driver.execute(..., inputs=run.value)
 # tracker.log_params(run.params)
 ```
+{% endcode %}
 
 ## Execution Boundary
 
 Use `run.value` at the Hamilton execution boundary, and log `run.params` beside Hamilton metadata:
 
+{% code overflow="wrap" %}
 ```python
 # from hamilton import driver
 # import my_hamilton_nodes
@@ -48,6 +51,7 @@ run = instantiate_with_params(
 # tracker.log_params(run.params)
 # tracker.log_metrics(result["validation_metrics"])
 ```
+{% endcode %}
 
 Use Hamilton `inputs=` for runtime choices such as dataset, feature set, and model family. Use Hamilton `config=` only for static graph-construction choices in your Hamilton project. Hypster stays outside Hamilton's graph; it selects and records the values that you pass into the graph.
 

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -4,6 +4,7 @@ Haystack pipelines often have swappable retrievers, rankers, prompts, and genera
 
 ## Shape
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate_with_params
 
@@ -35,11 +36,13 @@ run = instantiate_with_params(
 # pipeline = build_haystack_pipeline(run.value)
 # tracker.log_params(run.params)
 ```
+{% endcode %}
 
 ## Build The Pipeline After Instantiation
 
 Keep Hypster configs focused on replayable settings. Build Haystack components after `instantiate_with_params()` so exploration and UI generation do not open indexes, clients, or network connections.
 
+{% code overflow="wrap" %}
 ```python
 def build_haystack_pipeline(settings):
     retrieval = settings["retrieval"]
@@ -70,6 +73,7 @@ run = instantiate_with_params(
 pipeline = build_haystack_pipeline(run.value)
 tracker.log_params(run.params)
 ```
+{% endcode %}
 
 If your components are cheap pure-Python objects, a config can return factories or initialized components. For retrievers, indexes, remote LLM clients, and pipelines that allocate resources, prefer returning lightweight settings and building the Haystack pipeline outside the config function.
 

--- a/docs/integrations/optuna.md
+++ b/docs/integrations/optuna.md
@@ -4,18 +4,23 @@ Optuna is the first supported HPO backend for Hypster. The integration lives in 
 
 ## Install
 
+{% code overflow="wrap" %}
 ```bash
 uv add 'hypster[optuna]'
 ```
+{% endcode %}
 
 or:
 
+{% code overflow="wrap" %}
 ```bash
 pip install 'hypster[optuna]'
 ```
+{% endcode %}
 
 ## Basic Pattern
 
+{% code overflow="wrap" %}
 ```python
 import optuna
 from hypster import HP, instantiate
@@ -52,6 +57,7 @@ def objective(trial: optuna.Trial) -> float:
 study = optuna.create_study(direction="maximize")
 study.optimize(objective, n_trials=30)
 ```
+{% endcode %}
 
 ## What Is Supported
 

--- a/docs/philosophy/hypster-vs.-alternatives.md
+++ b/docs/philosophy/hypster-vs.-alternatives.md
@@ -16,12 +16,14 @@ Use Hypster when:
 
 YAML, TOML, and JSON are excellent for static settings. Hypster is better when the configuration space itself contains logic:
 
+{% code overflow="wrap" %}
 ```python
 if provider == "openai":
     llm = hp.nest(openai_config, name="openai")
 else:
     llm = hp.nest(gemini_config, name="gemini")
 ```
+{% endcode %}
 
 The active branch determines which parameters exist for a run.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -2,9 +2,11 @@
 
 This page lists the public API exposed by `hypster`.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, InteractiveResult, explore, instantiate, instantiate_with_params, interact
 ```
+{% endcode %}
 
 ## Config Function Contract
 
@@ -12,12 +14,14 @@ A config function must be callable and its first positional parameter must be na
 
 Config functions are pure Python, not a DSL. `instantiate()`, `explore()`, `interact()`, and the HPO adapter all execute the function to discover or select values, so public API calls inherit any side effects or expensive work in the function body.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP
 
 def config(hp: HP):
     return {"batch_size": hp.int(32, name="batch_size")}
 ```
+{% endcode %}
 
 The `hp: HP` annotation is recommended but not mandatory. If the first parameter has a type annotation, it must include `HP`. Callable objects are supported when `inspect.signature()` can read their `__call__` signature; signature validation errors use the class name.
 
@@ -25,6 +29,7 @@ Config functions may accept extra positional or keyword arguments. Pass those th
 
 ## instantiate
 
+{% code overflow="wrap" %}
 ```python
 instantiate(
     func,
@@ -35,6 +40,7 @@ instantiate(
     on_unknown="raise",
 )
 ```
+{% endcode %}
 
 Executes a config function and returns whatever the function returns.
 
@@ -50,6 +56,7 @@ Executes a config function and returns whatever the function returns.
 
 ## instantiate_with_params
 
+{% code overflow="wrap" %}
 ```python
 instantiate_with_params(
     func,
@@ -60,9 +67,11 @@ instantiate_with_params(
     on_unknown="raise",
 )
 ```
+{% endcode %}
 
 Executes a config function and returns an `InstantiationOutput`.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate_with_params
 
@@ -74,14 +83,17 @@ run = instantiate_with_params(config, values={"model": "large"})
 assert run.value == {"model": "large"}
 assert run.params == {"model": "large"}
 ```
+{% endcode %}
 
 `run.params` includes every reachable `hp.*` parameter selected during the run, including defaults.
 
 ## InstantiationOutput
 
+{% code overflow="wrap" %}
 ```python
 InstantiationOutput(value, params)
 ```
+{% endcode %}
 
 | Attribute | Meaning |
 | --- | --- |
@@ -90,6 +102,7 @@ InstantiationOutput(value, params)
 
 ## explore
 
+{% code overflow="wrap" %}
 ```python
 explore(
     func,
@@ -101,17 +114,20 @@ explore(
     return_info=False,
 )
 ```
+{% endcode %}
 
 Traces a config function with a schema-recording `HP`. This executes the function to discover the active branch.
 
 * With `return_info=False`, prints a tree and returns `None`.
 * With `return_info=True`, returns a `ConfigSchema`.
 
+{% code overflow="wrap" %}
 ```python
 schema = explore(config, return_info=True)
 print(schema.defaults())
 print(schema.to_dict())
 ```
+{% endcode %}
 
 ## ConfigSchema
 
@@ -125,6 +141,7 @@ Returned by `explore(..., return_info=True)`.
 
 ## interact
 
+{% code overflow="wrap" %}
 ```python
 interact(
     func,
@@ -136,20 +153,25 @@ interact(
     auto_apply=True,
 ) -> InteractiveResult
 ```
+{% endcode %}
 
 Creates a notebook widget session for a config function and returns an `InteractiveResult` handle. Install the visualization extra before using it:
 
+{% code overflow="wrap" %}
 ```bash
 uv add "hypster[viz]"
 ```
+{% endcode %}
 
 `interact()` explores the config to render reachable controls, then instantiates the config from the current widget state. Widget changes can trigger repeated config execution to keep dependent controls current. The returned handle is not the configured object itself:
 
+{% code overflow="wrap" %}
 ```python
 result = interact(config)
 current_value = result.value
 current_params = result.params
 ```
+{% endcode %}
 
 | Parameter | Meaning |
 | --- | --- |
@@ -161,12 +183,14 @@ current_params = result.params
 
 ## InteractiveResult
 
+{% code overflow="wrap" %}
 ```python
 result.value
 result.params
 result.snapshot
 result.interact()
 ```
+{% endcode %}
 
 | Attribute or method | Meaning |
 | --- | --- |
@@ -177,10 +201,12 @@ result.interact()
 
 Replay an interactive selection the same way you replay any Hypster run:
 
+{% code overflow="wrap" %}
 ```python
 result = interact(config)
 replayed = instantiate(config, values=result.params)
 ```
+{% endcode %}
 
 ## ParameterInfo
 
@@ -207,12 +233,14 @@ UI builders should use schema metadata to render controls, then round-trip user 
 
 All parameter names must be valid Python identifier-style strings: use letters, numbers, and underscores, and do not include dots, spaces, hyphens, or Python keywords. Hypster composes dotted paths from nesting.
 
+{% code overflow="wrap" %}
 ```python
 hp.int(default, *, name, min=None, max=None, strict=False, allow_none=False, hpo_spec=None, description=None)
 hp.float(default, *, name, min=None, max=None, strict=False, allow_none=False, hpo_spec=None, description=None)
 hp.text(default, *, name, allow_none=False, description=None)
 hp.bool(default, *, name, allow_none=False, description=None)
 ```
+{% endcode %}
 
 | Method | Selected value |
 | --- | --- |
@@ -226,21 +254,26 @@ Numeric coercion is consistent for top-level parameters and nested paths.
 
 ## HP Select Methods
 
+{% code overflow="wrap" %}
 ```python
 hp.select(options, *, name, default=NO_DEFAULT, options_only=False, allow_none=False, hpo_spec=None, description=None)
 hp.multi_select(options, *, name, default=None, options_only=False, allow_none=False, description=None)
 ```
+{% endcode %}
 
 `options` may be a list of logging-safe scalar choices or a dictionary from logging-safe scalar keys to any runtime values.
 
 Use `allow_none=True` when `None` is one of the list-form choices:
 
+{% code overflow="wrap" %}
 ```python
 hp.select([None, "basic"], name="tokenizer", default=None, allow_none=True)
 ```
+{% endcode %}
 
 `hp.select([], name="choice", allow_none=True)` is valid and defaults to `None`. Without `allow_none=True`, an empty option list with no explicit default raises.
 
+{% code overflow="wrap" %}
 ```python
 model = hp.select(
     {
@@ -251,6 +284,7 @@ model = hp.select(
     default="small",
 )
 ```
+{% endcode %}
 
 The selected params record `"small"` or `"large"`, while the config function receives the mapped dictionary value.
 
@@ -258,17 +292,20 @@ By default, `options_only=False`, so custom scalar values outside the listed opt
 
 ## HP Multi-Value Methods
 
+{% code overflow="wrap" %}
 ```python
 hp.multi_int(default, *, name, min=None, max=None, strict=False, allow_none=False, description=None)
 hp.multi_float(default, *, name, min=None, max=None, strict=False, allow_none=False, description=None)
 hp.multi_text(default, *, name, allow_none=False, description=None)
 hp.multi_bool(default, *, name, allow_none=False, description=None)
 ```
+{% endcode %}
 
 These methods select lists whose elements are validated like the corresponding scalar type. `multi_int` accepts integral floats by default, and `multi_float` accepts integers by default. Both reject bool values. Nullable elements are not supported for `multi_int`, `multi_float`, `multi_text`, or `multi_bool`. Use `multi_select(..., allow_none=True)` for nullable categorical lists.
 
 ## HP.nest
 
+{% code overflow="wrap" %}
 ```python
 hp.nest(
     child,
@@ -280,9 +317,11 @@ hp.nest(
     description=None,
 )
 ```
+{% endcode %}
 
 Executes another config function under a named path.
 
+{% code overflow="wrap" %}
 ```python
 def child(hp: HP):
     return {"x": hp.int(1, name="x")}
@@ -290,12 +329,15 @@ def child(hp: HP):
 def parent(hp: HP):
     return hp.nest(child, name="child")
 ```
+{% endcode %}
 
 Override nested values with dotted paths:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(parent, values={"child.x": 2})
 ```
+{% endcode %}
 
 Nested dictionaries are normalized to the same dotted paths, so `values={"child": {"x": 2}}` is also valid. The scope name itself is not a parameter leaf: `values={"child": 2}` raises as unknown or unreachable.
 
@@ -303,12 +345,15 @@ Explicit child-local `values=` passed to `hp.nest(child, name="child", values=..
 
 ## HP.collect
 
+{% code overflow="wrap" %}
 ```python
 hp.collect(locals_dict, include=None, exclude=None)
 ```
+{% endcode %}
 
 Collects local variables into a dictionary while excluding `hp`, `self`, dunder names, and private names.
 
+{% code overflow="wrap" %}
 ```python
 def config(hp: HP):
     batch_size = hp.int(32, name="batch_size")
@@ -316,3 +361,4 @@ def config(hp: HP):
     helper = "not returned"
     return hp.collect(locals(), exclude=["helper"])
 ```
+{% endcode %}

--- a/docs/reference/error-handling.md
+++ b/docs/reference/error-handling.md
@@ -10,6 +10,7 @@ Public validation failures currently raise `ValueError`. When `on_unknown="warn"
 
 `instantiate()`, `instantiate_with_params()`, and `explore()` default to `on_unknown="raise"`.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
 
@@ -21,11 +22,13 @@ def config(hp: HP):
 
 instantiate(config, values={"mode": "b", "count": 3})
 ```
+{% endcode %}
 
 `count` is unreachable on the `mode="b"` branch, so Hypster raises.
 
 Example message:
 
+{% code overflow="wrap" %}
 ```text
 Unknown or unreachable parameters:
   - 'count': Unknown parameter
@@ -33,6 +36,7 @@ Unknown or unreachable parameters:
 Run explore(config, values=...) to inspect the active branch.
 Nested dict values are interpreted as parameter paths; use dict-backed select keys for objects.
 ```
+{% endcode %}
 
 Unknown and unreachable values share the same public error family because both mean "this key was not consumed by the active run." To diagnose the difference, run `explore(config, values=...)` for the selected branch:
 
@@ -41,10 +45,13 @@ Unknown and unreachable values share the same public error family because both m
 
 A typo can include a nearest-name suggestion:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(config, values={"mode": "a", "coutn": 3})
 ```
+{% endcode %}
 
+{% code overflow="wrap" %}
 ```text
 Unknown or unreachable parameters:
   - 'coutn': Did you mean 'count'? (similarity: 80%)
@@ -52,16 +59,20 @@ Unknown or unreachable parameters:
 Run explore(config, values=...) to inspect the active branch.
 Nested dict values are interpreted as parameter paths; use dict-backed select keys for objects.
 ```
+{% endcode %}
 
 Use softer policies only when intentional:
 
+{% code overflow="wrap" %}
 ```python
 instantiate(config, values={"mode": "b", "count": 3}, on_unknown="warn")
 instantiate(config, values={"mode": "b", "count": 3}, on_unknown="ignore")
 ```
+{% endcode %}
 
 With `on_unknown="warn"`, use Python warning controls if you need to capture the message in a UI or test:
 
+{% code overflow="wrap" %}
 ```python
 import warnings
 
@@ -70,9 +81,11 @@ with warnings.catch_warnings(record=True) as caught:
 
 assert caught
 ```
+{% endcode %}
 
 For user-facing tools, a common strategy is:
 
+{% code overflow="wrap" %}
 ```python
 try:
     value = instantiate(config, values=form_values)
@@ -81,6 +94,7 @@ except ValueError as exc:
 else:
     run_workflow(value)
 ```
+{% endcode %}
 
 Interactive widget handles expose the same validation through a different boundary: direct `instantiate()` and `explore()` failures raise `ValueError`, while reading `InteractiveResult.value` or `InteractiveResult.params` during an invalid applied state raises `RuntimeError` with the underlying validation message. Show either message to the user and keep the last valid submitted params separate from draft UI state.
 
@@ -88,28 +102,34 @@ Interactive widget handles expose the same validation through a different bounda
 
 Parameter and nest names must be Python identifier-style strings.
 
+{% code overflow="wrap" %}
 ```python
 hp.int(32, name="batch_size")  # valid
 hp.int(32, name="batch-size")  # invalid
 ```
+{% endcode %}
 
 Use nesting to create dotted paths:
 
+{% code overflow="wrap" %}
 ```python
 hp.nest(child_config, name="model")
 # child_config's "learning_rate" parameter becomes "model.learning_rate"
 ```
+{% endcode %}
 
 ## Duplicate Value Paths
 
 These two entries spell the same final parameter path:
 
+{% code overflow="wrap" %}
 ```python
 values = {
     "model.learning_rate": 0.01,
     "model": {"learning_rate": 0.01},
 }
 ```
+{% endcode %}
 
 Hypster raises even if both values are identical, because duplicate inputs make logs ambiguous.
 
@@ -128,12 +148,15 @@ Each `hp.*` call validates runtime values:
 
 Do not put dictionaries or lists directly inside list-backed `select` choices:
 
+{% code overflow="wrap" %}
 ```python
 hp.select([{"layers": 2}, {"layers": 4}], name="model")
 ```
+{% endcode %}
 
 Use dictionary-backed select instead:
 
+{% code overflow="wrap" %}
 ```python
 hp.select(
     {
@@ -143,5 +166,6 @@ hp.select(
     name="model",
 )
 ```
+{% endcode %}
 
 The selected key is replayable, and the runtime value can still be complex.

--- a/docs/reference/optuna-hpo.md
+++ b/docs/reference/optuna-hpo.md
@@ -2,29 +2,37 @@
 
 Install Optuna support:
 
+{% code overflow="wrap" %}
 ```bash
 uv add 'hypster[optuna]'
 ```
+{% endcode %}
 
 Public imports:
 
+{% code overflow="wrap" %}
 ```python
 from hypster.hpo.optuna import suggest_values
 from hypster.hpo.types import HpoCategorical, HpoFloat, HpoInt
 ```
+{% endcode %}
 
 ## suggest_values
 
+{% code overflow="wrap" %}
 ```python
 suggest_values(trial, *, config, args=(), kwargs=None) -> dict
 ```
+{% endcode %}
 
 Runs `config` with a trial-backed `HP` proxy and returns a `values` dictionary that can be passed to `instantiate()`.
 
+{% code overflow="wrap" %}
 ```python
 values = suggest_values(trial, config=model_config)
 cfg = instantiate(model_config, values=values)
 ```
+{% endcode %}
 
 The adapter is branch-aware. It only suggests parameters reached by the sampled execution path.
 
@@ -32,6 +40,7 @@ For numeric suggestions, `min` and `max` on the `hp.int` or `hp.float` call defi
 
 ## HpoInt
 
+{% code overflow="wrap" %}
 ```python
 HpoInt(
     step=None,
@@ -40,6 +49,7 @@ HpoInt(
     include_max=True,
 )
 ```
+{% endcode %}
 
 | Field | Meaning |
 | --- | --- |
@@ -50,6 +60,7 @@ HpoInt(
 
 ## HpoFloat
 
+{% code overflow="wrap" %}
 ```python
 HpoFloat(
     step=None,
@@ -60,6 +71,7 @@ HpoFloat(
     spread=None,
 )
 ```
+{% endcode %}
 
 | Field | Meaning |
 | --- | --- |
@@ -73,9 +85,11 @@ If `distribution="loguniform"`, the adapter uses Optuna's log sampling even if `
 
 ## HpoCategorical
 
+{% code overflow="wrap" %}
 ```python
 HpoCategorical(ordered=False, weights=None)
 ```
+{% endcode %}
 
 The current Optuna adapter uses `trial.suggest_categorical()` for `hp.select`. `ordered=True` and `weights=...` are rejected because Optuna categorical suggestions cannot express ordered or weighted categorical semantics.
 
@@ -100,6 +114,7 @@ Explicit child-local overrides passed with `hp.nest(child, name="child", values=
 
 `suggest_values()` raises `ValueError` when a backend-agnostic HPO spec asks for semantics that Optuna cannot represent.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP
 from hypster.hpo.optuna import suggest_values
@@ -123,9 +138,12 @@ def weighted_choice_config(hp: HP):
         hpo_spec=HpoCategorical(weights=[0.8, 0.2]),
     )
 ```
+{% endcode %}
 
 Both fail during `suggest_values(trial, config=...)` before a values dictionary is returned. Show the error as configuration feedback:
 
+{% code overflow="wrap" %}
 ```text
 This HPO spec cannot be represented by the Optuna adapter. Use uniform/loguniform float sampling, remove categorical weights or ordering, or implement custom sampling inside the objective.
 ```
+{% endcode %}

--- a/docs/reproducibility/deploying-to-production.md
+++ b/docs/reproducibility/deploying-to-production.md
@@ -12,6 +12,7 @@ Hypster is in preview, so production use should be deliberate. When you do deplo
 
 ## Example Smoke Test
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate_with_params
 
@@ -29,6 +30,7 @@ def test_production_config():
     )
     assert run.params["replicas"] == 4
 ```
+{% endcode %}
 
 ## Avoid Stale Overrides
 

--- a/docs/reproducibility/experiment-tracking.md
+++ b/docs/reproducibility/experiment-tracking.md
@@ -2,6 +2,7 @@
 
 Use `instantiate_with_params()` to log the exact parameters selected by a run.
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate_with_params
 
@@ -23,14 +24,17 @@ assert run.params == {
     "batch_size": 128,
 }
 ```
+{% endcode %}
 
 ## Log To A Tracker
 
+{% code overflow="wrap" %}
 ```python
 def log_hypster_run(tracker, run):
     for path, value in run.params.items():
         tracker.log_param(path, value)
 ```
+{% endcode %}
 
 The params include defaults as well as explicit overrides. That matters because defaults may change between versions.
 
@@ -38,6 +42,7 @@ The params include defaults as well as explicit overrides. That matters because 
 
 Use `run.params` for replay, then store adjacent metadata that explains the code, data, and outputs that produced the run:
 
+{% code overflow="wrap" %}
 ```python
 import hypster
 
@@ -52,6 +57,7 @@ record = {
     "dataset_id": "warehouse/churn/2026-05-01",
 }
 ```
+{% endcode %}
 
 For trackers with separate concepts, log `params` as parameters, versions and dataset IDs as tags, metrics as metrics, and large files as artifacts.
 
@@ -65,6 +71,7 @@ At minimum, log:
 * `run.params`
 * the metric values produced by the run
 
+{% code overflow="wrap" %}
 ```python
 import hypster
 
@@ -73,14 +80,17 @@ metadata = {
     "params": run.params,
 }
 ```
+{% endcode %}
 
 ## Replay
 
+{% code overflow="wrap" %}
 ```python
 from hypster import instantiate
 
 replayed = instantiate(training_config, values=run.params)
 assert replayed == run.value
 ```
+{% endcode %}
 
 If replay fails because a parameter is now unknown, inspect the old payload with `explore(training_config, values=old_params, on_unknown="warn")` and migrate it deliberately.

--- a/docs/reproducibility/observing-past-runs.md
+++ b/docs/reproducibility/observing-past-runs.md
@@ -4,6 +4,7 @@ When a past run stores Hypster params, you can inspect what those params mean ag
 
 ## Inspect The Active Branch
 
+{% code overflow="wrap" %}
 ```python
 from hypster import HP, explore
 
@@ -19,6 +20,7 @@ past_params = {"model": "forest", "n_estimators": 500}
 
 explore(config, values=past_params)
 ```
+{% endcode %}
 
 The tree shows the reachable parameters for that recorded branch.
 
@@ -26,17 +28,21 @@ The tree shows the reachable parameters for that recorded branch.
 
 Use `on_unknown="warn"` when reviewing old payloads that may include stale fields:
 
+{% code overflow="wrap" %}
 ```python
 explore(config, values={"model": "linear", "n_estimators": 500}, on_unknown="warn")
 ```
+{% endcode %}
 
 Do not replay with `on_unknown="ignore"` until you have decided which old values should be dropped or migrated.
 
 ## Compare Defaults
 
+{% code overflow="wrap" %}
 ```python
 schema = explore(config, values=past_params, return_info=True)
 current_branch_defaults = schema.defaults()
 ```
+{% endcode %}
 
 This is useful when you want to know which values were explicit in a past run and which current defaults would apply if they were omitted.

--- a/docs/reproducibility/serialization.md
+++ b/docs/reproducibility/serialization.md
@@ -4,6 +4,7 @@ Hypster does not define a custom serialization format. The recommended reproduci
 
 ## JSON Params
 
+{% code overflow="wrap" %}
 ```python
 import json
 from hypster import HP, explore, instantiate, instantiate_with_params
@@ -20,11 +21,13 @@ restored = json.loads(payload)
 
 assert instantiate(config, values=restored) == run.value
 ```
+{% endcode %}
 
 ## Complex Runtime Values
 
 Use dict-backed `select` so the serialized params contain simple keys:
 
+{% code overflow="wrap" %}
 ```python
 def model_config(hp: HP):
     return hp.select(
@@ -36,6 +39,7 @@ def model_config(hp: HP):
         default="small",
     )
 ```
+{% endcode %}
 
 `instantiate_with_params(model_config, values={"model": "large"}).params` records `{"model": "large"}`, not the mapped dictionary.
 
@@ -43,10 +47,12 @@ def model_config(hp: HP):
 
 `explore(config, return_info=True).to_dict()` returns JSON-serializable schema metadata for UIs, catalogs, and validation tools.
 
+{% code overflow="wrap" %}
 ```python
 schema = explore(config, return_info=True).to_dict()
 json.dumps(schema)
 ```
+{% endcode %}
 
 Schema metadata is not a replacement for selected params. Use schema for rendering and params for replay.
 
@@ -54,6 +60,7 @@ Schema metadata is not a replacement for selected params. Use schema for renderi
 
 When params leave the current process, store them with enough identity to understand which code and data produced the original run:
 
+{% code overflow="wrap" %}
 ```python
 import json
 import hypster
@@ -73,6 +80,7 @@ restored = json.loads(payload)
 
 replayed = instantiate(config, values=restored["params"])
 ```
+{% endcode %}
 
 If replay fails after the config evolves, inspect the old payload with `explore(config, values=restored["params"], on_unknown="warn")`, migrate the parameter names deliberately, and save the migrated artifact as a new record.
 
@@ -80,6 +88,7 @@ If replay fails after the config evolves, inspect the old payload with `explore(
 
 The versioned artifact still protects you when defaults change, because replay uses stored params:
 
+{% code overflow="wrap" %}
 ```python
 def training_config(hp: HP):
     return {"batch_size": hp.int(64, name="batch_size")}
@@ -105,3 +114,4 @@ def training_config(hp: HP):
 
 assert instantiate(training_config, values=restored["params"]) == {"batch_size": 64}
 ```
+{% endcode %}


### PR DESCRIPTION
## Summary

- Updated docs/README LLM examples from older model IDs to current provider examples: `gpt-5.5`, `gpt-5.4-mini`, `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-haiku-4-5`, `gemini-3.5-flash`, and `gemini-3.1-pro-preview`.
- Added GitBook native wrapped-code containers (`{% code overflow="wrap" %}`) around docs code blocks so long snippets wrap instead of forcing horizontal scrolling.
- Hard-wrapped README snippets directly, since GitHub README rendering does not understand GitBook block tags.

## Source Check

Verified model naming against official provider docs:

- OpenAI models: https://developers.openai.com/api/docs/models
- Gemini models: https://ai.google.dev/gemini-api/docs/models
- Anthropic models: https://platform.claude.com/docs/en/about-claude/models/overview

## Before / After

Before:

```python
model_name = hp.select(["gpt-5", "claude-sonnet-4-0", "gemini-2.5-flash"], name="model_name")
```

After:

```python
model_name = hp.select(
    [
        "gpt-5.5",
        "claude-sonnet-4-6",
        "claude-opus-4-7",
        "gemini-3.5-flash",
    ],
    name="model_name",
    default="gpt-5.5",
)
```

Code blocks in GitBook docs now use wrapping metadata:

````markdown
{% code overflow="wrap" %}
```python
from hypster import explore

explore(llm_config)
```
{% endcode %}
````

## Validation

- `git diff --check`
- `uv run pre-commit run --files $(git diff --cached --name-only)`
- `uv run pytest tests/test_version.py tests/test_explore.py`
