### PR TITLE
[codex] Remove docs preview warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated lockfile-only vulnerable dependencies for Mako, pytest, and Pygments.
 
 ### Removed
-- Removed the README production-readiness warning block.
+- Removed production-readiness warning blocks from the README and docs.
 
 ## [0.5.2] - 2026-05-24
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,12 +19,6 @@ layout:
 
 <div data-full-width="false"><figure><picture><source srcset=".gitbook/assets/hypster_text_white_text.png" media="(prefers-color-scheme: dark)"><img src=".gitbook/assets/hypster_with_text (1).png" alt=""></picture><figcaption></figcaption></figure></div>
 
-## Hypster is a lightweight configuration framework for managing and **optimizing AI & ML workflows**
-
-> Hypster is in preview and is not ready for production use.
->
-> We're working hard to make Hypster stable and feature-complete, but until then, expect to encounter bugs, missing features, and occasional breaking changes.
-
 ## Key Features
 
 * :snake: **Pure Python, Not a DSL**: Use normal functions, `if` statements, loops, helper functions, imports, and real object construction

--- a/docs/reproducibility/deploying-to-production.md
+++ b/docs/reproducibility/deploying-to-production.md
@@ -1,6 +1,6 @@
 # Deploying To Production
 
-Hypster is in preview, so production use should be deliberate. When you do deploy it, treat selected params as part of the release artifact.
+When you deploy Hypster, treat selected params as part of the release artifact.
 
 ## Recommended Pattern
 


### PR DESCRIPTION
## Summary
- Remove the GitBook homepage tagline and preview/production-readiness warning block.
- Remove the remaining preview wording from the production deployment guide.
- Update the `0.5.3` changelog entry so it covers both README and docs warning removals.

## Before / After

Before:
```md
## Hypster is a lightweight configuration framework for managing and **optimizing AI & ML workflows**

> Hypster is in preview and is not ready for production use.
>
> We're working hard to make Hypster stable and feature-complete, but until then, expect to encounter bugs, missing features, and occasional breaking changes.
```

After:
```md
## Key Features
```

## Validation
- `rg -n "Hypster is in preview|not ready for production|stable and feature-complete|expect to encounter bugs|occasional breaking changes|Hypster is a lightweight configuration framework" docs`
- `git diff --check`
- `uv run pre-commit run --files CHANGELOG.md docs/README.md docs/reproducibility/deploying-to-production.md`
- commit hook: trim trailing whitespace, EOF, large-file check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed production-readiness warning blocks from README and documentation
  * Cleaned up introductory sections to streamline content
  * Updated production deployment guidance to reflect current best practices for configuration management
  * Updated changelog to document documentation improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypster/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->