### PR TITLE
[codex] Prepare v0.5.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-05-24
+
+### Changed
+- Updated release guidance to include the `viz` extra in generated GitHub releases, workflow summaries, README installation examples, and GitBook installation docs.
+- Corrected README and GitBook examples to emphasize the preferred runtime-object return pattern and dict-backed nested component selection.
+
+### Fixed
+- Updated lockfile-only vulnerable dependencies for Mako, pytest, and Pygments.
+
+### Removed
+- Removed the README production-readiness warning block.
+
 ## [0.5.2] - 2026-05-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@
   </em>
 </p>
 
-> ⚠️ Hypster is in active development and not yet battle-tested in production.
-> If you’re gaining value and want to promote it to production, please reach out!
-
 ## Key Features
 
 - 🐍 **Pure Python, Not a DSL**: Use normal functions, `if` statements, loops, lists, helper functions, imports, and runtime objects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hypster"
-version = "0.5.2"
+version = "0.5.3"
 description = "A flexible configuration system for Python projects"
 authors = [
     {name = "Gilad Rubin", email = "me@giladrubin.com"}

--- a/src/hypster/_version.py
+++ b/src/hypster/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/uv.lock
+++ b/uv.lock
@@ -388,7 +388,7 @@ wheels = [
 
 [[package]]
 name = "hypster"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump Hypster from `0.5.2` to `0.5.3` in `pyproject.toml`, `src/hypster/_version.py`, and `uv.lock`.
- Add a `0.5.3` changelog entry covering the post-`v0.5.2` PRs: #37 dependency security updates, #38 release install guidance, and #39 runtime-object docs corrections.
- Remove the README production-readiness warning block requested by the user.

## Before / After

Before:
```md
> ⚠️ Hypster is in active development and not yet battle-tested in production.
> If you’re gaining value and want to promote it to production, please reach out!
```
```toml
version = "0.5.2"
```

After:
```md
## Key Features
```
```toml
version = "0.5.3"
```

## Validation
- `uv lock --check`
- `git diff --check`
- `uv run pytest tests/test_version.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`
- `uv run pre-commit run --files CHANGELOG.md README.md pyproject.toml src/hypster/_version.py uv.lock`
- commit hook: ruff, ruff-format, trim trailing whitespace, EOF, large-file check, mypy