### PR TITLE
[codex] Correct docs runtime object patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@
 
 ## Key Features
 
-- 🐍 **Pure Python, Not a DSL**: Use normal functions, `if` statements, loops, lists, helper functions, imports, dataclasses, and runtime objects
+- 🐍 **Pure Python, Not a DSL**: Use normal functions, `if` statements, loops, lists, helper functions, imports, and runtime objects
 - 🪆 **Hierarchical, Conditional Configurations**: Support for nested and swappable configurations
 - 📐 **Type Safety**: Built-in type hints and validation
 - 🧪 **Hyperparameter Optimization Built-In**: Native, first-class optuna support
 
-Hypster configs are ordinary Python functions rather than a separate configuration language. That keeps them flexible and readable, but it also means Hypster discovers the available parameters by executing the function. Keep config functions fast and side-effect-free: avoid paid API calls, network calls, file writes, training, database access, and costly initialization in code paths used by `explore()`, HPO, or interactive UIs.
+Hypster configs are ordinary Python functions rather than a separate configuration language. That keeps them flexible and readable, but it also means Hypster discovers the available parameters by executing the function. A config usually returns the initialized object your application needs. Keep config functions fast and side-effect-free: avoid paid API calls, network calls, file writes, training, database access, and costly initialization in code paths used by `explore()`, HPO, or interactive UIs.
 
 ## Installation
 
@@ -75,31 +75,55 @@ pip install 'hypster[optuna]'
 Define a configuration function and instantiate it with overrides:
 
 ```python
-from dataclasses import dataclass
 from hypster import HP, explore, instantiate_with_params
+from my_app.llms import GeminiClient, OpenAIClient
 
-@dataclass
-class LLMSettings:
-    provider: str
-    temperature: float
-    max_tokens: int
 
-def llm_config(hp: HP) -> LLMSettings:
-    provider = hp.select(["openai", "gemini"], name="provider", default="openai", options_only=True)
+def openai_config(hp: HP) -> OpenAIClient:
+    model = hp.select(["gpt-5", "gpt-5-mini"], name="model", default="gpt-5-mini", options_only=True)
     temperature = hp.float(0.7, name="temperature", min=0.0, max=1.0)
     max_tokens = hp.int(256, name="max_tokens", min=1, max=4096)
-    return LLMSettings(provider=provider, temperature=temperature, max_tokens=max_tokens)
+    return OpenAIClient(model=model, temperature=temperature, max_tokens=max_tokens)
+
+
+def gemini_config(hp: HP) -> GeminiClient:
+    model = hp.select(
+        ["gemini-3.5-flash", "gemini-3.1-pro"],
+        name="model",
+        default="gemini-3.5-flash",
+        options_only=True,
+    )
+    temperature = hp.float(0.3, name="temperature", min=0.0, max=1.0)
+    return GeminiClient(model=model, temperature=temperature)
+
+
+llm_options = {
+    "openai": openai_config,
+    "gemini": gemini_config,
+}
+
+# Use a named options dict for swappable components. The params log the
+# simple key, while the config receives the selected child config function.
+
+def llm_config(hp: HP):
+    selected_config = hp.select(llm_options, name="provider", default="openai", options_only=True)
+    return hp.nest(selected_config, name="llm")
 
 explore(llm_config)
 # llm_config
 # ├── provider: select = "openai"  (options: ["openai", "gemini"])
-# ├── temperature: float = 0.7  (0.0-1.0)
-# └── max_tokens: int = 256  (1-4096)
+# └── llm
+#     ├── model: select = "gpt-5-mini"  (options: ["gpt-5", "gpt-5-mini"])
+#     ├── temperature: float = 0.7  (0.0-1.0)
+#     └── max_tokens: int = 256  (1-4096)
 
-run = instantiate_with_params(llm_config, values={"provider": "gemini", "temperature": 0.3})
+run = instantiate_with_params(
+    llm_config,
+    values={"provider": "gemini", "llm.temperature": 0.1},
+)
 
-assert run.value == LLMSettings(provider="gemini", temperature=0.3, max_tokens=256)
-assert run.params == {"provider": "gemini", "temperature": 0.3, "max_tokens": 256}
+response = run.value.invoke("How's your day going?")
+assert run.params["provider"] == "gemini"
 ```
 
 Use `explore(..., values=...)` to inspect a specific conditional branch before you instantiate it, or `explore(..., return_info=True)` to get a JSON-serializable schema object.
@@ -111,42 +135,39 @@ import optuna
 from hypster import HP, instantiate
 from hypster.hpo.optuna import suggest_values
 from hypster.hpo.types import HpoFloat, HpoInt
