### PR TITLE
[codex] Update release install guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,11 +68,13 @@ jobs:
         run: |
           echo "🔄 Updating version to $VERSION"
 
-          # Backup original file
+          # Backup original files
           cp pyproject.toml pyproject.toml.backup
+          cp src/hypster/_version.py src/hypster/_version.py.backup
 
           # Update version in pyproject.toml
           sed -i -E "0,/^version = \".*\"/s//version = \"$VERSION\"/" pyproject.toml
+          sed -i -E "s/^__version__ = \".*\"/__version__ = \"$VERSION\"/" src/hypster/_version.py
 
           # Verify the change was made
           if ! grep -q "version = \"$VERSION\"" pyproject.toml; then
@@ -82,19 +84,27 @@ jobs:
             exit 1
           fi
 
+          if ! grep -q "__version__ = \"$VERSION\"" src/hypster/_version.py; then
+            echo "❌ Failed to update version in src/hypster/_version.py"
+            echo "Current content around version line:"
+            grep -n -A2 -B2 "__version__ = " src/hypster/_version.py || echo "No version line found"
+            exit 1
+          fi
+
           echo "✅ Version updated successfully"
           echo "Updated version line:"
           grep "version = " pyproject.toml
+          grep "__version__ = " src/hypster/_version.py
 
           # Configure git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Check if there are changes to commit
-          if git diff --quiet pyproject.toml; then
+          if git diff --quiet pyproject.toml src/hypster/_version.py; then
             echo "⚠️ No version changes detected"
           else
-            git add pyproject.toml
+            git add pyproject.toml src/hypster/_version.py
             git commit -m "chore: bump version to v$VERSION"
 
             # Push changes
@@ -208,7 +218,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.version_update.outputs.version }}
-          name: "Hypster v${{ steps.version_update.outputs.version }}"
+          name: "hypster v${{ steps.version_update.outputs.version }}"
           body: |
             ${{ steps.changelog.outputs.content }}
 
@@ -224,6 +234,11 @@ jobs:
             **With HPO support:**
             ```bash
             pip install 'hypster[optuna]==${{ steps.version_update.outputs.version }}'
+            ```
+
+            **With notebook visualization UI:**
+            ```bash
+            pip install 'hypster[viz]==${{ steps.version_update.outputs.version }}'
             ```
 
             ## 📚 Documentation
@@ -249,6 +264,8 @@ jobs:
           echo "### 📦 Installation Commands" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "pip install hypster==${{ steps.version_update.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "pip install 'hypster[optuna]==${{ steps.version_update.outputs.version }}'" >> $GITHUB_STEP_SUMMARY
+          echo "pip install 'hypster[viz]==${{ steps.version_update.outputs.version }}'" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   publish-pypi:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Or using pip:
 
 ```bash
 pip install hypster
+# optional notebook visualization UI
+pip install 'hypster[viz]'
+# optional HPO backend
+pip install 'hypster[optuna]'
 ```
 
 ## Quick Start

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,6 +99,14 @@ uv add 'hypster[optuna]'
 ```
 {% endcode %}
 
+For the notebook visualization UI:
+
+{% code overflow="wrap" %}
+```bash
+uv add 'hypster[viz]'
+```
+{% endcode %}
+
 ## Where To Go Next
 
 <table data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>Getting Started</strong></td><td>Install Hypster, define your first config, explore branches, and instantiate values.</td><td><a href="getting-started/installation.md">installation.md</a></td></tr><tr><td><strong>Examples</strong></td><td>Copy patterns for ML, data processing, AI workflows, nested configs, UI generation, and experiment tracking.</td><td><a href="examples/">examples</a></td></tr><tr><td><strong>Reference</strong></td><td>Exact public API signatures, parameter behavior, error handling, and Optuna integration facts.</td><td><a href="reference/api.md">api.md</a></td></tr></tbody></table>


### PR DESCRIPTION
## Summary
- Rename generated GitHub releases from `Hypster v...` to `hypster v...`.
- Add the `[viz]` install option to generated release notes, the GitHub Actions summary, README pip instructions, and the GitBook landing page.
- Keep release version bumps aligned with the repo rule by updating both `pyproject.toml` and `src/hypster/_version.py` in the workflow.

## Before / After

Before:
```yaml
name: "Hypster v${{ steps.version_update.outputs.version }}"
```
```bash
pip install hypster==0.5.2
pip install 'hypster[optuna]==0.5.2'
```

After:
```yaml
name: "hypster v${{ steps.version_update.outputs.version }}"
```
```bash
pip install hypster==0.5.2
pip install 'hypster[optuna]==0.5.2'
pip install 'hypster[viz]==0.5.2'
```

## Validation
- `uv run pytest tests/test_version.py`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'workflow yaml ok'"`
- `git diff --check`
- pre-commit hook on commit: trim trailing whitespace, end-of-file, YAML check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Installation instructions updated to include optional package extras: `hypster[viz]` for notebook visualization UI and `hypster[optuna]` for HPO backend integration.

* **Chores**
  * Enhanced GitHub Actions release workflow for improved version management and release documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypster/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->