+from sklearn.base import ClassifierMixin
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
 
 
-def model_cfg(hp: HP):
-    family = hp.select(
-        ["linear", "forest"],
-        name="family",
-        default="forest",
-        options_only=True,
+def logistic_config(hp: HP) -> LogisticRegression:
+    C = hp.float(1.0, name="C", min=1e-4, max=10.0, hpo_spec=HpoFloat(scale="log"))
+    return LogisticRegression(C=C, max_iter=1000)
+
+
+def forest_config(hp: HP) -> RandomForestClassifier:
+    n_estimators = hp.int(
+        200,
+        name="n_estimators",
+        min=50,
+        max=1000,
+        hpo_spec=HpoInt(step=50),
     )
-    if family == "linear":
-        return {
-            "family": family,
-            "alpha": hp.float(
-                0.1,
-                name="alpha",
-                min=1e-4,
-                max=10.0,
-                hpo_spec=HpoFloat(scale="log"),
-            ),
-        }
-    return {
-        "family": family,
-        "n_estimators": hp.int(
-            200,
-            name="n_estimators",
-            min=50,
-            max=1000,
-            hpo_spec=HpoInt(step=50),
-        ),
-    }
+    return RandomForestClassifier(n_estimators=n_estimators, random_state=42)
+
+
+model_options = {"logistic": logistic_config, "forest": forest_config}
+
+
+def model_cfg(hp: HP) -> ClassifierMixin:
+    model_config = hp.select(model_options, name="model_family", default="forest", options_only=True)
+    return hp.nest(model_config, name="model")
 
 
 def objective(trial: optuna.Trial) -> float:
     values = suggest_values(trial, config=model_cfg)
-    cfg = instantiate(model_cfg, values=values)
-    return train_and_score(cfg)
+    model = instantiate(model_cfg, values=values)
+    return train_and_score(model)
 
 study = optuna.create_study(direction="maximize")
 study.optimize(objective, n_trials=30)

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,13 +19,13 @@ layout:
 
 <div data-full-width="false"><figure><picture><source srcset=".gitbook/assets/hypster_text_white_text.png" media="(prefers-color-scheme: dark)"><img src=".gitbook/assets/hypster_with_text (1).png" alt=""></picture><figcaption></figcaption></figure></div>
 
-### Hypster is a lightweight configuration framework for managing and **optimizing AI & ML workflows**
+## Hypster is a lightweight configuration framework for managing and **optimizing AI & ML workflows**
 
 > Hypster is in preview and is not ready for production use.
 >
 > We're working hard to make Hypster stable and feature-complete, but until then, expect to encounter bugs, missing features, and occasional breaking changes.
 
-### Key Features
+## Key Features
 
 * :snake: **Pure Python, Not a DSL**: Use normal functions, `if` statements, loops, helper functions, imports, and real object construction
 * :nesting\_dolls: **Hierarchical, Conditional Configurations**: Support for nested and swappable runtime components
@@ -37,7 +37,7 @@ Hypster configs are ordinary Python functions rather than a separate configurati
 
 > Show your support by giving us a [star](https://github.com/gilad-rubin/hypster)! ⭐
 
-### How Does it work?
+## How Does it work?
 
 {% stepper %}
 {% step %}

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,71 +19,29 @@ layout:
 
 <div data-full-width="false"><figure><picture><source srcset=".gitbook/assets/hypster_text_white_text.png" media="(prefers-color-scheme: dark)"><img src=".gitbook/assets/hypster_with_text (1).png" alt=""></picture><figcaption></figcaption></figure></div>
 
-## Hypster is a lightweight configuration framework for building, exploring, replaying, and optimizing Python workflows.
+### Hypster is a lightweight configuration framework for managing and **optimizing AI & ML workflows**
 
 > Hypster is in preview and is not ready for production use.
 >
 > We're working hard to make Hypster stable and feature-complete, but until then, expect to encounter bugs, missing features, and occasional breaking changes.
 
-Hypster is designed for projects where a "configuration" is not just a flat settings file. It works well when you need conditional branches, nested components, ML and AI experiments, data pipelines, or a UI/search system that needs to discover the active parameter space before running code.
+### Key Features
 
-Hypster configs are pure Python functions, not a separate DSL. You can use normal `if` statements, loops, lists, helper functions, imports, dataclasses, and initialized objects. The tradeoff is important: to discover which parameters exist for a branch, Hypster runs the config function. Keep that function fast and free of side effects or surprise costs, especially when using `explore()` or `interact()`.
+* :snake: **Pure Python, Not a DSL**: Use normal functions, `if` statements, loops, helper functions, imports, and real object construction
+* :nesting\_dolls: **Hierarchical, Conditional Configurations**: Support for nested and swappable runtime components
+* :triangular\_ruler: **Type Safety**: Built-in type hints and validation
+* :mag: **Schema Exploration**: Inspect parameters, defaults, and active branches with `explore()`
+* :test_tube: **Hyperparameter Optimization Built-In**: Native, first-class optuna support
 
-## First Example
+Hypster configs are ordinary Python functions rather than a separate configuration language. That keeps them flexible and readable, but it also means Hypster discovers the available parameters by executing the function. Keep config functions fast and side-effect-free: avoid paid API calls, network calls, file writes, training, database access, and costly initialization in code paths used by `explore()`, HPO, or interactive UIs.
 
-{% code overflow="wrap" %}
-```python
-from dataclasses import dataclass
-from hypster import HP, explore, instantiate_with_params
+> Show your support by giving us a [star](https://github.com/gilad-rubin/hypster)! ⭐
 
-@dataclass
-class ForestTrainingConfig:
-    seed: int
-    n_estimators: int
-    max_depth: int | None
+### How Does it work?
 
-@dataclass
-class LinearTrainingConfig:
-    seed: int
-    alpha: float
-
-def train_config(hp: HP) -> ForestTrainingConfig | LinearTrainingConfig:
-    model = hp.select(["linear", "forest"], name="model", default="forest")
-    seed = hp.int(42, name="seed", min=0)
-
-    if model == "forest":
-        n_estimators = hp.int(200, name="n_estimators", min=10, max=1000)
-        max_depth = hp.int(None, name="max_depth", allow_none=True)
-        return ForestTrainingConfig(seed=seed, n_estimators=n_estimators, max_depth=max_depth)
-
-    alpha = hp.float(0.1, name="alpha", min=0.0, max=10.0)
-    return LinearTrainingConfig(seed=seed, alpha=alpha)
-
-explore(train_config)
-
-run = instantiate_with_params(
-    train_config,
-    values={"model": "forest", "n_estimators": 500},
-)
-
-print(run.value)
-print(run.params)
-```
-{% endcode %}
-
-The output value is the typed runtime object you use in your application. The `params` sidecar is the replayable record of every parameter Hypster selected on that run, including defaults.
-
-## Why Use Hypster?
-
-* **Plain Python configs**: a config function is an ordinary function whose first argument is `hp: HP`.
-* **Typed runtime outputs**: return initialized objects directly, with a return type annotation when the output type matters.
-* **Branch-aware exploration**: `explore()` shows the active parameter tree, including nested branches selected by `values=`.
-* **Replayable runs**: `instantiate_with_params()` records the selected parameter paths for experiment tracking and production replay.
-* **Nested composition**: use `hp.nest()` to assemble workflows from smaller config functions.
-* **Typed validation**: numeric bounds, scalar types, nullable values, select options, and unknown overrides are checked at the API boundary.
-* **HPO bridge**: `hypster.hpo.optuna.suggest_values()` converts the same config function into an Optuna search space.
-
-## Install
+{% stepper %}
+{% step %}
+**Install Hypster**
 
 {% code overflow="wrap" %}
 ```bash
@@ -91,53 +49,114 @@ uv add hypster
 ```
 {% endcode %}
 
-For Optuna support:
+Or using pip:
 
 {% code overflow="wrap" %}
 ```bash
+pip install hypster
+```
+{% endcode %}
+
+{% code overflow="wrap" %}
+```bash
+# optional notebook visualization UI
+uv add 'hypster[viz]'
+# optional HPO backend
 uv add 'hypster[optuna]'
 ```
 {% endcode %}
 
-For the notebook visualization UI:
-
 {% code overflow="wrap" %}
 ```bash
-uv add 'hypster[viz]'
+# optional notebook visualization UI
+pip install 'hypster[viz]'
+# optional HPO backend
+pip install 'hypster[optuna]'
 ```
 {% endcode %}
+{% endstep %}
 
-## Where To Go Next
+{% step %}
+**Define a configuration space**
 
-<table data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>Getting Started</strong></td><td>Install Hypster, define your first config, explore branches, and instantiate values.</td><td><a href="getting-started/installation.md">installation.md</a></td></tr><tr><td><strong>Examples</strong></td><td>Copy patterns for ML, data processing, AI workflows, nested configs, UI generation, and experiment tracking.</td><td><a href="examples/">examples</a></td></tr><tr><td><strong>Reference</strong></td><td>Exact public API signatures, parameter behavior, error handling, and Optuna integration facts.</td><td><a href="reference/api.md">api.md</a></td></tr></tbody></table>
+{% code overflow="wrap" %}
+```python
+from hypster import HP
+from my_app.llms import LLMClient
+
+
+def llm_config(hp: HP) -> LLMClient:
+    model_name = hp.select(
+        ["gpt-5", "claude-sonnet-4-6", "gemini-3.5-flash"],
+        name="model_name",
+        default="gpt-5",
+        options_only=True,
+    )
+    temperature = hp.float(0.0, name="temperature", min=0.0, max=1.0)
+    return LLMClient(model_name=model_name, temperature=temperature)
+```
+{% endcode %}
+{% endstep %}
+
+{% step %}
+**Explore your configuration**
+
+{% code overflow="wrap" %}
+```python
+from hypster import explore
+
+explore(llm_config)
+```
+{% endcode %}
+{% endstep %}
+
+{% step %}
+**Instantiate your runtime object**
+
+{% code overflow="wrap" %}
+```python
+from hypster import instantiate
+
+llm = instantiate(llm_config, values={"model_name": "gpt-5", "temperature": 0.7})
+```
+{% endcode %}
+{% endstep %}
+
+{% step %}
+**Execute!**
+
+{% code overflow="wrap" %}
+```python
+llm.invoke("What is Hypster?")
+```
+{% endcode %}
+{% endstep %}
+{% endstepper %}
+
+## Discover Hypster
+
+<table data-view="cards"><thead><tr><th></th><th></th><th></th><th data-hidden data-card-cover data-type="files"></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>Getting Started</strong></td><td>How to create &#x26; instantiate Hypster configs</td><td></td><td><a href=".gitbook/assets/Group 4 (5).png">Group 4 (5).png</a></td><td><a href="getting-started/installation.md">installation.md</a></td></tr><tr><td><strong>Tutorials</strong></td><td>Step-by-step guides for ML &#x26; Generative AI use-cases</td><td></td><td><a href=".gitbook/assets/Group 53.png">Group 53.png</a></td><td><a href="examples/">examples</a></td></tr><tr><td><strong>Best Practices</strong></td><td>How to make the most out of Hypster</td><td></td><td><a href=".gitbook/assets/Group 26.png">Group 26.png</a></td><td><a href="in-depth/basic-best-practices.md">basic-best-practices.md</a></td></tr></tbody></table>
+
+## Why Use Hypster?
+
+In modern AI/ML development, we often need to handle **multiple configurations across different scenarios**. This is essential because:
+
+1. We don't know in advance which **hyperparameters** will best optimize our performance metrics and satisfy our constraints.
+2. We need to support multiple **"modes"** for different scenarios. For example:
+   1. Local vs. Remote Environments, Development vs. Production Settings
+   2. Different App Configurations for specific use-cases and populations
+
+Hypster takes care of these challenges by providing a simple way to define configuration spaces and instantiate them into concrete workflows. This enables you to manage and optimize swappable runtime components in your codebase.
 
 ## Core Workflow
 
-{% stepper %}
-{% step %}
-**Define a config function**
+* **Define** ordinary Python config functions whose first argument is `hp: HP`.
+* **Return** the initialized object your application will use whenever that object is cheap and safe to construct.
+* **Choose** swappable components with named option dictionaries that map simple keys to config functions.
+* **Explore** the active parameter tree with `explore(config)` before running a branch.
+* **Instantiate** with `instantiate(config, values={...})` when you only need the returned object.
+* **Log params** with `instantiate_with_params(config, values={...})` when you need a stable replay record.
 
-Use `hp.*` calls for values that should be visible, overrideable, replayable, or searchable.
-{% endstep %}
-
-{% step %}
-**Explore the active schema**
-
-Run `explore(config)` for a tree, or `explore(config, return_info=True)` for JSON-serializable metadata.
-{% endstep %}
-
-{% step %}
-**Instantiate the runtime object**
-
-Call `instantiate(config, values={...})` when you only need the returned value.
-{% endstep %}
-
-{% step %}
-**Log the replayable params**
-
-Call `instantiate_with_params(config, values={...})` when you need a stable record for experiments, UI state, or production replay.
-{% endstep %}
-{% endstepper %}
 
 ## Design Notes
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -6,11 +6,13 @@ Hypster config functions are plain Python functions:
 
 {% code overflow="wrap" %}
 ```python
+from pathlib import Path
+
 from hypster import HP
 
-def config(hp: HP):
+def config(hp: HP) -> Path:
     mode = hp.select(["fast", "accurate"], name="mode", default="fast")
-    return {"mode": mode}
+    return Path("runs") / mode
 ```
 {% endcode %}
 
@@ -38,8 +40,9 @@ The same function can serve several jobs:
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, explore, instantiate_with_params
+from my_app.processing import PipelineRun
 
-def pipeline_config(hp: HP):
+def pipeline_config(hp: HP) -> PipelineRun:
     stage = hp.select(["debug", "full"], name="stage", default="debug")
 
     if stage == "full":
@@ -47,7 +50,7 @@ def pipeline_config(hp: HP):
     else:
         sample_rows = hp.int(1000, name="sample_rows", min=100, max=1_000_000)
 
-    return {"stage": stage, "sample_rows": sample_rows}
+    return PipelineRun(stage=stage, sample_rows=sample_rows)
 
 explore(pipeline_config)
 
@@ -56,7 +59,8 @@ run = instantiate_with_params(
     values={"stage": "full", "sample_rows": 250_000},
 )
 
-assert run.value == {"stage": "full", "sample_rows": 250_000}
+assert run.value.stage == "full"
+assert run.value.sample_rows == 250_000
 assert run.params == {"stage": "full", "sample_rows": 250_000}
 ```
 {% endcode %}

--- a/docs/examples/ai-workflows.md
+++ b/docs/examples/ai-workflows.md
@@ -6,73 +6,104 @@ Hypster is useful when an AI workflow needs to switch providers, retrieval modes
 
 {% code overflow="wrap" %}
 ```python
-from dataclasses import dataclass
 from hypster import HP, explore, instantiate_with_params
+from my_app.llms import GeminiClient, OpenAIClient
 
-@dataclass
-class ProviderConfig:
-    provider: str
-    model: str
-    temperature: float
-    max_tokens: int
-
-def openai_config(hp: HP) -> ProviderConfig:
-    return ProviderConfig(
-        provider="openai",
-        model=hp.select(
-            ["gpt-5.4-mini", "gpt-5.5"],
-            name="model",
-            default="gpt-5.4-mini",
-            options_only=True,
-        ),
-        temperature=hp.float(0.2, name="temperature", min=0.0, max=2.0),
-        max_tokens=hp.int(1024, name="max_tokens", min=1, max=16_384),
+def openai_config(hp: HP) -> OpenAIClient:
+    model_name = hp.select(
+        ["gpt-5.4-mini", "gpt-5.5"],
+        name="model_name",
+        default="gpt-5.4-mini",
+        options_only=True,
+    )
+    temperature = hp.float(0.2, name="temperature", min=0.0, max=2.0)
+    max_tokens = hp.int(1024, name="max_tokens", min=1, max=16_384)
+    reasoning_effort = hp.select(
+        [None, "low", "medium", "high"],
+        name="reasoning_effort",
+        default=None,
+        allow_none=True,
+        options_only=True,
+    )
+    return OpenAIClient(
+        model=model_name,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        reasoning_effort=reasoning_effort,
     )
 
-def gemini_config(hp: HP) -> ProviderConfig:
-    return ProviderConfig(
-        provider="gemini",
-        model=hp.select(
-            ["gemini-3.5-flash", "gemini-3.1-pro-preview"],
-            name="model",
-            default="gemini-3.5-flash",
-            options_only=True,
-        ),
-        temperature=hp.float(0.3, name="temperature", min=0.0, max=2.0),
-        max_tokens=hp.int(2048, name="max_tokens", min=1, max=16_384),
+def gemini_config(hp: HP) -> GeminiClient:
+    model_name = hp.select(
+        ["gemini-3.5-flash", "gemini-3.1-pro-preview"],
+        name="model_name",
+        default="gemini-3.5-flash",
+        options_only=True,
     )
+    temperature = hp.float(0.3, name="temperature", min=0.0, max=2.0)
+    max_tokens = hp.int(2048, name="max_tokens", min=1, max=16_384)
+    return GeminiClient(model=model_name, temperature=temperature, max_tokens=max_tokens)
+
+provider_options = {
+    "openai": openai_config,
+    "gemini": gemini_config,
+}
 ```
 {% endcode %}
 
+These examples assume client and retriever constructors are local, cheap, and lazy. If construction opens network connections, loads indexes, or calls paid APIs, keep that work outside the config and build it after `instantiate()`.
+
 ## RAG And Output Settings
 
-Use dict-backed `select` when the runtime value is complex. The parameter records the simple key, while your app receives the mapped object.
+Use dict-backed `select` when the runtime value is complex. The parameter records the simple key, while your app receives the mapped object or selected config function.
 
 {% code overflow="wrap" %}
 ```python
+from my_app.rag import BM25Retriever, DenseRetriever, HybridRetriever
+from my_app.rendering import JsonRenderer, MarkdownRenderer, TextRenderer
+
+def keyword_retriever(hp: HP) -> BM25Retriever:
+    index_name = hp.text("docs-v1", name="index_name")
+    top_k = hp.int(8, name="top_k", min=1, max=50)
+    return BM25Retriever(index=index_name, top_k=top_k)
+
+def vector_retriever(hp: HP) -> DenseRetriever:
+    index_name = hp.text("docs-embeddings-v3", name="index_name")
+    top_k = hp.int(8, name="top_k", min=1, max=50)
+    return DenseRetriever(index=index_name, top_k=top_k)
+
+def hybrid_retriever(hp: HP) -> HybridRetriever:
+    index_name = hp.text("docs-hybrid-v2", name="index_name")
+    keyword_weight = hp.float(0.35, name="keyword_weight", min=0.0, max=1.0)
+    top_k = hp.int(8, name="top_k", min=1, max=50)
+    return HybridRetriever(index=index_name, keyword_weight=keyword_weight, top_k=top_k)
+
+retriever_options = {
+    "keyword": keyword_retriever,
+    "vector": vector_retriever,
+    "hybrid": hybrid_retriever,
+}
+
 def retrieval_config(hp: HP):
-    retriever = hp.select(
-        {
-            "keyword": {"kind": "bm25", "index": "docs-v1"},
-            "vector": {"kind": "dense", "index": "docs-embeddings-v3"},
-            "hybrid": {"kind": "hybrid", "keyword_weight": 0.35},
-        },
-        name="retriever",
-        default="hybrid",
-        options_only=True,
-    )
-    return {
-        "retriever": retriever,
-        "top_k": hp.int(8, name="top_k", min=1, max=50),
-        "rerank": hp.bool(True, name="rerank"),
-    }
+    selected_config = hp.select(retriever_options, name="retriever_kind", default="hybrid", options_only=True)
+    return hp.nest(selected_config, name="retriever")
 
 def output_config(hp: HP):
-    return {
-        "format": hp.select(["text", "json", "markdown"], name="format", default="text", options_only=True),
-        "include_citations": hp.bool(True, name="include_citations"),
-        "system_prompt": hp.text("Answer with concise, sourced reasoning.", name="system_prompt"),
-    }
+    renderer_cls = hp.select(
+        {
+            "text": TextRenderer,
+            "json": JsonRenderer,
+            "markdown": MarkdownRenderer,
+        },
+        name="format",
+        default="text",
+        options_only=True,
+    )
+    include_citations = hp.bool(True, name="include_citations")
+    system_prompt = hp.text("Answer with concise, sourced reasoning.", name="system_prompt")
+    return renderer_cls(
+        include_citations=include_citations,
+        system_prompt=system_prompt,
+    )
 ```
 {% endcode %}
 
@@ -80,20 +111,16 @@ def output_config(hp: HP):
 
 {% code overflow="wrap" %}
 ```python
-def qa_workflow_config(hp: HP):
-    provider = hp.select(["openai", "gemini"], name="provider", default="openai", options_only=True)
+from my_app.workflows import QAWorkflow
 
-    if provider == "openai":
-        llm = hp.nest(openai_config, name="openai")
-    else:
-        llm = hp.nest(gemini_config, name="gemini")
+def qa_workflow_config(hp: HP) -> QAWorkflow:
+    selected_provider = hp.select(provider_options, name="provider", default="openai", options_only=True)
 
-    return {
-        "provider": provider,
-        "llm": llm,
-        "retrieval": hp.nest(retrieval_config, name="retrieval"),
-        "output": hp.nest(output_config, name="output"),
-    }
+    return QAWorkflow(
+        llm=hp.nest(selected_provider, name="llm"),
+        retriever=hp.nest(retrieval_config, name="retrieval"),
+        output=hp.nest(output_config, name="output"),
+    )
 ```
 {% endcode %}
 
@@ -103,30 +130,30 @@ def qa_workflow_config(hp: HP):
 ```python
 explore(
     qa_workflow_config,
-    values={"provider": "gemini", "gemini.temperature": 0.1, "retrieval.top_k": 12},
+    values={"provider": "gemini", "llm.temperature": 0.1, "retrieval.retriever.top_k": 12},
 )
 
 run = instantiate_with_params(
     qa_workflow_config,
     values={
         "provider": "gemini",
-        "gemini.model": "gemini-3.1-pro-preview",
-        "gemini.temperature": 0.1,
-        "retrieval.retriever": "vector",
+        "llm.model_name": "gemini-3.1-pro-preview",
+        "llm.temperature": 0.1,
+        "retrieval.retriever_kind": "vector",
         "output.format": "markdown",
     },
 )
 
 assert run.params["provider"] == "gemini"
-assert run.params["gemini.model"] == "gemini-3.1-pro-preview"
-assert run.params["retrieval.retriever"] == "vector"
-assert run.value["retrieval"]["retriever"]["kind"] == "dense"
+assert run.params["llm.model_name"] == "gemini-3.1-pro-preview"
+assert run.params["retrieval.retriever_kind"] == "vector"
+assert run.value.retriever.index == "docs-embeddings-v3"
 ```
 {% endcode %}
 
 ## Branch Safety
 
-This raises by default because `openai.temperature` is unreachable when the `gemini` branch is selected:
+This raises by default because `llm.reasoning_effort` is only reachable when the `openai` branch is selected:
 
 {% code overflow="wrap" %}
 ```python
@@ -134,7 +161,7 @@ from hypster import instantiate
 
 instantiate(
     qa_workflow_config,
-    values={"provider": "gemini", "openai.temperature": 0.7},
+    values={"provider": "gemini", "llm.reasoning_effort": "high"},
 )
 ```
 {% endcode %}

--- a/docs/examples/data-processing.md
+++ b/docs/examples/data-processing.md
@@ -6,51 +6,48 @@ Data pipelines often mix environment choices, schema decisions, cleaning rules, 
 
 {% code overflow="wrap" %}
 ```python
-from dataclasses import dataclass
 from hypster import HP, explore, instantiate
+from my_app.data import Cleaner, CsvReader, DataPipeline
+from my_app.exporters import CsvExporter, JsonLinesExporter, ParquetExporter
 
-@dataclass
-class CsvInput:
-    path: str
-    delimiter: str
-    encoding: str
-
-@dataclass
-class CleaningRules:
-    drop_empty_rows: bool
-    normalize_columns: bool
-    fill_missing_numeric: float | None
-    date_columns: list[str]
-
-@dataclass
-class ExportConfig:
-    format: str
-    path: str
-    include_header: bool
-
-def input_config(hp: HP) -> CsvInput:
-    return CsvInput(
+def input_config(hp: HP) -> CsvReader:
+    return CsvReader(
         path=hp.text("data/raw/events.csv", name="path"),
         delimiter=hp.select([",", "\t", "|"], name="delimiter", default=",", options_only=True),
         encoding=hp.select(["utf-8", "latin-1"], name="encoding", default="utf-8", options_only=True),
     )
 
-def cleaning_config(hp: HP) -> CleaningRules:
-    return CleaningRules(
+def cleaning_config(hp: HP) -> Cleaner:
+    return Cleaner(
         drop_empty_rows=hp.bool(True, name="drop_empty_rows"),
         normalize_columns=hp.bool(True, name="normalize_columns"),
         fill_missing_numeric=hp.float(None, name="fill_missing_numeric", allow_none=True),
         date_columns=hp.multi_text(["created_at"], name="date_columns"),
     )
 
-def export_config(hp: HP) -> ExportConfig:
-    return ExportConfig(
-        format=hp.select(["parquet", "csv", "jsonl"], name="format", default="parquet", options_only=True),
-        path=hp.text("data/processed/events.parquet", name="path"),
+def parquet_export_config(hp: HP) -> ParquetExporter:
+    return ParquetExporter(path=hp.text("data/processed/events.parquet", name="path"))
+
+def csv_export_config(hp: HP) -> CsvExporter:
+    return CsvExporter(
+        path=hp.text("data/processed/events.csv", name="path"),
         include_header=hp.bool(True, name="include_header"),
     )
 
-def data_pipeline_config(hp: HP):
+def jsonl_export_config(hp: HP) -> JsonLinesExporter:
+    return JsonLinesExporter(path=hp.text("data/processed/events.jsonl", name="path"))
+
+export_options = {
+    "parquet": parquet_export_config,
+    "csv": csv_export_config,
+    "jsonl": jsonl_export_config,
+}
+
+def export_config(hp: HP):
+    selected_config = hp.select(export_options, name="format", default="parquet", options_only=True)
+    return hp.nest(selected_config, name="settings")
+
+def data_pipeline_config(hp: HP) -> DataPipeline:
     mode = hp.select(["sample", "full"], name="mode", default="sample", options_only=True)
 
     if mode == "full":
@@ -58,15 +55,17 @@ def data_pipeline_config(hp: HP):
     else:
         row_limit = hp.int(10_000, name="row_limit", min=1)
 
-    return {
-        "mode": mode,
-        "row_limit": row_limit,
-        "input": hp.nest(input_config, name="input"),
-        "cleaning": hp.nest(cleaning_config, name="cleaning"),
-        "export": hp.nest(export_config, name="export"),
-    }
+    return DataPipeline(
+        mode=mode,
+        row_limit=row_limit,
+        reader=hp.nest(input_config, name="input"),
+        cleaner=hp.nest(cleaning_config, name="cleaning"),
+        exporter=hp.nest(export_config, name="export"),
+    )
 ```
 {% endcode %}
+
+This shape assumes the reader, cleaner, and exporter constructors are lightweight and do not read or write data. Run the actual pipeline after `instantiate()` returns.
 
 ## Explore A Production Branch
 
@@ -78,6 +77,7 @@ explore(
         "mode": "full",
         "input.path": "s3://warehouse/events/2026-05-24.csv",
         "export.format": "jsonl",
+        "export.settings.path": "s3://warehouse/processed/events.jsonl",
     },
 )
 ```
@@ -87,29 +87,27 @@ explore(
 
 {% code overflow="wrap" %}
 ```python
-cfg = instantiate(
+pipeline = instantiate(
     data_pipeline_config,
     values={
         "mode": "full",
-        "input": {
-            "path": "s3://warehouse/events/2026-05-24.csv",
-            "delimiter": ",",
-        },
+        "input.path": "s3://warehouse/events/2026-05-24.csv",
+        "input.delimiter": ",",
         "cleaning.fill_missing_numeric": 0.0,
         "export.format": "jsonl",
-        "export.path": "s3://warehouse/processed/events.jsonl",
+        "export.settings.path": "s3://warehouse/processed/events.jsonl",
     },
 )
 
-assert cfg["mode"] == "full"
-assert cfg["input"].path.startswith("s3://")
-assert cfg["cleaning"].fill_missing_numeric == 0.0
+assert pipeline.mode == "full"
+assert pipeline.reader.path.startswith("s3://")
+assert pipeline.cleaner.fill_missing_numeric == 0.0
 ```
 {% endcode %}
 
 ## Why This Shape Works
 
 * The `mode` branch changes the default row limit while keeping the same parameter path.
-* Dotted keys and nested dictionaries can both express nested values.
+* Dotted keys keep nested runtime objects replayable without returning a settings dictionary.
 * `options_only=True` prevents typos in finite choices such as export formats.
 * Nullable numeric values use `allow_none=True`, which makes `None` an explicit, replayable value.

--- a/docs/examples/experiment-tracking.md
+++ b/docs/examples/experiment-tracking.md
@@ -7,43 +7,55 @@ Use `instantiate_with_params()` when you need both the runtime object and the ex
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate, instantiate_with_params
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from my_app.experiments import TrainingJob
+from my_app.features import FeatureSelector
 
-def feature_config(hp: HP):
-    return {
-        "numeric": hp.multi_text(["age", "income"], name="numeric"),
-        "categorical": hp.multi_text(["country"], name="categorical"),
-        "scale": hp.bool(True, name="scale"),
-    }
+def feature_config(hp: HP) -> FeatureSelector:
+    numeric = hp.multi_text(["age", "income"], name="numeric")
+    categorical = hp.multi_text(["country"], name="categorical")
+    scale = hp.bool(True, name="scale")
+    return FeatureSelector(numeric=numeric, categorical=categorical, scale=scale)
 
-def model_config(hp: HP):
-    model = hp.select(["linear", "tree"], name="model", default="linear", options_only=True)
+def linear_model(hp: HP) -> LogisticRegression:
+    C = hp.float(1.0, name="C", min=1e-4, max=100.0)
+    return LogisticRegression(C=C, max_iter=1000)
+
+def tree_model(hp: HP) -> RandomForestClassifier:
+    max_depth = hp.int(6, name="max_depth", min=1, max=64)
+    return RandomForestClassifier(max_depth=max_depth, random_state=42)
+
+model_options = {
+    "linear": linear_model,
+    "tree": tree_model,
+}
+
+def training_job_config(hp: HP) -> TrainingJob:
+    selected_model = hp.select(model_options, name="model_family", default="linear", options_only=True)
     features = hp.nest(feature_config, name="features")
-
-    if model == "tree":
-        depth = hp.int(6, name="depth", min=1, max=64)
-        return {"model": model, "features": features, "depth": depth}
-
-    alpha = hp.float(0.1, name="alpha", min=0.0, max=10.0)
-    return {"model": model, "features": features, "alpha": alpha}
+    model = hp.nest(selected_model, name="model")
+    return TrainingJob(features=features, model=model)
 
 run = instantiate_with_params(
-    model_config,
+    training_job_config,
     values={
-        "model": "tree",
-        "depth": 12,
+        "model_family": "tree",
+        "model.max_depth": 12,
         "features.numeric": ["age", "income", "days_active"],
     },
 )
 
-assert run.value["depth"] == 12
+assert run.value.model.max_depth == 12
 assert run.params == {
-    "model": "tree",
+    "model_family": "tree",
     "features.numeric": ["age", "income", "days_active"],
     "features.categorical": ["country"],
     "features.scale": True,
-    "depth": 12,
+    "model.max_depth": 12,
 }
-assert instantiate(model_config, values=run.params) == run.value
+replayed = instantiate(training_job_config, values=run.params)
+assert replayed.model.max_depth == run.value.model.max_depth
 ```
 {% endcode %}
 

--- a/docs/examples/interactive-ui.md
+++ b/docs/examples/interactive-ui.md
@@ -9,18 +9,21 @@ The public schema hook is `explore(config, return_info=True)`: it returns metada
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, explore, instantiate
+from my_app.backends import AppRuntime, LocalBackend, RemoteBackend
 
-def app_config(hp: HP):
+def app_config(hp: HP) -> AppRuntime:
     provider = hp.select(["local", "remote"], name="provider", default="local", options_only=True)
     batch_size = hp.int(32, name="batch_size", min=1, max=512)
 
     if provider == "remote":
         endpoint = hp.text("https://api.example.com", name="endpoint")
         timeout = hp.float(10.0, name="timeout", min=0.1, max=120.0)
-        return {"provider": provider, "batch_size": batch_size, "endpoint": endpoint, "timeout": timeout}
+        backend = RemoteBackend(endpoint=endpoint, timeout=timeout)
+        return AppRuntime(provider=provider, batch_size=batch_size, backend=backend)
 
     threads = hp.int(4, name="threads", min=1, max=64)
-    return {"provider": provider, "batch_size": batch_size, "threads": threads}
+    backend = LocalBackend(threads=threads)
+    return AppRuntime(provider=provider, batch_size=batch_size, backend=backend)
 
 def flatten_parameters(parameters):
     fields = []
@@ -56,8 +59,8 @@ schema = explore(app_config, values=ui_values, return_info=True)
 cfg = instantiate(app_config, values=ui_values)
 
 assert schema.defaults()["provider"] == "local"
-assert cfg["provider"] == "remote"
-assert cfg["timeout"] == 30.0
+assert cfg.provider == "remote"
+assert cfg.backend.timeout == 30.0
 ```
 {% endcode %}
 

--- a/docs/examples/machine-learning.md
+++ b/docs/examples/machine-learning.md
@@ -39,19 +39,22 @@ def forest_model(hp: HP) -> RandomForestClassifier:
 
 ## Choose The Active Model
 
+For model families, keep the selectable options in a dict from replayable keys to child config functions. This scales better than a long conditional, keeps each model's hyperparameters close to the object it initializes, and lets UIs show the selected model parameters as one nested group.
+
 {% code overflow="wrap" %}
 ```python
+model_options = {
+    "logistic": logistic_model,
+    "forest": forest_model,
+}
+
 def classifier_config(hp: HP) -> ClassifierMixin:
-    model_family = hp.select(["logistic", "forest"], name="model_family", default="forest", options_only=True)
-
-    if model_family == "logistic":
-        return hp.nest(logistic_model, name="logistic")
-
-    return hp.nest(forest_model, name="forest")
+    selected_config = hp.select(model_options, name="model_family", default="forest", options_only=True)
+    return hp.nest(selected_config, name="model")
 ```
 {% endcode %}
 
-The config returns a ready-to-use classifier, not a dictionary that must be assembled later.
+The config returns a ready-to-use classifier, not a dictionary that must be assembled later. The selected params record `"forest"` or `"logistic"`, while the application receives the initialized estimator.
 
 ## Explore And Instantiate
 
@@ -63,8 +66,8 @@ run = instantiate_with_params(
     classifier_config,
     values={
         "model_family": "forest",
-        "forest.n_estimators": 500,
-        "forest.max_depth": 12,
+        "model.n_estimators": 500,
+        "model.max_depth": 12,
     },
 )
 
@@ -79,10 +82,10 @@ Expected selected params:
 ```python
 {
     "model_family": "forest",
-    "forest.n_estimators": 500,
-    "forest.max_depth": 12,
-    "forest.min_samples_leaf": 2,
-    "forest.random_state": 42,
+    "model.n_estimators": 500,
+    "model.max_depth": 12,
+    "model.min_samples_leaf": 2,
+    "model.random_state": 42,
 }
 ```
 {% endcode %}
@@ -91,77 +94,56 @@ Use `model.fit(X_train, y_train)` in your training code after instantiation. Kee
 
 ## Build A Full Pipeline Config
 
-For larger experiments, nest preprocessing, training, and model configs under one parent. Each nested config owns one part of the workflow, while the selected params remain a flat replayable dictionary.
+For larger experiments, nest preprocessing and model configs under one parent. Each nested config owns one part of the workflow, while the selected params remain a flat replayable dictionary.
 
 {% code overflow="wrap" %}
 ```python
-from dataclasses import dataclass
+from sklearn.impute import SimpleImputer
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import RobustScaler, StandardScaler
 
 
-@dataclass(frozen=True)
-class PreprocessingSettings:
-    scaler: str | None
-    impute_strategy: str
-
-
-@dataclass(frozen=True)
-class TrainingSettings:
-    cv_folds: int
-    scoring: str
-
-
-@dataclass(frozen=True)
-class MLExperiment:
-    preprocessing: PreprocessingSettings
-    training: TrainingSettings
-    model: ClassifierMixin
-
-
-def preprocessing_config(hp: HP) -> PreprocessingSettings:
-    return PreprocessingSettings(
-        scaler=hp.select(
-            [None, "standard", "robust"],
-            name="scaler",
-            default="standard",
-            allow_none=True,
-            options_only=True,
-        ),
-        impute_strategy=hp.select(["median", "mean"], name="impute_strategy", default="median", options_only=True),
+def preprocessing_config(hp: HP) -> Pipeline:
+    scaler = hp.select(
+        [None, "standard", "robust"],
+        name="scaler",
+        default="standard",
+        allow_none=True,
+        options_only=True,
     )
+    impute_strategy = hp.select(["median", "mean"], name="impute_strategy", default="median", options_only=True)
+
+    steps = [("imputer", SimpleImputer(strategy=impute_strategy))]
+    if scaler == "standard":
+        steps.append(("scaler", StandardScaler()))
+    elif scaler == "robust":
+        steps.append(("scaler", RobustScaler()))
+
+    return Pipeline(steps)
 
 
-def training_settings(hp: HP) -> TrainingSettings:
-    return TrainingSettings(
-        cv_folds=hp.int(5, name="cv_folds", min=2, max=10),
-        scoring=hp.select(["accuracy", "f1", "roc_auc"], name="scoring", default="f1", options_only=True),
-    )
-
-
-def experiment_config(hp: HP) -> MLExperiment:
-    return MLExperiment(
-        preprocessing=hp.nest(preprocessing_config, name="preprocessing"),
-        training=hp.nest(training_settings, name="training"),
-        model=hp.nest(classifier_config, name="model"),
-    )
+def experiment_config(hp: HP) -> Pipeline:
+    preprocessing = hp.nest(preprocessing_config, name="preprocessing")
+    classifier = hp.nest(classifier_config, name="classifier")
+    return Pipeline([("preprocessing", preprocessing), ("classifier", classifier)])
 
 
 run = instantiate_with_params(
     experiment_config,
     values={
         "preprocessing.scaler": "robust",
-        "training.cv_folds": 3,
-        "model.model_family": "forest",
-        "model.forest.n_estimators": 500,
+        "classifier.model_family": "forest",
+        "classifier.model.n_estimators": 500,
     },
 )
 
-assert isinstance(run.value.model, RandomForestClassifier)
+assert isinstance(run.value.named_steps["classifier"], RandomForestClassifier)
 assert run.params["preprocessing.scaler"] == "robust"
-assert run.params["model.forest.n_estimators"] == 500
+assert run.params["classifier.model.n_estimators"] == 500
 ```
 {% endcode %}
 
-Use `run.value.preprocessing` to build your feature transformer, `run.value.model` as the initialized estimator, and `run.params` as the exact experiment record.
+Use `run.value.fit(X_train, y_train)` in your training code, and log `run.params` as the exact experiment record.
 
 ## Make It HPO-Ready
 

--- a/docs/examples/nested-workflows.md
+++ b/docs/examples/nested-workflows.md
@@ -1,42 +1,47 @@
 # Nested Workflows
 
-Use `hp.nest()` to split a large workflow into smaller config functions. Nested config values receive dotted parameter paths such as `trainer.optimizer.learning_rate`.
+Use `hp.nest()` to split a large workflow into smaller config functions. Nested config values receive dotted parameter paths such as `trainer.optimizer.settings.learning_rate`.
 
 ## A Deeply Nested Training Workflow
 
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, explore, instantiate
+from my_app.training import Adam, Optimizer, SGD, Trainer, TrainingExperiment
 
-def optimizer_config(hp: HP):
-    algorithm = hp.select(["adam", "sgd"], name="algorithm", default="adam", options_only=True)
+def adam_config(hp: HP) -> Adam:
+    learning_rate = hp.float(0.001, name="learning_rate", min=1e-6, max=1.0)
+    beta1 = hp.float(0.9, name="beta1", min=0.0, max=0.999)
+    return Adam(learning_rate=learning_rate, beta1=beta1)
 
-    if algorithm == "adam":
-        return {
-            "algorithm": algorithm,
-            "learning_rate": hp.float(0.001, name="learning_rate", min=1e-6, max=1.0),
-            "beta1": hp.float(0.9, name="beta1", min=0.0, max=0.999),
-        }
+def sgd_config(hp: HP) -> SGD:
+    learning_rate = hp.float(0.01, name="learning_rate", min=1e-6, max=1.0)
+    momentum = hp.float(0.9, name="momentum", min=0.0, max=1.0)
+    return SGD(learning_rate=learning_rate, momentum=momentum)
 
-    return {
-        "algorithm": algorithm,
-        "learning_rate": hp.float(0.01, name="learning_rate", min=1e-6, max=1.0),
-        "momentum": hp.float(0.9, name="momentum", min=0.0, max=1.0),
-    }
+optimizer_options = {
+    "adam": adam_config,
+    "sgd": sgd_config,
+}
 
-def trainer_config(hp: HP, epochs_default: int = 10):
-    return {
-        "epochs": hp.int(epochs_default, name="epochs", min=1, max=1000),
-        "batch_size": hp.int(64, name="batch_size", min=1, max=2048),
-        "optimizer": hp.nest(optimizer_config, name="optimizer"),
-    }
+def optimizer_config(hp: HP) -> Optimizer:
+    selected_config = hp.select(optimizer_options, name="algorithm", default="adam", options_only=True)
+    return hp.nest(selected_config, name="settings")
 
-def experiment_config(hp: HP):
+def trainer_config(hp: HP, epochs_default: int = 10) -> Trainer:
+    epochs = hp.int(epochs_default, name="epochs", min=1, max=1000)
+    batch_size = hp.int(64, name="batch_size", min=1, max=2048)
+    optimizer = hp.nest(optimizer_config, name="optimizer")
+    return Trainer(epochs=epochs, batch_size=batch_size, optimizer=optimizer)
+
+def experiment_config(hp: HP) -> TrainingExperiment:
     dataset = hp.select(["mnist", "cifar10"], name="dataset", default="mnist", options_only=True)
     trainer = hp.nest(trainer_config, name="trainer", kwargs={"epochs_default": 20})
-    return {"dataset": dataset, "trainer": trainer}
+    return TrainingExperiment(dataset=dataset, trainer=trainer)
 ```
 {% endcode %}
+
+The `optimizer_options` dict is deliberately separate from `optimizer_config()`. For nested workflows, that keeps the parent function small while making the set of selectable components obvious.
 
 ## Override Nested Values
 
@@ -48,12 +53,12 @@ cfg = instantiate(
         "dataset": "cifar10",
         "trainer.epochs": 50,
         "trainer.optimizer.algorithm": "sgd",
-        "trainer.optimizer.momentum": 0.95,
+        "trainer.optimizer.settings.momentum": 0.95,
     },
 )
 
-assert cfg["trainer"]["optimizer"]["algorithm"] == "sgd"
-assert cfg["trainer"]["optimizer"]["momentum"] == 0.95
+assert isinstance(cfg.trainer.optimizer, SGD)
+assert cfg.trainer.optimizer.momentum == 0.95
 ```
 {% endcode %}
 
@@ -69,7 +74,7 @@ cfg = instantiate(
             "epochs": 50,
             "optimizer": {
                 "algorithm": "sgd",
-                "momentum": 0.95,
+                "settings": {"momentum": 0.95},
             },
         },
     },

--- a/docs/getting-started/defining-a-configuration-space.md
+++ b/docs/getting-started/defining-a-configuration-space.md
@@ -1,6 +1,6 @@
 # Define A Config Function
 
-A Hypster configuration space is an ordinary Python function whose first argument is named `hp`. It is not a DSL or a separate config file format: use normal Python control flow, lists, helper functions, imports, dataclasses, and object construction.
+A Hypster configuration space is an ordinary Python function whose first argument is named `hp`. It is not a DSL or a separate config file format: use normal Python control flow, lists, helper functions, imports, and object construction.
 
 {% code overflow="wrap" %}
 ```python
@@ -13,7 +13,7 @@ def config(hp: HP):
 
 `hp` must be the first positional parameter; keyword-only `hp` is rejected before the config executes. The `hp: HP` annotation is recommended, but unannotated config functions are still valid.
 
-The function can return anything your application needs: a dictionary, dataclass, model instance, tuple, or fully constructed workflow object. Prefer a return type annotation when the output is a meaningful object.
+The function can return anything your application needs, but the most common pattern is to return the initialized runtime object your application will use. Prefer a return type annotation when the output is a meaningful object.
 
 Because Hypster discovers available parameters by running this function, keep config bodies fast and predictable. Avoid side effects such as writes, training, paid API calls, network calls, database access, or heavyweight initialization inside the config.
 
@@ -24,17 +24,14 @@ Use `hp.*` calls for values that should be visible, overrideable, replayable, se
 {% code overflow="wrap" %}
 ```python
 from hypster import HP
+from my_app.llms import LLMClient
 
-def llm_config(hp: HP):
+def llm_config(hp: HP) -> LLMClient:
     provider = hp.select(["openai", "gemini"], name="provider", default="openai", options_only=True)
     temperature = hp.float(0.2, name="temperature", min=0.0, max=2.0)
     max_tokens = hp.int(1024, name="max_tokens", min=1, max=16_384)
 
-    return {
-        "provider": provider,
-        "temperature": temperature,
-        "max_tokens": max_tokens,
-    }
+    return LLMClient(provider=provider, temperature=temperature, max_tokens=max_tokens)
 ```
 {% endcode %}
 
@@ -46,20 +43,22 @@ Hypster is define-by-run. Only parameters touched by the active branch are selec
 
 {% code overflow="wrap" %}
 ```python
-def model_config(hp: HP):
+from sklearn.base import ClassifierMixin
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+
+from hypster import HP
+
+def model_config(hp: HP) -> ClassifierMixin:
     family = hp.select(["linear", "forest"], name="family", default="forest", options_only=True)
 
     if family == "linear":
-        return {
-            "family": family,
-            "alpha": hp.float(0.1, name="alpha", min=0.0, max=10.0),
-        }
+        C = hp.float(1.0, name="C", min=1e-4, max=100.0)
+        return LogisticRegression(C=C, max_iter=1000)
 
-    return {
-        "family": family,
-        "n_estimators": hp.int(200, name="n_estimators", min=10, max=1000),
-        "max_depth": hp.int(None, name="max_depth", min=1, max=100, allow_none=True),
-    }
+    n_estimators = hp.int(200, name="n_estimators", min=10, max=1000)
+    max_depth = hp.int(None, name="max_depth", min=1, max=100, allow_none=True)
+    return RandomForestClassifier(n_estimators=n_estimators, max_depth=max_depth)
 ```
 {% endcode %}
 
@@ -69,21 +68,33 @@ This define-by-run model is what makes normal Python branches work: Hypster runs
 
 ## Compose With Nesting
 
-Split large configs into smaller functions and compose them with `hp.nest()`.
+The branch example above works, but for reusable components we recommend composition with `hp.nest()`. Each model gets its own config function, the parent config only chooses which child to run, and interactive UIs can render the nested child parameters as a contained group.
 
 {% code overflow="wrap" %}
 ```python
-def optimizer_config(hp: HP):
-    return {
-        "learning_rate": hp.float(0.001, name="learning_rate", min=1e-6, max=1.0),
-        "weight_decay": hp.float(0.0, name="weight_decay", min=0.0, max=1.0),
-    }
+from sklearn.base import ClassifierMixin
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
 
-def training_config(hp: HP):
-    return {
-        "epochs": hp.int(10, name="epochs", min=1),
-        "optimizer": hp.nest(optimizer_config, name="optimizer"),
-    }
+from hypster import HP
+
+def logistic_model(hp: HP) -> LogisticRegression:
+    C = hp.float(1.0, name="C", min=1e-4, max=100.0)
+    return LogisticRegression(C=C, max_iter=1000)
+
+def forest_model(hp: HP) -> RandomForestClassifier:
+    n_estimators = hp.int(200, name="n_estimators", min=10, max=1000)
+    max_depth = hp.int(None, name="max_depth", min=1, max=100, allow_none=True)
+    return RandomForestClassifier(n_estimators=n_estimators, max_depth=max_depth)
+
+model_options = {
+    "linear": logistic_model,
+    "forest": forest_model,
+}
+
+def model_config(hp: HP) -> ClassifierMixin:
+    selected_config = hp.select(model_options, name="family", default="forest", options_only=True)
+    return hp.nest(selected_config, name="model")
 ```
 {% endcode %}
 
@@ -91,30 +102,17 @@ Nested parameters use dotted paths in `values=`:
 
 {% code overflow="wrap" %}
 ```python
-{"optimizer.learning_rate": 0.01}
+{"family": "forest", "model.n_estimators": 500}
 ```
 {% endcode %}
 
-## Use Dict-Backed Selects For Complex Values
+Compared with the inline branch version, this keeps the forest parameters under the `model` group and the linear parameters under the same reusable child scope. That makes larger configs easier to scan, test, reuse, and render in interactive UIs.
 
-Select choices must be logging-safe scalars. If the runtime value is complex, map a simple key to it:
+## Use Dict-Backed Selects For Swappable Components
 
-{% code overflow="wrap" %}
-```python
-def architecture_config(hp: HP):
-    return hp.select(
-        {
-            "small": {"layers": 2, "units": [64, 32]},
-            "large": {"layers": 4, "units": [256, 128]},
-        },
-        name="architecture",
-        default="small",
-        options_only=True,
-    )
-```
-{% endcode %}
+The nested model example uses a dict-backed `select`: `values=` records the simple key such as `"forest"`, while the config receives the mapped function `forest_model`.
 
-Your config receives the mapped dictionary, while `instantiate_with_params()` records the key. Add `options_only=True` when values outside the mapping should be rejected.
+Keep the options mapping in a named variable such as `model_options`, `optimizer_options`, or `retriever_options`. That makes long option sets easier to scan, test, and reuse, while the parent config stays focused on the runtime decision. Add `options_only=True` when values outside the mapping should be rejected.
 
 ## Return Initialized Objects
 
@@ -127,12 +125,15 @@ from hypster import HP
 
 def classifier_config(hp: HP) -> RandomForestClassifier:
     n_estimators = hp.int(200, name="n_estimators", min=10, max=1000)
-    max_depth = hp.int(None, name="max_depth", allow_none=True)
+    max_depth = hp.int(None, name="max_depth", min=1, max=100, allow_none=True)
+    min_samples_leaf = hp.int(2, name="min_samples_leaf", min=1, max=50)
+    random_state = hp.int(42, name="random_state", min=0)
 
     return RandomForestClassifier(
         n_estimators=n_estimators,
         max_depth=max_depth,
-        random_state=42,
+        min_samples_leaf=min_samples_leaf,
+        random_state=random_state,
     )
 ```
 {% endcode %}

--- a/docs/getting-started/exploring-a-configuration-space.md
+++ b/docs/getting-started/exploring-a-configuration-space.md
@@ -9,28 +9,27 @@ That execution should be cheap and safe. Keep side effects, paid API calls, data
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, explore
+from my_app.backends import Application, LocalBackend, RemoteBackend
 
-def local_backend(hp: HP):
-    return {
-        "threads": hp.int(4, name="threads", min=1, max=64),
-        "cache": hp.bool(True, name="cache"),
-    }
+def local_backend(hp: HP) -> LocalBackend:
+    threads = hp.int(4, name="threads", min=1, max=64)
+    cache = hp.bool(True, name="cache")
+    return LocalBackend(threads=threads, cache=cache)
 
-def remote_backend(hp: HP):
-    return {
-        "endpoint": hp.text("https://api.example.com", name="endpoint"),
-        "timeout": hp.float(10.0, name="timeout", min=0.1, max=120.0),
-    }
+def remote_backend(hp: HP) -> RemoteBackend:
+    endpoint = hp.text("https://api.example.com", name="endpoint")
+    timeout = hp.float(10.0, name="timeout", min=0.1, max=120.0)
+    return RemoteBackend(endpoint=endpoint, timeout=timeout)
 
-def app_config(hp: HP):
-    backend = hp.select(["local", "remote"], name="backend", default="local", options_only=True)
+backend_options = {
+    "local": local_backend,
+    "remote": remote_backend,
+}
 
-    if backend == "local":
-        settings = hp.nest(local_backend, name="local")
-    else:
-        settings = hp.nest(remote_backend, name="remote")
-
-    return {"backend": backend, "settings": settings}
+def app_config(hp: HP) -> Application:
+    selected_config = hp.select(backend_options, name="backend", default="local", options_only=True)
+    backend = hp.nest(selected_config, name="backend_settings")
+    return Application(backend=backend)
 
 explore(app_config)
 ```
@@ -42,7 +41,7 @@ Expected output:
 ```text
 app_config
 ├── backend: select = "local"  (options: ["local", "remote"])
-└── local
+└── backend_settings
     ├── threads: int = 4  (1-64)
     └── cache: bool = True
 ```
@@ -56,7 +55,7 @@ Pass `values=` to choose a branch before tracing it:
 ```python
 explore(
     app_config,
-    values={"backend": "remote", "remote.timeout": 30.0},
+    values={"backend": "remote", "backend_settings.timeout": 30.0},
 )
 ```
 {% endcode %}
@@ -67,7 +66,7 @@ Expected output:
 ```text
 app_config
 ├── backend: select = "remote"  (options: ["local", "remote"])
-└── remote
+└── backend_settings
     ├── endpoint: text = "https://api.example.com"
     └── timeout: float = 30.0  (0.1-120.0)
 ```
@@ -94,8 +93,8 @@ For programmatic inspection before instantiation, use `schema = explore(config, 
 ```python
 {
     "backend": "local",
-    "local.threads": 4,
-    "local.cache": True,
+    "backend_settings.threads": 4,
+    "backend_settings.cache": True,
 }
 ```
 {% endcode %}

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -77,27 +77,20 @@ Run a smoke test in the same environment where your project runs:
 
 {% code overflow="wrap" %}
 ```python
-from dataclasses import dataclass
+from pathlib import Path
 
 from hypster import HP, explore, instantiate
 
 
-@dataclass(frozen=True)
-class DataSettings:
-    path: str
-    batch_size: int
-
-
-def config(hp: HP) -> DataSettings:
-    return DataSettings(
-        path=hp.text("data/train.csv", name="path"),
-        batch_size=hp.int(32, name="batch_size", min=1),
-    )
+def config(hp: HP) -> Path:
+    data_dir = hp.text("data", name="data_dir")
+    split = hp.select(["train", "validation"], name="split", default="train", options_only=True)
+    return Path(data_dir) / f"{split}.csv"
 
 
 explore(config)
-settings = instantiate(config, values={"batch_size": 64})
-assert settings.batch_size == 64
+path = instantiate(config, values={"split": "validation"})
+assert path == Path("data/validation.csv")
 ```
 {% endcode %}
 
@@ -106,8 +99,8 @@ Expected tree:
 {% code overflow="wrap" %}
 ```text
 config
-├── path: text = 'data/train.csv'
-└── batch_size: int = 32  (min: 1)
+├── data_dir: text = 'data'
+└── split: select = 'train'  (options: ['train', 'validation'])
 ```
 {% endcode %}
 

--- a/docs/getting-started/instantiating-a-configuration-space.md
+++ b/docs/getting-started/instantiating-a-configuration-space.md
@@ -5,17 +5,26 @@ Use `instantiate()` to execute a config function and get its returned runtime va
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
+from sklearn.base import ClassifierMixin
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
 
-def model_config(hp: HP):
-    family = hp.select(["linear", "forest"], name="family", default="forest", options_only=True)
+def linear_model(hp: HP) -> LogisticRegression:
+    C = hp.float(1.0, name="C", min=1e-4, max=100.0)
+    return LogisticRegression(C=C, max_iter=1000)
 
-    if family == "linear":
-        return {"family": family, "alpha": hp.float(0.1, name="alpha", min=0.0, max=10.0)}
+def forest_model(hp: HP) -> RandomForestClassifier:
+    n_estimators = hp.int(200, name="n_estimators", min=10, max=1000)
+    return RandomForestClassifier(n_estimators=n_estimators, random_state=42)
 
-    return {"family": family, "n_estimators": hp.int(200, name="n_estimators", min=10, max=1000)}
+model_options = {"linear": linear_model, "forest": forest_model}
 
-cfg = instantiate(model_config, values={"family": "forest", "n_estimators": 500})
-assert cfg == {"family": "forest", "n_estimators": 500}
+def model_config(hp: HP) -> ClassifierMixin:
+    selected_config = hp.select(model_options, name="family", default="forest", options_only=True)
+    return hp.nest(selected_config, name="model")
+
+model = instantiate(model_config, values={"family": "forest", "model.n_estimators": 500})
+assert isinstance(model, RandomForestClassifier)
 ```
 {% endcode %}
 
@@ -28,19 +37,20 @@ Use `instantiate_with_params()` when you need a replayable record for experiment
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate, instantiate_with_params
+from my_app.llms import OpenAIClient
 
-def llm_config(hp: HP):
-    provider = hp.select(["gemini", "openai"], name="provider", default="gemini", options_only=True)
+def llm_config(hp: HP) -> OpenAIClient:
+    model_name = hp.select(["gpt-5-mini", "gpt-5"], name="model_name", default="gpt-5-mini", options_only=True)
     temperature = hp.float(0.2, name="temperature", min=0.0, max=2.0)
-    return {"provider": provider, "temperature": temperature}
+    return OpenAIClient(model=model_name, temperature=temperature)
 
-run = instantiate_with_params(llm_config, values={"provider": "openai"})
+run = instantiate_with_params(llm_config, values={"model_name": "gpt-5"})
 
-assert run.value == {"provider": "openai", "temperature": 0.2}
-assert run.params == {"provider": "openai", "temperature": 0.2}
+assert run.value.model == "gpt-5"
+assert run.params == {"model_name": "gpt-5", "temperature": 0.2}
 
 replayed = instantiate(llm_config, values=run.params)
-assert replayed == run.value
+assert replayed.model == run.value.model
 ```
 {% endcode %}
 
@@ -97,7 +107,7 @@ See [Values & Overrides](../in-depth/values-and-overrides.md) for more examples.
 {% code overflow="wrap" %}
 ```python
 def config(hp: HP):
-    max_depth = hp.int(None, name="max_depth", allow_none=True)
+    max_depth = hp.int(None, name="max_depth", min=1, max=100, allow_none=True)
     thinking_level = hp.select(
         [None, "low", "medium", "high"],
         name="thinking_level",

--- a/docs/getting-started/interactive-instantiation-ui.md
+++ b/docs/getting-started/interactive-instantiation-ui.md
@@ -26,47 +26,49 @@ The `viz` extra installs the widget runtime needed by Jupyter Notebook, JupyterL
 
 {% code overflow="wrap" %}
 ```python
-from dataclasses import dataclass
-
 from hypster import HP, interact
+from my_app.llms import AnthropicClient, OpenAIClient
 
 
-@dataclass(frozen=True)
-class ModelSettings:
-    provider: str
-    model: str
-    temperature: float
-    cache: bool
+def openai_config(hp: HP) -> OpenAIClient:
+    model_name = hp.select(
+        ["gpt-5-mini", "gpt-5"],
+        name="model_name",
+        default="gpt-5-mini",
+        options_only=True,
+    )
+    temperature = hp.float(0.2, name="temperature", min=0.0, max=1.0)
+    cache = hp.bool(True, name="cache")
+    return OpenAIClient(model=model_name, temperature=temperature, cache=cache)
 
 
-def model_config(hp: HP) -> ModelSettings:
-    provider = hp.select(
-        ["openai", "anthropic"],
+def anthropic_config(hp: HP) -> AnthropicClient:
+    model_name = hp.select(
+        ["claude-sonnet", "claude-opus"],
+        name="model_name",
+        default="claude-sonnet",
+        options_only=True,
+    )
+    temperature = hp.float(0.2, name="temperature", min=0.0, max=1.0)
+    cache = hp.bool(True, name="cache")
+    return AnthropicClient(model=model_name, temperature=temperature, cache=cache)
+
+
+model_options = {
+    "openai": openai_config,
+    "anthropic": anthropic_config,
+}
+
+
+def model_config(hp: HP):
+    selected_config = hp.select(
+        model_options,
         name="provider",
         default="openai",
+        options_only=True,
         description="Chooses which provider branch is active.",
     )
-    if provider == "anthropic":
-        model = hp.select(
-            ["claude-sonnet-4-6", "claude-opus-4-7"],
-            name="model",
-            default="claude-sonnet-4-6",
-            options_only=True,
-        )
-    else:
-        model = hp.select(
-            ["gpt-5.4-mini", "gpt-5.5"],
-            name="model",
-            default="gpt-5.4-mini",
-            options_only=True,
-        )
-
-    return ModelSettings(
-        provider=provider,
-        model=model,
-        temperature=hp.float(0.2, name="temperature", min=0.0, max=1.0),
-        cache=hp.bool(True, name="cache"),
-    )
+    return hp.nest(selected_config, name="model")
 
 
 result = interact(model_config)
@@ -77,12 +79,12 @@ result = interact(model_config)
 
 {% code overflow="wrap" %}
 ```python
-settings = result.value
+client = result.value
 params = result.params
 ```
 {% endcode %}
 
-`result.value` has the same type as the config function return value. In this example it is a `ModelSettings` instance.
+`result.value` has the same type as the config function return value. In this example it is an initialized `OpenAIClient` or `AnthropicClient`.
 
 `result.params` is a flat dotted-path dictionary that can be replayed through `instantiate(..., values=result.params)` or logged to experiment-tracking tools.
 

--- a/docs/getting-started/selecting-output-variables.md
+++ b/docs/getting-started/selecting-output-variables.md
@@ -18,51 +18,11 @@ layout:
 
 # Select Return Values
 
-Hypster config functions return exactly what you decide to return. There is no framework-specific config object to build unless you want one.
-
-## Return A Dict
-
-{% code overflow="wrap" %}
-```python
-from hypster import HP, instantiate
-
-def config(hp: HP):
-    model_name = hp.select(["small", "large"], name="model_name", default="small")
-    batch_size = hp.int(32, name="batch_size")
-    return {"model_name": model_name, "batch_size": batch_size}
-
-cfg = instantiate(config, values={"model_name": "large"})
-assert cfg == {"model_name": "large", "batch_size": 32}
-```
-{% endcode %}
-
-## Return A Dataclass
-
-{% code overflow="wrap" %}
-```python
-from dataclasses import dataclass
-from hypster import HP, instantiate
-
-@dataclass
-class TrainingConfig:
-    batch_size: int
-    learning_rate: float
-
-def config(hp: HP) -> TrainingConfig:
-    return TrainingConfig(
-        batch_size=hp.int(32, name="batch_size", min=1),
-        learning_rate=hp.float(0.001, name="learning_rate", min=0.0),
-    )
-
-cfg = instantiate(config, values={"batch_size": 64})
-assert cfg.batch_size == 64
-assert cfg == TrainingConfig(batch_size=64, learning_rate=0.001)
-```
-{% endcode %}
+Hypster config functions return exactly what you decide to return. There is no framework-specific config object to build. In most application code, the cleanest return value is the initialized object that the caller will actually use.
 
 ## Return Initialized Runtime Objects
 
-One common Hypster style is to make the config a typed factory for the object your application will use.
+The common Hypster style is to make the config a typed factory for a runtime object.
 
 {% code overflow="wrap" %}
 ```python
@@ -71,9 +31,62 @@ from hypster import HP, instantiate
 
 def classifier_config(hp: HP) -> RandomForestClassifier:
     n_estimators = hp.int(200, name="n_estimators", min=10, max=1000)
-    max_depth = hp.int(None, name="max_depth", allow_none=True)
+    max_depth = hp.int(None, name="max_depth", min=1, max=100, allow_none=True)
     min_samples_leaf = hp.int(2, name="min_samples_leaf", min=1, max=50)
+    random_state = hp.int(42, name="random_state", min=0)
 
+    return RandomForestClassifier(
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        min_samples_leaf=min_samples_leaf,
+        random_state=random_state,
+    )
+
+model = instantiate(classifier_config, values={"n_estimators": 500})
+assert isinstance(model, RandomForestClassifier)
+```
+{% endcode %}
+
+The return type annotation helps readers, IDEs, and downstream code understand what instantiation produces.
+
+## Return A Dict When The Runtime Shape Is A Dict
+
+Returning a dict is fine when the object your application needs is actually a mapping. Avoid using dicts as a generic bag of settings that must be assembled somewhere else.
+
+{% code overflow="wrap" %}
+```python
+from hypster import HP, instantiate
+
+def metric_tags_config(hp: HP) -> dict[str, str]:
+    environment = hp.select(["dev", "staging", "prod"], name="environment", default="dev", options_only=True)
+    owner = hp.text("ml-platform", name="owner")
+    return {"environment": environment, "owner": owner}
+
+tags = instantiate(metric_tags_config, values={"environment": "prod"})
+assert tags == {"environment": "prod", "owner": "ml-platform"}
+```
+{% endcode %}
+
+## Use Dict-Backed Selects For Swappable Objects
+
+Use dict-backed `select` when a parameter should log a simple key but return a more complex runtime value. For swappable configs, map keys to config functions and nest the selected function.
+
+{% code overflow="wrap" %}
+```python
+from sklearn.base import ClassifierMixin
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+
+from hypster import HP
+
+def logistic_model(hp: HP) -> LogisticRegression:
+    C = hp.float(1.0, name="C", min=1e-4, max=100.0)
+    return LogisticRegression(C=C, max_iter=1000)
+
+def forest_model(hp: HP) -> RandomForestClassifier:
+    n_estimators = hp.int(200, name="n_estimators", min=10, max=1000)
+    max_depth = hp.int(None, name="max_depth", min=1, max=100, allow_none=True)
+    min_samples_leaf = hp.int(2, name="min_samples_leaf", min=1, max=50)
     return RandomForestClassifier(
         n_estimators=n_estimators,
         max_depth=max_depth,
@@ -81,26 +94,18 @@ def classifier_config(hp: HP) -> RandomForestClassifier:
         random_state=42,
     )
 
-model = instantiate(classifier_config, values={"n_estimators": 500})
+model_options = {
+    "logistic": logistic_model,
+    "forest": forest_model,
+}
+
+def classifier_config(hp: HP) -> ClassifierMixin:
+    selected_config = hp.select(model_options, name="model_family", default="forest", options_only=True)
+    return hp.nest(selected_config, name="model")
 ```
 {% endcode %}
 
-The return type annotation helps readers, IDEs, and downstream code understand what instantiation produces.
-
-Use dict-backed `select` when a parameter should log a simple key but return a more complex runtime value:
-
-{% code overflow="wrap" %}
-```python
-architecture = hp.select(
-    {
-        "small": {"layers": 2, "units": [64, 32]},
-        "large": {"layers": 4, "units": [256, 128]},
-    },
-    name="architecture",
-    default="small",
-)
-```
-{% endcode %}
+The named `model_options` dict is part of the pattern. If the option set is long, keeping it separate from the parent config is usually clearer than embedding a large dictionary inside `hp.select(...)` or growing an `if`/`elif` chain. Nesting also gives UI renderers a natural group for the selected child's controls.
 
 ## Use hp.collect
 

--- a/docs/how-to/build-an-interactive-ui.md
+++ b/docs/how-to/build-an-interactive-ui.md
@@ -11,35 +11,37 @@ Use `explore(config, return_info=True)` to discover fields, render controls in y
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, explore
+from my_app.search import KeywordRetriever, SearchRuntime, VectorRetriever
 
 
-def keyword_retrieval(hp: HP):
-    return {
-        "index": hp.text("documents-v1", name="index", description="Keyword index name."),
-        "top_k": hp.int(20, name="top_k", min=1, max=100),
-    }
+def keyword_retrieval(hp: HP) -> KeywordRetriever:
+    index = hp.text("documents-v1", name="index", description="Keyword index name.")
+    top_k = hp.int(20, name="top_k", min=1, max=100)
+    return KeywordRetriever(index=index, top_k=top_k)
 
 
-def vector_retrieval(hp: HP):
-    return {
-        "index": hp.text("embeddings-v1", name="index", description="Vector index name."),
-        "top_k": hp.int(10, name="top_k", min=1, max=100),
-        "score_threshold": hp.float(0.2, name="score_threshold", min=0.0, max=1.0),
-    }
+def vector_retrieval(hp: HP) -> VectorRetriever:
+    index = hp.text("embeddings-v1", name="index", description="Vector index name.")
+    top_k = hp.int(10, name="top_k", min=1, max=100)
+    score_threshold = hp.float(0.2, name="score_threshold", min=0.0, max=1.0)
+    return VectorRetriever(index=index, top_k=top_k, score_threshold=score_threshold)
 
 
-def search_config(hp: HP):
-    backend = hp.select(
-        ["keyword", "vector"],
+retrieval_options = {
+    "keyword": keyword_retrieval,
+    "vector": vector_retrieval,
+}
+
+
+def search_config(hp: HP) -> SearchRuntime:
+    selected_config = hp.select(
+        retrieval_options,
         name="backend",
         default="keyword",
         options_only=True,
         description="Chooses the retrieval branch.",
     )
-    if backend == "vector":
-        retrieval = hp.nest(vector_retrieval, name="retrieval")
-    else:
-        retrieval = hp.nest(keyword_retrieval, name="retrieval")
+    retrieval = hp.nest(selected_config, name="retrieval")
 
     features = hp.multi_select(
         [None, "cache", "trace"],
@@ -48,7 +50,7 @@ def search_config(hp: HP):
         allow_none=True,
     )
 
-    return {"backend": backend, "retrieval": retrieval, "features": features}
+    return SearchRuntime(retrieval=retrieval, features=features)
 
 
 schema = explore(search_config, return_info=True)
@@ -167,6 +169,8 @@ Schema metadata is JSON-serializable. After exploring the vector branch with val
 
 For dict-backed selects, `options` contains the replayable keys, not the mapped runtime objects.
 
+This is another reason to prefer named option dictionaries for swappable components: UIs can render simple stable keys such as `"keyword"` and `"vector"`, while the config still receives the mapped class or child config function.
+
 ## 3. Render Controls
 
 Map field kinds to controls in your UI framework:
@@ -250,8 +254,8 @@ ui_values = {
 }
 
 cfg = instantiate(search_config, values=ui_values)
-assert cfg["backend"] == "vector"
-assert cfg["retrieval"]["top_k"] == 12
+assert isinstance(cfg.retrieval, VectorRetriever)
+assert cfg.retrieval.top_k == 12
 ```
 {% endcode %}
 

--- a/docs/how-to/capture-replayable-params.md
+++ b/docs/how-to/capture-replayable-params.md
@@ -7,24 +7,22 @@ Use `instantiate_with_params()` when a run needs a durable parameter record.
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate, instantiate_with_params
+from my_app.reporting import ReportRequest
 
-def report_config(hp: HP):
-    return {
-        "audience": hp.select(["exec", "technical"], name="audience", default="technical", options_only=True),
-        "include_appendix": hp.bool(True, name="include_appendix"),
-        "max_pages": hp.int(12, name="max_pages", min=1, max=100),
-    }
+def report_config(hp: HP) -> ReportRequest:
+    audience = hp.select(["exec", "technical"], name="audience", default="technical", options_only=True)
+    include_appendix = hp.bool(True, name="include_appendix")
+    max_pages = hp.int(12, name="max_pages", min=1, max=100)
+    return ReportRequest(audience=audience, include_appendix=include_appendix, max_pages=max_pages)
 
 run = instantiate_with_params(
     report_config,
     values={"audience": "exec", "max_pages": 6},
 )
 
-assert run.value == {
-    "audience": "exec",
-    "include_appendix": True,
-    "max_pages": 6,
-}
+assert run.value.audience == "exec"
+assert run.value.include_appendix is True
+assert run.value.max_pages == 6
 assert run.params == {
     "audience": "exec",
     "include_appendix": True,
@@ -38,7 +36,7 @@ assert run.params == {
 {% code overflow="wrap" %}
 ```python
 replayed = instantiate(report_config, values=run.params)
-assert replayed == run.value
+assert replayed.max_pages == run.value.max_pages
 ```
 {% endcode %}
 
@@ -46,19 +44,19 @@ Captured params include defaults, so replay does not silently pick up later defa
 
 {% code overflow="wrap" %}
 ```python
-def old_config(hp: HP):
-    return {"batch_size": hp.int(64, name="batch_size")}
+def old_config(hp: HP) -> int:
+    return hp.int(64, name="batch_size")
 
 
 old_run = instantiate_with_params(old_config)
 assert old_run.params == {"batch_size": 64}
 
 
-def new_config(hp: HP):
-    return {"batch_size": hp.int(128, name="batch_size")}
+def new_config(hp: HP) -> int:
+    return hp.int(128, name="batch_size")
 
 
-assert instantiate(new_config, values=old_run.params) == {"batch_size": 64}
+assert instantiate(new_config, values=old_run.params) == 64
 ```
 {% endcode %}
 
@@ -83,19 +81,26 @@ Use dict-backed `select` when a runtime choice is a complex object. The params r
 
 {% code overflow="wrap" %}
 ```python
+from my_app.models import LargeMLP, SmallMLP
+
+def small_model(hp: HP) -> SmallMLP:
+    return SmallMLP(layers=2, units=[64, 32])
+
+def large_model(hp: HP) -> LargeMLP:
+    return LargeMLP(layers=4, units=[256, 128])
+
+model_options = {
+    "small": small_model,
+    "large": large_model,
+}
+
 def model_config(hp: HP):
-    return hp.select(
-        {
-            "small": {"layers": 2, "units": [64, 32]},
-            "large": {"layers": 4, "units": [256, 128]},
-        },
-        name="model",
-        default="small",
-    )
+    selected_config = hp.select(model_options, name="model", default="small", options_only=True)
+    return hp.nest(selected_config, name="settings")
 
 run = instantiate_with_params(model_config, values={"model": "large"})
 
-assert run.value == {"layers": 4, "units": [256, 128]}
+assert isinstance(run.value, LargeMLP)
 assert run.params == {"model": "large"}
 ```
 {% endcode %}

--- a/docs/how-to/compose-nested-configs.md
+++ b/docs/how-to/compose-nested-configs.md
@@ -7,30 +7,36 @@ Use this guide when one workflow should be assembled from reusable smaller confi
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, explore, instantiate
+from my_app.embeddings import BpeTokenizer, EmbeddingPipeline, Encoder, Tokenizer, WordPieceTokenizer
 
-def tokenizer_config(hp: HP):
-    return {
-        "kind": hp.select(["wordpiece", "bpe"], name="kind", default="bpe", options_only=True),
-        "lowercase": hp.bool(True, name="lowercase"),
-    }
+tokenizer_options = {
+    "wordpiece": WordPieceTokenizer,
+    "bpe": BpeTokenizer,
+}
 
-def encoder_config(hp: HP):
+def tokenizer_config(hp: HP) -> Tokenizer:
+    tokenizer_cls = hp.select(tokenizer_options, name="kind", default="bpe", options_only=True)
+    lowercase = hp.bool(True, name="lowercase")
+    return tokenizer_cls(lowercase=lowercase)
+
+def encoder_config(hp: HP) -> Encoder:
     size = hp.select(["small", "base"], name="size", default="small", options_only=True)
     hidden_size = 384 if size == "small" else 768
-    return {"size": size, "hidden_size": hidden_size}
+    return Encoder(size=size, hidden_size=hidden_size)
 ```
 {% endcode %}
+
+Use this named-options shape when a parent config chooses between swappable children. The dictionary provides the stable keys Hypster logs, while the values can be classes, callables, or full child config functions.
 
 ## Nest Them In A Parent
 
 {% code overflow="wrap" %}
 ```python
-def embedding_pipeline(hp: HP):
-    return {
-        "tokenizer": hp.nest(tokenizer_config, name="tokenizer"),
-        "encoder": hp.nest(encoder_config, name="encoder"),
-        "normalize": hp.bool(True, name="normalize"),
-    }
+def embedding_pipeline(hp: HP) -> EmbeddingPipeline:
+    tokenizer = hp.nest(tokenizer_config, name="tokenizer")
+    encoder = hp.nest(encoder_config, name="encoder")
+    normalize = hp.bool(True, name="normalize")
+    return EmbeddingPipeline(tokenizer=tokenizer, encoder=encoder, normalize=normalize)
 ```
 {% endcode %}
 
@@ -47,7 +53,7 @@ cfg = instantiate(
     },
 )
 
-assert cfg["encoder"]["hidden_size"] == 768
+assert cfg.encoder.hidden_size == 768
 ```
 {% endcode %}
 
@@ -74,17 +80,17 @@ When you pass child-local values through `hp.nest(child, name="child", values=..
 
 {% code overflow="wrap" %}
 ```python
-def sampler_config(hp: HP, default_batch_size: int):
-    return {
-        "batch_size": hp.int(default_batch_size, name="batch_size", min=1),
-        "shuffle": hp.bool(True, name="shuffle"),
-    }
+from my_app.training import BatchSampler, TrainingInputs
 
-def training_config(hp: HP):
-    return {
-        "train": hp.nest(sampler_config, name="train", args=(128,)),
-        "eval": hp.nest(sampler_config, name="eval", kwargs={"default_batch_size": 256}),
-    }
+def sampler_config(hp: HP, default_batch_size: int) -> BatchSampler:
+    batch_size = hp.int(default_batch_size, name="batch_size", min=1)
+    shuffle = hp.bool(True, name="shuffle")
+    return BatchSampler(batch_size=batch_size, shuffle=shuffle)
+
+def training_config(hp: HP) -> TrainingInputs:
+    train = hp.nest(sampler_config, name="train", args=(128,))
+    eval = hp.nest(sampler_config, name="eval", kwargs={"default_batch_size": 256})
+    return TrainingInputs(train=train, eval=eval)
 ```
 {% endcode %}
 

--- a/docs/how-to/create-a-replayable-config.md
+++ b/docs/how-to/create-a-replayable-config.md
@@ -8,24 +8,15 @@ The config is a normal Python function. Keep it cheap and side-effect-free so `e
 
 {% code overflow="wrap" %}
 ```python
-from dataclasses import dataclass
-
 from hypster import HP
+from my_app.data import CsvDataset
 
 
-@dataclass(frozen=True)
-class DataLoadSettings:
-    path: str
-    batch_size: int
-    shuffle: bool
-
-
-def data_config(hp: HP) -> DataLoadSettings:
-    return DataLoadSettings(
-        path=hp.text("data/train.csv", name="path"),
-        batch_size=hp.int(64, name="batch_size", min=1),
-        shuffle=hp.bool(True, name="shuffle"),
-    )
+def data_config(hp: HP) -> CsvDataset:
+    path = hp.text("data/train.csv", name="path")
+    batch_size = hp.int(64, name="batch_size", min=1)
+    shuffle = hp.bool(True, name="shuffle")
+    return CsvDataset(path=path, batch_size=batch_size, shuffle=shuffle)
 ```
 {% endcode %}
 
@@ -56,13 +47,11 @@ fields = schema.to_dict()["parameters"]
 ```python
 from hypster import instantiate
 
-settings = instantiate(data_config, values={"batch_size": 128})
+dataset = instantiate(data_config, values={"batch_size": 128})
 
-assert settings == DataLoadSettings(
-    path="data/train.csv",
-    batch_size=128,
-    shuffle=True,
-)
+assert dataset.path == "data/train.csv"
+assert dataset.batch_size == 128
+assert dataset.shuffle is True
 ```
 {% endcode %}
 
@@ -74,7 +63,7 @@ from hypster import instantiate_with_params
 
 run = instantiate_with_params(data_config, values={"batch_size": 128})
 
-assert run.value == settings
+assert run.value.batch_size == dataset.batch_size
 assert run.params == {
     "path": "data/train.csv",
     "batch_size": 128,
@@ -93,7 +82,7 @@ payload = json.dumps(run.params, sort_keys=True)
 restored_params = json.loads(payload)
 
 replayed = instantiate(data_config, values=restored_params)
-assert replayed == run.value
+assert replayed.batch_size == run.value.batch_size
 ```
 {% endcode %}
 

--- a/docs/how-to/perform-hyperparameter-optimization.md
+++ b/docs/how-to/perform-hyperparameter-optimization.md
@@ -22,28 +22,24 @@ pip install 'hypster[optuna]'
 
 {% code overflow="wrap" %}
 ```python
-from dataclasses import dataclass
+from sklearn.base import ClassifierMixin
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+
 from hypster import HP, instantiate_with_params
 from hypster.hpo.types import HpoFloat, HpoInt
 
-@dataclass
-class ModelConfig:
-    family: str
-    params: dict
+def linear_model(hp: HP) -> LogisticRegression:
+    C = hp.float(
+        1.0,
+        name="C",
+        min=1e-4,
+        max=10.0,
+        hpo_spec=HpoFloat(scale="log"),
+    )
+    return LogisticRegression(C=C, max_iter=1000)
 
-def model_config(hp: HP) -> ModelConfig:
-    family = hp.select(["linear", "forest"], name="family", default="forest", options_only=True)
-
-    if family == "linear":
-        alpha = hp.float(
-            0.1,
-            name="alpha",
-            min=1e-4,
-            max=10.0,
-            hpo_spec=HpoFloat(scale="log"),
-        )
-        return ModelConfig(family=family, params={"alpha": alpha})
-
+def forest_model(hp: HP) -> RandomForestClassifier:
     n_estimators = hp.int(
         200,
         name="n_estimators",
@@ -52,7 +48,20 @@ def model_config(hp: HP) -> ModelConfig:
         hpo_spec=HpoInt(step=50),
     )
     max_depth = hp.int(12, name="max_depth", min=2, max=64, hpo_spec=HpoInt(scale="log"))
-    return ModelConfig(family=family, params={"n_estimators": n_estimators, "max_depth": max_depth})
+    return RandomForestClassifier(
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        random_state=42,
+    )
+
+model_options = {
+    "linear": linear_model,
+    "forest": forest_model,
+}
+
+def model_config(hp: HP) -> ClassifierMixin:
+    selected_config = hp.select(model_options, name="model_family", default="forest", options_only=True)
+    return hp.nest(selected_config, name="model")
 ```
 {% endcode %}
 
@@ -61,13 +70,14 @@ def model_config(hp: HP) -> ModelConfig:
 {% code overflow="wrap" %}
 ```python
 import optuna
+from sklearn.model_selection import cross_val_score
+
 from hypster.hpo.optuna import suggest_values
 
-def train_and_score(cfg: ModelConfig) -> float:
-    # Replace with your training loop.
-    if cfg.family == "linear":
-        return 0.7
-    return 0.8
+def train_and_score(model: ClassifierMixin) -> float:
+    # Replace X_train and y_train with your dataset.
+    scores = cross_val_score(model, X_train, y_train, cv=3, scoring="accuracy")
+    return float(scores.mean())
 
 def objective(trial: optuna.Trial) -> float:
     values = suggest_values(trial, config=model_config)
@@ -86,7 +96,7 @@ Wrap the config when you want a fixed branch. This keeps Optuna from sampling pa
 
 {% code overflow="wrap" %}
 ```python
-def forest_only_config(hp: HP) -> ModelConfig:
+def forest_only_config(hp: HP) -> RandomForestClassifier:
     n_estimators = hp.int(
         200,
         name="n_estimators",
@@ -95,7 +105,11 @@ def forest_only_config(hp: HP) -> ModelConfig:
         hpo_spec=HpoInt(step=50),
     )
     max_depth = hp.int(12, name="max_depth", min=2, max=64, hpo_spec=HpoInt(scale="log"))
-    return ModelConfig(family="forest", params={"n_estimators": n_estimators, "max_depth": max_depth})
+    return RandomForestClassifier(
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        random_state=42,
+    )
 
 def objective(trial: optuna.Trial) -> float:
     values = suggest_values(trial, config=forest_only_config)

--- a/docs/in-depth/basic-best-practices.md
+++ b/docs/in-depth/basic-best-practices.md
@@ -4,7 +4,7 @@ These practices keep Hypster configs easy to explore, optimize, log, and replay.
 
 ## Embrace Pure Python
 
-Hypster configs are ordinary Python functions rather than a DSL. Use `if` statements, loops, local variables, lists, helpers, dataclasses, imports, and typed return values when they make the config clearer.
+Hypster configs are ordinary Python functions rather than a DSL. Use `if` statements, loops, local variables, lists, helpers, imports, and typed return values when they make the config clearer.
 
 The implication is that Hypster discovers the available parameters by running your function. Design config functions so they can be run repeatedly by `explore()`, HPO, and interactive UIs without causing side effects or surprising costs.
 
@@ -45,7 +45,7 @@ Use this boundary when deciding what a config should return:
 
 | Return from the config | Usually safe during `explore()`? | Notes |
 | --- | --- | --- |
-| Dataclasses, dictionaries, enums, small Python objects | Yes | Good for UI generation, experiment tracking, and replay. |
+| Enums, paths, mappings your runtime actually consumes, small Python objects | Yes | Good for UI generation, experiment tracking, and replay. |
 | In-memory model estimators or pipeline objects | Usually | Good when construction is cheap and does not open files, sockets, or remote handles. |
 | SDK clients, database handles, loaded indexes, network retrievers | Usually no | Return lightweight settings or factories, then build these after `instantiate()`. |
 | Training jobs, writes, API calls, migrations | No | Run these outside the config function. |
@@ -73,36 +73,60 @@ Branch when downstream structure changes:
 
 {% code overflow="wrap" %}
 ```python
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+
+from hypster import HP
+
 def model_config(hp: HP):
     family = hp.select(["linear", "forest"], name="family", default="forest", options_only=True)
 
     if family == "linear":
-        return {"alpha": hp.float(0.1, name="alpha", min=0.0, max=10.0)}
+        C = hp.float(1.0, name="C", min=1e-4, max=100.0)
+        return LogisticRegression(C=C, max_iter=1000)
 
-    return {"n_estimators": hp.int(200, name="n_estimators", min=10)}
+    n_estimators = hp.int(200, name="n_estimators", min=10, max=1000)
+    max_depth = hp.int(None, name="max_depth", min=1, max=100, allow_none=True)
+    return RandomForestClassifier(n_estimators=n_estimators, max_depth=max_depth)
 ```
 {% endcode %}
 
 Avoid carrying irrelevant parameters for inactive branches. Branch-aware configs make experiment logs cleaner and HPO search spaces smaller.
 
-## Use Dict-Backed Selects For Complex Runtime Values
+Use inline branches for small, local differences. When the branch chooses between reusable components, prefer composition with `hp.nest()` and a dict-backed `select` over a long `if`/`elif` chain. The key stays replayable, each component keeps its parameters local, and interactive UIs can render the selected child config as a contained group.
 
-Select keys should be simple and replayable. Map those keys to complex runtime values:
+## Prefer Dict-Backed Selects For Swappable Components
+
+Select keys should be simple and replayable. For swappable runtime components, map those keys to config functions and then nest the selected function:
 
 {% code overflow="wrap" %}
 ```python
-tokenizer = hp.select(
-    {
-        "simple": "basic_tokenizer",
-        "wordpiece": {"kind": "wordpiece", "vocab": "vocab.txt"},
-    },
-    name="tokenizer",
-    default="wordpiece",
-)
+from my_app.tokenizers import SimpleTokenizer, Tokenizer, WordPieceTokenizer
+
+def simple_tokenizer_config(hp: HP) -> SimpleTokenizer:
+    lowercase = hp.bool(True, name="lowercase")
+    return SimpleTokenizer(lowercase=lowercase)
+
+def wordpiece_tokenizer_config(hp: HP) -> WordPieceTokenizer:
+    vocab_path = hp.text("vocab.txt", name="vocab_path")
+    return WordPieceTokenizer(vocab_path=vocab_path)
+
+tokenizer_options = {
+    "simple": simple_tokenizer_config,
+    "wordpiece": wordpiece_tokenizer_config,
+}
+
+def tokenizer_config(hp: HP) -> Tokenizer:
+    selected_config = hp.select(tokenizer_options, name="tokenizer", default="wordpiece", options_only=True)
+    return hp.nest(selected_config, name="settings")
 ```
 {% endcode %}
 
-This keeps `params={"tokenizer": "wordpiece"}` while your app receives the mapped dictionary when that branch is selected.
+This keeps `params={"tokenizer": "wordpiece", "settings.vocab_path": "vocab.txt"}` while your app receives the selected tokenizer object.
+
+Keep the options mapping in a named variable such as `tokenizer_options`, `model_options`, or `retriever_options`. That keeps the parent config readable, especially when the mapping is long, and makes it easy to reuse the same option set in HPO, interactive UIs, tests, and nested configs.
+
+For a tiny branch with one or two scalar differences, an `if` statement is fine. Once each branch has its own parameters or returns a different runtime type, split the branches into child config functions and choose between them with a dict-backed select.
 
 ## Turn On `options_only=True` For Enums
 
@@ -120,7 +144,7 @@ provider = hp.select(["openai", "gemini"], name="provider", default="openai", op
 
 {% code overflow="wrap" %}
 ```python
-max_depth = hp.int(None, name="max_depth", allow_none=True)
+max_depth = hp.int(None, name="max_depth", min=1, max=100, allow_none=True)
 ```
 {% endcode %}
 
@@ -194,11 +218,11 @@ Return what the caller needs. A small return surface makes configs easier to tes
 
 {% code overflow="wrap" %}
 ```python
-return {
-    "model": model,
-    "optimizer": optimizer,
-}
+def training_config(hp: HP) -> TrainingRunner:
+    model = hp.nest(model_config, name="model")
+    optimizer = hp.nest(optimizer_config, name="optimizer")
+    return TrainingRunner(model=model, optimizer=optimizer)
 ```
 {% endcode %}
 
-Use `hp.collect(locals(), include=[...])` when that makes the return explicit and concise.
+Use `hp.collect(locals(), include=[...])` when the caller genuinely wants a mapping and that makes the return explicit and concise.

--- a/docs/in-depth/hp-call-types/README.md
+++ b/docs/in-depth/hp-call-types/README.md
@@ -2,6 +2,8 @@
 
 `HP` methods define the public parameters in a config function. Each call records a parameter path, validates overrides, and can be explored or replayed.
 
+The examples in this reference sometimes return small dictionaries to keep the call behavior visible. In application code, prefer returning the initialized runtime object unless the mapping itself is the object your caller needs.
+
 ## Scalar Calls
 
 | Call | Use for | Notes |

--- a/docs/in-depth/hp-call-types/select-and-multi-select.md
+++ b/docs/in-depth/hp-call-types/select-and-multi-select.md
@@ -92,7 +92,7 @@ assert run.params == {"model": "large"}
 Dictionary form is the recommended way to return:
 
 * objects or callables
-* dictionaries, lists, tuples, or dataclasses
+* dictionaries, lists, or tuples that your runtime actually consumes
 * long provider/model IDs behind short aliases
 
 {% code overflow="wrap" %}

--- a/docs/in-depth/nest.md
+++ b/docs/in-depth/nest.md
@@ -7,21 +7,20 @@
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate
+from my_app.training import AdamW, DataLoaders, BatchSampler, TrainingRun
 
-def optimizer_config(hp: HP):
-    return {
-        "learning_rate": hp.float(0.001, name="learning_rate", min=1e-6, max=1.0),
-        "weight_decay": hp.float(0.0, name="weight_decay", min=0.0, max=1.0),
-    }
+def optimizer_config(hp: HP) -> AdamW:
+    learning_rate = hp.float(0.001, name="learning_rate", min=1e-6, max=1.0)
+    weight_decay = hp.float(0.0, name="weight_decay", min=0.0, max=1.0)
+    return AdamW(learning_rate=learning_rate, weight_decay=weight_decay)
 
-def training_config(hp: HP):
-    return {
-        "epochs": hp.int(10, name="epochs", min=1),
-        "optimizer": hp.nest(optimizer_config, name="optimizer"),
-    }
+def training_config(hp: HP) -> TrainingRun:
+    epochs = hp.int(10, name="epochs", min=1)
+    optimizer = hp.nest(optimizer_config, name="optimizer")
+    return TrainingRun(epochs=epochs, optimizer=optimizer)
 
 cfg = instantiate(training_config, values={"optimizer.learning_rate": 0.01})
-assert cfg["optimizer"]["learning_rate"] == 0.01
+assert cfg.optimizer.learning_rate == 0.01
 ```
 {% endcode %}
 
@@ -59,10 +58,10 @@ def parent(hp: HP):
         optimizer_config,
         name="optimizer",
         values={"learning_rate": 0.005},
-    )
+)
 
-assert instantiate(parent)["learning_rate"] == 0.005
-assert instantiate(parent, values={"optimizer.learning_rate": 0.02})["learning_rate"] == 0.005
+assert instantiate(parent).learning_rate == 0.005
+assert instantiate(parent, values={"optimizer.learning_rate": 0.02}).learning_rate == 0.005
 ```
 {% endcode %}
 
@@ -74,7 +73,7 @@ def overridable_parent(hp: HP):
     return hp.nest(optimizer_config, name="optimizer")
 
 cfg = instantiate(overridable_parent, values={"optimizer.learning_rate": 0.02})
-assert cfg["learning_rate"] == 0.02
+assert cfg.learning_rate == 0.02
 ```
 {% endcode %}
 
@@ -96,17 +95,15 @@ Use child-local `values=` for parent-owned policy, test fixtures, or internal co
 
 {% code overflow="wrap" %}
 ```python
-def sampler_config(hp: HP, default_batch_size: int):
-    return {
-        "batch_size": hp.int(default_batch_size, name="batch_size", min=1),
-        "shuffle": hp.bool(True, name="shuffle"),
-    }
+def sampler_config(hp: HP, default_batch_size: int) -> BatchSampler:
+    batch_size = hp.int(default_batch_size, name="batch_size", min=1)
+    shuffle = hp.bool(True, name="shuffle")
+    return BatchSampler(batch_size=batch_size, shuffle=shuffle)
 
-def data_config(hp: HP):
-    return {
-        "train": hp.nest(sampler_config, name="train", args=(128,)),
-        "eval": hp.nest(sampler_config, name="eval", kwargs={"default_batch_size": 256}),
-    }
+def data_config(hp: HP) -> DataLoaders:
+    train = hp.nest(sampler_config, name="train", args=(128,))
+    eval = hp.nest(sampler_config, name="eval", kwargs={"default_batch_size": 256})
+    return DataLoaders(train=train, eval=eval)
 ```
 {% endcode %}
 
@@ -116,21 +113,20 @@ You can choose which child config to run:
 
 {% code overflow="wrap" %}
 ```python
-def local_config(hp: HP):
-    return {"threads": hp.int(4, name="threads", min=1)}
+from my_app.backends import AppRuntime, LocalBackend, RemoteBackend
 
-def remote_config(hp: HP):
-    return {"endpoint": hp.text("https://api.example.com", name="endpoint")}
+def local_config(hp: HP) -> LocalBackend:
+    return LocalBackend(threads=hp.int(4, name="threads", min=1))
 
-def app_config(hp: HP):
-    backend = hp.select(["local", "remote"], name="backend", default="local", options_only=True)
+def remote_config(hp: HP) -> RemoteBackend:
+    return RemoteBackend(endpoint=hp.text("https://api.example.com", name="endpoint"))
 
-    if backend == "local":
-        settings = hp.nest(local_config, name="local")
-    else:
-        settings = hp.nest(remote_config, name="remote")
+backend_options = {"local": local_config, "remote": remote_config}
 
-    return {"backend": backend, "settings": settings}
+def app_config(hp: HP) -> AppRuntime:
+    selected_config = hp.select(backend_options, name="backend", default="local", options_only=True)
+    backend = hp.nest(selected_config, name="settings")
+    return AppRuntime(backend=backend)
 ```
 {% endcode %}
 
@@ -138,15 +134,15 @@ This value is valid:
 
 {% code overflow="wrap" %}
 ```python
-instantiate(app_config, values={"backend": "remote", "remote.endpoint": "https://staging.example.com"})
+instantiate(app_config, values={"backend": "remote", "settings.endpoint": "https://staging.example.com"})
 ```
 {% endcode %}
 
-This value raises by default because `local.threads` is unreachable on the `remote` branch:
+This value raises by default because `settings.threads` is unreachable on the `remote` branch:
 
 {% code overflow="wrap" %}
 ```python
-instantiate(app_config, values={"backend": "remote", "local.threads": 8})
+instantiate(app_config, values={"backend": "remote", "settings.threads": 8})
 ```
 {% endcode %}
 

--- a/docs/in-depth/performing-hyperparameter-optimization.md
+++ b/docs/in-depth/performing-hyperparameter-optimization.md
@@ -22,24 +22,24 @@ Use `hpo_spec=` to document search semantics where the parameter is defined:
 ```python
 from hypster import HP
 from hypster.hpo.types import HpoFloat, HpoInt
+from my_app.training import Trainer
 
-def config(hp: HP):
-    return {
-        "learning_rate": hp.float(
-            0.001,
-            name="learning_rate",
-            min=1e-6,
-            max=1.0,
-            hpo_spec=HpoFloat(scale="log"),
-        ),
-        "batch_size": hp.int(
-            64,
-            name="batch_size",
-            min=16,
-            max=512,
-            hpo_spec=HpoInt(step=16),
-        ),
-    }
+def config(hp: HP) -> Trainer:
+    learning_rate = hp.float(
+        0.001,
+        name="learning_rate",
+        min=1e-6,
+        max=1.0,
+        hpo_spec=HpoFloat(scale="log"),
+    )
+    batch_size = hp.int(
+        64,
+        name="batch_size",
+        min=16,
+        max=512,
+        hpo_spec=HpoInt(step=16),
+    )
+    return Trainer(learning_rate=learning_rate, batch_size=batch_size)
 ```
 {% endcode %}
 
@@ -73,13 +73,17 @@ Nullable numeric HPO parameters are not supported directly. Model the nullable c
 
 {% code overflow="wrap" %}
 ```python
-def tree_config(hp: HP):
+from sklearn.ensemble import RandomForestClassifier
+
+def tree_config(hp: HP) -> RandomForestClassifier:
     depth_mode = hp.select(["unlimited", "bounded"], name="depth_mode", default="bounded", options_only=True)
 
     if depth_mode == "unlimited":
-        return {"max_depth": None}
+        max_depth = None
+    else:
+        max_depth = hp.int(12, name="max_depth", min=1, max=64)
 
-    return {"max_depth": hp.int(12, name="max_depth", min=1, max=64)}
+    return RandomForestClassifier(max_depth=max_depth, random_state=42)
 ```
 {% endcode %}
 

--- a/docs/in-depth/values-and-overrides.md
+++ b/docs/in-depth/values-and-overrides.md
@@ -98,15 +98,25 @@ Only parameters touched by the active branch may appear in `values=`.
 
 {% code overflow="wrap" %}
 ```python
-def model_config(hp: HP):
-    family = hp.select(["linear", "forest"], name="family", default="linear", options_only=True)
+from sklearn.base import ClassifierMixin
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
 
-    if family == "linear":
-        return {"alpha": hp.float(0.1, name="alpha", min=0.0, max=10.0)}
+def linear_model(hp: HP) -> LogisticRegression:
+    C = hp.float(1.0, name="C", min=1e-4, max=100.0)
+    return LogisticRegression(C=C, max_iter=1000)
 
-    return {"n_estimators": hp.int(200, name="n_estimators", min=10)}
+def forest_model(hp: HP) -> RandomForestClassifier:
+    n_estimators = hp.int(200, name="n_estimators", min=10)
+    return RandomForestClassifier(n_estimators=n_estimators, random_state=42)
 
-instantiate(model_config, values={"family": "linear", "n_estimators": 500})
+model_options = {"linear": linear_model, "forest": forest_model}
+
+def model_config(hp: HP) -> ClassifierMixin:
+    selected_config = hp.select(model_options, name="family", default="linear", options_only=True)
+    return hp.nest(selected_config, name="model")
+
+instantiate(model_config, values={"family": "linear", "model.n_estimators": 500})
 # ValueError: Unknown or unreachable parameters
 ```
 {% endcode %}

--- a/docs/integrations/optuna.md
+++ b/docs/integrations/optuna.md
@@ -23,23 +23,25 @@ pip install 'hypster[optuna]'
 {% code overflow="wrap" %}
 ```python
 import optuna
+from sklearn.base import ClassifierMixin
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+
 from hypster import HP, instantiate
 from hypster.hpo.optuna import suggest_values
 from hypster.hpo.types import HpoFloat, HpoInt
 
-def model_config(hp: HP):
-    family = hp.select(["linear", "forest"], name="family", default="forest", options_only=True)
+def linear_model(hp: HP) -> LogisticRegression:
+    C = hp.float(
+        1.0,
+        name="C",
+        min=1e-4,
+        max=10.0,
+        hpo_spec=HpoFloat(scale="log"),
+    )
+    return LogisticRegression(C=C, max_iter=1000)
 
-    if family == "linear":
-        alpha = hp.float(
-            0.1,
-            name="alpha",
-            min=1e-4,
-            max=10.0,
-            hpo_spec=HpoFloat(scale="log"),
-        )
-        return {"family": family, "alpha": alpha}
-
+def forest_model(hp: HP) -> RandomForestClassifier:
     n_estimators = hp.int(
         200,
         name="n_estimators",
@@ -47,12 +49,21 @@ def model_config(hp: HP):
         max=1000,
         hpo_spec=HpoInt(step=50),
     )
-    return {"family": family, "n_estimators": n_estimators}
+    return RandomForestClassifier(n_estimators=n_estimators, random_state=42)
+
+model_options = {
+    "linear": linear_model,
+    "forest": forest_model,
+}
+
+def model_config(hp: HP) -> ClassifierMixin:
+    selected_config = hp.select(model_options, name="model_family", default="forest", options_only=True)
+    return hp.nest(selected_config, name="model")
 
 def objective(trial: optuna.Trial) -> float:
     values = suggest_values(trial, config=model_config)
-    cfg = instantiate(model_config, values=values)
-    return train_and_score(cfg)
+    model = instantiate(model_config, values=values)
+    return train_and_score(model)
 
 study = optuna.create_study(direction="maximize")
 study.optimize(objective, n_trials=30)

--- a/docs/philosophy/unique-features.md
+++ b/docs/philosophy/unique-features.md
@@ -6,7 +6,7 @@ icon: alicorn
 
 ## Define-By-Run Configuration
 
-Hypster config functions are normal Python rather than a DSL. Branches, loops, helper functions, lists, dataclasses, and imports work the way Python developers expect.
+Hypster config functions are normal Python rather than a DSL. Branches, loops, helper functions, lists, imports, and object construction work the way Python developers expect.
 
 The price of that flexibility is honest execution: Hypster discovers parameters by running the config function. Keep discovery paths fast and side-effect-free so exploration, UI rendering, and HPO can rerun them safely.
 
@@ -25,6 +25,8 @@ The price of that flexibility is honest execution: Hypster discovers parameters 
 ## Dict-Backed Selects
 
 Hypster separates the logged key from the runtime value. This lets you log `"large"` while returning an object, dictionary, tuple, or factory.
+
+For swappable components, the idiomatic shape is a named options dictionary from simple keys to config functions, followed by `hp.nest()` on the selected function. That keeps logs stable, UI options simple, and the parent config readable even when the option set grows.
 
 ## Strict Unknown Values By Default
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -18,12 +18,14 @@ Config functions are pure Python, not a DSL. `instantiate()`, `explore()`, `inte
 ```python
 from hypster import HP
 
-def config(hp: HP):
-    return {"batch_size": hp.int(32, name="batch_size")}
+def config(hp: HP) -> int:
+    return hp.int(32, name="batch_size")
 ```
 {% endcode %}
 
 The `hp: HP` annotation is recommended but not mandatory. If the first parameter has a type annotation, it must include `HP`. Callable objects are supported when `inspect.signature()` can read their `__call__` signature; signature validation errors use the class name.
+
+Reference examples use small return values for compactness. In application docs and production code, the usual pattern is to return the initialized object your application will use.
 
 Config functions may accept extra positional or keyword arguments. Pass those through `args=` and `kwargs=`.
 
@@ -75,12 +77,12 @@ Executes a config function and returns an `InstantiationOutput`.
 ```python
 from hypster import HP, instantiate_with_params
 
-def config(hp: HP):
-    return {"model": hp.select(["small", "large"], name="model", default="small")}
+def config(hp: HP) -> str:
+    return hp.select(["small", "large"], name="model", default="small")
 
 run = instantiate_with_params(config, values={"model": "large"})
 
-assert run.value == {"model": "large"}
+assert run.value == "large"
 assert run.params == {"model": "large"}
 ```
 {% endcode %}

--- a/docs/reproducibility/deploying-to-production.md
+++ b/docs/reproducibility/deploying-to-production.md
@@ -15,13 +15,13 @@ Hypster is in preview, so production use should be deliberate. When you do deplo
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate_with_params
+from my_app.deploy import ServiceDeployment
 
-def service_config(hp: HP):
-    return {
-        "replicas": hp.int(2, name="replicas", min=1, max=20),
-        "provider": hp.select(["local", "remote"], name="provider", default="remote", options_only=True),
-        "timeout": hp.float(10.0, name="timeout", min=0.1, max=120.0),
-    }
+def service_config(hp: HP) -> ServiceDeployment:
+    replicas = hp.int(2, name="replicas", min=1, max=20)
+    provider = hp.select(["local", "remote"], name="provider", default="remote", options_only=True)
+    timeout = hp.float(10.0, name="timeout", min=0.1, max=120.0)
+    return ServiceDeployment(replicas=replicas, provider=provider, timeout=timeout)
 
 def test_production_config():
     run = instantiate_with_params(

--- a/docs/reproducibility/experiment-tracking.md
+++ b/docs/reproducibility/experiment-tracking.md
@@ -5,21 +5,21 @@ Use `instantiate_with_params()` to log the exact parameters selected by a run.
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, instantiate_with_params
+from my_app.training import TrainingJob
 
-def training_config(hp: HP):
-    return {
-        "model": hp.select(["linear", "forest"], name="model", default="forest", options_only=True),
-        "seed": hp.int(42, name="seed", min=0),
-        "batch_size": hp.int(64, name="batch_size", min=1),
-    }
+def training_config(hp: HP) -> TrainingJob:
+    model_family = hp.select(["linear", "forest"], name="model_family", default="forest", options_only=True)
+    seed = hp.int(42, name="seed", min=0)
+    batch_size = hp.int(64, name="batch_size", min=1)
+    return TrainingJob(model_family=model_family, seed=seed, batch_size=batch_size)
 
 run = instantiate_with_params(
     training_config,
-    values={"model": "linear", "batch_size": 128},
+    values={"model_family": "linear", "batch_size": 128},
 )
 
 assert run.params == {
-    "model": "linear",
+    "model_family": "linear",
     "seed": 42,
     "batch_size": 128,
 }
@@ -89,7 +89,8 @@ metadata = {
 from hypster import instantiate
 
 replayed = instantiate(training_config, values=run.params)
-assert replayed == run.value
+assert replayed.model_family == run.value.model_family
+assert replayed.batch_size == run.value.batch_size
 ```
 {% endcode %}
 

--- a/docs/reproducibility/observing-past-runs.md
+++ b/docs/reproducibility/observing-past-runs.md
@@ -7,16 +7,25 @@ When a past run stores Hypster params, you can inspect what those params mean ag
 {% code overflow="wrap" %}
 ```python
 from hypster import HP, explore
+from sklearn.base import ClassifierMixin
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
 
-def config(hp: HP):
-    model = hp.select(["linear", "forest"], name="model", default="linear", options_only=True)
+def linear_model(hp: HP) -> LogisticRegression:
+    C = hp.float(1.0, name="C", min=1e-4, max=100.0)
+    return LogisticRegression(C=C, max_iter=1000)
 
-    if model == "forest":
-        return {"model": model, "n_estimators": hp.int(200, name="n_estimators", min=10)}
+def forest_model(hp: HP) -> RandomForestClassifier:
+    n_estimators = hp.int(200, name="n_estimators", min=10)
+    return RandomForestClassifier(n_estimators=n_estimators, random_state=42)
 
-    return {"model": model, "alpha": hp.float(0.1, name="alpha", min=0.0, max=10.0)}
+model_options = {"linear": linear_model, "forest": forest_model}
 
-past_params = {"model": "forest", "n_estimators": 500}
+def config(hp: HP) -> ClassifierMixin:
+    selected_config = hp.select(model_options, name="model_family", default="linear", options_only=True)
+    return hp.nest(selected_config, name="model")
+
+past_params = {"model_family": "forest", "model.n_estimators": 500}
 
 explore(config, values=past_params)
 ```
@@ -30,7 +39,7 @@ Use `on_unknown="warn"` when reviewing old payloads that may include stale field
 
 {% code overflow="wrap" %}
 ```python
-explore(config, values={"model": "linear", "n_estimators": 500}, on_unknown="warn")
+explore(config, values={"model_family": "linear", "model.n_estimators": 500}, on_unknown="warn")
 ```
 {% endcode %}
 

--- a/docs/reproducibility/serialization.md
+++ b/docs/reproducibility/serialization.md
@@ -91,6 +91,10 @@ The versioned artifact still protects you when defaults change, because replay u
 
 {% code overflow="wrap" %}
 ```python
+import json
+import hypster
+from hypster import HP, instantiate, instantiate_with_params
+
 def training_config(hp: HP) -> int:
     return hp.int(64, name="batch_size")
 

--- a/docs/reproducibility/serialization.md
+++ b/docs/reproducibility/serialization.md
@@ -8,18 +8,18 @@ Hypster does not define a custom serialization format. The recommended reproduci
 ```python
 import json
 from hypster import HP, explore, instantiate, instantiate_with_params
+from my_app.llms import LLMClient
 
-def config(hp: HP):
-    return {
-        "provider": hp.select(["openai", "gemini"], name="provider", default="openai", options_only=True),
-        "temperature": hp.float(0.2, name="temperature", min=0.0, max=2.0),
-    }
+def config(hp: HP) -> LLMClient:
+    provider = hp.select(["openai", "gemini"], name="provider", default="openai", options_only=True)
+    temperature = hp.float(0.2, name="temperature", min=0.0, max=2.0)
+    return LLMClient(provider=provider, temperature=temperature)
 
 run = instantiate_with_params(config, values={"provider": "gemini"})
 payload = json.dumps(run.params, sort_keys=True)
 restored = json.loads(payload)
 
-assert instantiate(config, values=restored) == run.value
+assert instantiate(config, values=restored).provider == run.value.provider
 ```
 {% endcode %}
 
@@ -29,19 +29,20 @@ Use dict-backed `select` so the serialized params contain simple keys:
 
 {% code overflow="wrap" %}
 ```python
+from my_app.models import LargeMLP, SmallMLP
+
+model_options = {
+    "small": SmallMLP,
+    "large": LargeMLP,
+}
+
 def model_config(hp: HP):
-    return hp.select(
-        {
-            "small": {"layers": 2, "units": [64, 32]},
-            "large": {"layers": 4, "units": [256, 128]},
-        },
-        name="model",
-        default="small",
-    )
+    model_cls = hp.select(model_options, name="model", default="small", options_only=True)
+    return model_cls()
 ```
 {% endcode %}
 
-`instantiate_with_params(model_config, values={"model": "large"}).params` records `{"model": "large"}`, not the mapped dictionary.
+`instantiate_with_params(model_config, values={"model": "large"}).params` records `{"model": "large"}`, not the mapped class.
 
 ## Schema Serialization
 
@@ -90,8 +91,8 @@ The versioned artifact still protects you when defaults change, because replay u
 
 {% code overflow="wrap" %}
 ```python
-def training_config(hp: HP):
-    return {"batch_size": hp.int(64, name="batch_size")}
+def training_config(hp: HP) -> int:
+    return hp.int(64, name="batch_size")
 
 
 old_run = instantiate_with_params(training_config)
@@ -108,10 +109,10 @@ payload = json.dumps(artifact, sort_keys=True)
 restored = json.loads(payload)
 
 
-def training_config(hp: HP):
-    return {"batch_size": hp.int(128, name="batch_size")}
+def training_config(hp: HP) -> int:
+    return hp.int(128, name="batch_size")
 
 
-assert instantiate(training_config, values=restored["params"]) == {"batch_size": 64}
+assert instantiate(training_config, values=restored["params"]) == 64
 ```
 {% endcode %}


### PR DESCRIPTION
## Summary

This PR corrects the Hypster docs so the primary examples teach the intended runtime-object pattern instead of wrapper dataclasses or generic settings dictionaries.

It also restores the GitBook homepage to the stepper-style flow while keeping the newer release install guidance for `viz` and `optuna` extras.

## Why

The previous docs made dataclasses look like the default Hypster style. That obscured the main value of Hypster: pure-Python config functions can directly construct and return the runtime object the application will use. For swappable components, the docs now consistently show named dict-backed option maps plus `hp.nest()`.

## Before / After

Before, the homepage taught wrapper dataclasses:

```python
@dataclass
class ForestTrainingConfig:
    seed: int
    n_estimators: int
    max_depth: int | None


def train_config(hp: HP) -> ForestTrainingConfig | LinearTrainingConfig:
    model = hp.select(["linear", "forest"], name="model", default="forest")
    ...
    return ForestTrainingConfig(...)
```

After, docs show runtime-object configs and dict-backed nested composition:

```python
model_options = {
    "linear": logistic_model,
    "forest": forest_model,
}


def model_config(hp: HP) -> ClassifierMixin:
    selected_config = hp.select(model_options, name="family", default="forest", options_only=True)
    return hp.nest(selected_config, name="model")
```

## What Changed

- Replaced dataclass-style examples across README and GitBook docs.
- Reworked ML, data processing, AI workflow, nesting, interactive UI, HPO, integration, and reproducibility examples around initialized runtime objects.
- Added explicit best-practice guidance for pure-Python configs, side-effect boundaries, and dict-backed selectable component maps.
- Updated the “Compose With Nesting” section to show the same logistic-regression/random-forest example as both an inline branch and the recommended nested composition pattern.
- Restored the homepage stepper structure and corrected it to return an initialized object.

## Validation

- `rg -n "dataclass|dataclasses|ForestTrainingConfig|LinearTrainingConfig|LLMSettings|ProviderConfig|CsvInput|CleaningRules|ExportConfig|PreprocessingSettings|TrainingSettings|MLExperiment|DataSettings|ModelSettings|TrainingConfig|DataLoadSettings|ModelConfig|First Example|from dataclasses" README.md docs`
- Python syntax compilation for complete Markdown `python` snippets.
- Markdown fence and local-link checker across README, CHANGELOG, and docs.
- `git diff --check`
- Pre-commit on commit: trailing whitespace, EOF, large-file checks; code-only hooks skipped because this PR is docs-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated examples across the site to return initialized runtime objects (e.g., clients, models, pipelines) instead of dicts or dataclasses.
  * Standardized nested parameter paths and composition patterns (select + nest) for swappable components, replayable overrides (e.g., model.n_estimators), and safer explore/instantiate workflows.
  * Revised quick-starts, HPO, ML, UI, and reproducibility guides to reflect these patterns and update assertions/examples accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypster/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->