### PR TITLE
[codex] Add Hypster positioning notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,8 @@
 - When changing `[project].version` in `pyproject.toml`, update `src/hypster/_version.py` in the same change.
 - Keep `src/hypster/__init__.py` free of eager `importlib.metadata` imports; they significantly slow down `import hypster`.
 - Run `uv run pytest tests/test_version.py` after version-related changes.
+
+## Positioning And README Work
+
+- Use `dev/positioning/` as the source of raw positioning notes before changing the GitHub README, docs front page, or product messaging.
+- Keep public copy technical and concrete: lead with code and benefits, avoid salesy language, and preserve the FastAPI/FastMCP-style README shape.

--- a/README.md
+++ b/README.md
@@ -38,12 +38,10 @@
 
 ## Key Features
 
-- 🐍 **Pure Python, Not a DSL**: Use normal functions, `if` statements, loops, lists, helper functions, imports, and runtime objects
+- 🐍 **Pythonic API**: Intuitive & minimal syntax that feels natural to Python developers
 - 🪆 **Hierarchical, Conditional Configurations**: Support for nested and swappable configurations
 - 📐 **Type Safety**: Built-in type hints and validation
 - 🧪 **Hyperparameter Optimization Built-In**: Native, first-class optuna support
-
-Hypster configs are ordinary Python functions rather than a separate configuration language. That keeps them flexible and readable, but it also means Hypster discovers the available parameters by executing the function. A config usually returns the initialized object your application needs. Keep config functions fast and side-effect-free: avoid paid API calls, network calls, file writes, training, database access, and costly initialization in code paths used by `explore()`, HPO, or interactive UIs.
 
 ## Installation
 

--- a/dev/positioning/README.md
+++ b/dev/positioning/README.md
@@ -49,14 +49,11 @@ need it.
 
 ## Current Product Truths To Check Before Public Copy
 
-- The current checkout exposes `instantiate`, `explore`, `interactive_explore`,
-  and `apply_vscode_theme`.
-- `instantiate_with_params` exists on the `codex/reproducible-instantiation-params`
-  branch, not in the current `master` checkout.
-- Current docs still have placeholder pages under `docs/reproducibility/`.
-- Current docs mention that interactive UI was removed, while the current source
-  includes `interactive_explore`. Public copy should reconcile this before
-  making interactive UI a headline feature.
+- The current public API exposes `instantiate`, `instantiate_with_params`,
+  `explore`, and `interact`.
+- The notebook UI is installed with the `viz` extra: `hypster[viz]`.
+- Reproducibility docs now cover `instantiate_with_params`, serialization,
+  experiment tracking, observing past runs, and production deployment.
 - Older articles use legacy API names such as `@config`, `hp.number`, automatic
   naming, `final_vars`, `save`, and `load`. Reuse the ideas, but translate
   examples into the current API before publishing.

--- a/dev/positioning/README.md
+++ b/dev/positioning/README.md
@@ -1,0 +1,62 @@
+# Hypster Positioning Notes
+
+This folder is a raw strategy workspace for Hypster's differentiation, benefits,
+audiences, use cases, and product language.
+
+It is intentionally not a user guide. The public docs explain how to use
+Hypster. This space explains why Hypster matters, who it helps, where it fits,
+and how to talk about it without turning the README into sales copy.
+
+## Core Direction
+
+Hypster is a hierarchical, modular configuration management framework for
+Python, built for complex AI and ML workflows.
+
+Supporting version:
+
+Hypster helps you define the valid ways your system can run using plain Python
+functions, compose reusable configs for nested components, explore the active
+configuration tree, and instantiate or optimize one concrete setup when you
+need it.
+
+## Messaging Principles
+
+- Lead with a concrete developer problem, not a category phrase.
+- Explain "configuration space" only after grounding it in "valid ways your
+  system can run."
+- Use positive framing: "plain Python functions", "normal control flow",
+  "nested reusable configs", "explorable configuration tree."
+- Keep the README technical and useful. The proof should be in a tiny example,
+  then a compact benefit list.
+- Avoid positioning Hypster only as HPO. HPO is one major benefit, but the
+  bigger idea is making complex systems configurable, inspectable, reusable,
+  observable, and optimizable.
+- Treat AI agents as a real audience: a Hypster config gives an agent a bounded,
+  typed, inspectable action surface for choosing workflow variants.
+
+## Files
+
+- [benefits.md](benefits.md) - benefit inventory and payoffs.
+- [use-cases.md](use-cases.md) - product, AI/ML, RAG, agent, and platform use
+  cases.
+- [audiences.md](audiences.md) - who Hypster is for and what each group gets.
+- [reproducibility-observability.md](reproducibility-observability.md) -
+  `instantiate_with_params`, replay, and logging story.
+- [positioning-language.md](positioning-language.md) - taglines, README bullets,
+  and words to use or avoid.
+- [source-notes.md](source-notes.md) - source map from articles, current docs,
+  branches, and architecture lessons.
+
+## Current Product Truths To Check Before Public Copy
+
+- The current checkout exposes `instantiate`, `explore`, `interactive_explore`,
+  and `apply_vscode_theme`.
+- `instantiate_with_params` exists on the `codex/reproducible-instantiation-params`
+  branch, not in the current `master` checkout.
+- Current docs still have placeholder pages under `docs/reproducibility/`.
+- Current docs mention that interactive UI was removed, while the current source
+  includes `interactive_explore`. Public copy should reconcile this before
+  making interactive UI a headline feature.
+- Older articles use legacy API names such as `@config`, `hp.number`, automatic
+  naming, `final_vars`, `save`, and `load`. Reuse the ideas, but translate
+  examples into the current API before publishing.

--- a/dev/positioning/audiences.md
+++ b/dev/positioning/audiences.md
@@ -1,0 +1,150 @@
+# Audiences
+
+Hypster should feel technical, useful, and unsentimental. Different readers
+care about different benefits.
+
+## Python Developers
+
+Pain:
+
+- Configuration logic gets duplicated across files and scripts.
+- Complex branches are painful to represent in static config formats.
+- Production code and experiment code drift apart.
+- Adding a new provider/component requires touching too many places.
+
+Benefit:
+
+- Use ordinary Python functions for configuration.
+- Compose reusable configs instead of copying setup code.
+- Keep conditional logic close to the objects and workflows it configures.
+- Refactor configuration with the same tools used for code.
+
+Good copy:
+
+- "Use normal Python control flow to manage complex configuration."
+- "Define config modules once, then compose them into larger workflows."
+
+## Data Scientists
+
+Pain:
+
+- Notebooks accumulate ad hoc parameters.
+- Experiment settings are hard to replay.
+- Valuable alternatives disappear after the best run is found.
+- Manual trial-and-error slows down iteration.
+
+Benefit:
+
+- Explore options interactively.
+- Capture selected params for each run.
+- Move from a one-off notebook to a reusable configuration function.
+- Reuse the same config for manual runs and HPO.
+
+Good copy:
+
+- "Make experiments replayable without rewriting your workflow."
+- "Keep the decision space alive after a run finishes."
+
+## AI Engineers
+
+Pain:
+
+- RAG/agent systems have many moving parts.
+- Pipeline structure changes based on provider, mode, query type, cost, latency,
+  and evaluation results.
+- A single hard-coded pipeline becomes brittle quickly.
+
+Benefit:
+
+- Model a family of valid workflows.
+- Compose configs for retrievers, prompts, LLMs, embedders, vector stores, and
+  evaluators.
+- Test new combinations without rewriting core execution logic.
+- Route different requests to different valid configurations.
+
+Good copy:
+
+- "Build configurable AI systems from reusable parts."
+- "Treat your RAG pipeline as a design space, not a single hard-coded path."
+
+## ML Engineers And MLOps
+
+Pain:
+
+- HPO often focuses only on model parameters.
+- Experiment trackers receive incomplete or inconsistent config metadata.
+- Defaults are not always logged.
+- Unknown/unreachable config values can silently corrupt reproducibility.
+
+Benefit:
+
+- Optimize whole workflows, including preprocessing, retrieval, prompts, and
+  model choices.
+- Log a complete selected-params sidecar.
+- Replay the exact parameter set.
+- Fail loudly on unknown or unreachable values when strictness matters.
+
+Good copy:
+
+- "Log the concrete parameter set behind each run."
+- "Optimize workflow structure and hyperparameters from the same config."
+
+## Platform Teams
+
+Pain:
+
+- Internal users need flexibility without editing production code.
+- Multiple teams need different variants of the same workflow.
+- UI/control-plane surfaces need a reliable source of configurable options.
+
+Benefit:
+
+- Generate parameter UIs from config schemas.
+- Centralize valid options and defaults.
+- Keep custom variants bounded and inspectable.
+- Support per-request configuration in APIs.
+
+Good copy:
+
+- "Expose safe workflow variants without handing users the codebase."
+- "Use the config tree as the contract between platform and application code."
+
+## Product Teams
+
+Pain:
+
+- AI features need A/B tests, customer-specific behavior, and fast iteration.
+- Quality, latency, and cost tradeoffs change by context.
+- Product changes often force code changes in the pipeline layer.
+
+Benefit:
+
+- Define supported modes explicitly.
+- Route users or requests to different configurations.
+- Compare variants against the same evaluation harness.
+- Add new product modes as config branches.
+
+Good copy:
+
+- "Ship multiple valid modes of the same AI system."
+- "Adapt quality, latency, and cost tradeoffs by scenario."
+
+## AI Agents
+
+Pain:
+
+- Agents need to operate inside explicit boundaries.
+- Asking an agent to edit code to change behavior is risky.
+- Agents need introspection before selecting a workflow.
+
+Benefit:
+
+- The config schema becomes an action surface.
+- The agent can inspect options, defaults, and bounds.
+- The agent can select values, run, observe metrics, and replay.
+- Human developers still own the valid choices.
+
+Good copy:
+
+- "Give agents a bounded way to choose workflow variants."
+- "Let agents configure systems without rewriting them."

--- a/dev/positioning/benefits.md
+++ b/dev/positioning/benefits.md
@@ -108,8 +108,8 @@ README language:
 
 ### Reproducibility And Observability
 
-The `instantiate_with_params` branch adds a dedicated API for returning the
-normal instantiated value plus a replayable params sidecar.
+`instantiate_with_params` returns the normal instantiated value plus a replayable
+params sidecar.
 
 Payoff:
 

--- a/dev/positioning/benefits.md
+++ b/dev/positioning/benefits.md
@@ -1,0 +1,229 @@
+# Benefits
+
+This is the raw benefit inventory. Public README copy should choose only a few
+of these, then prove them with code.
+
+## Core Benefit Cluster
+
+### Define The Valid Ways A Workflow Can Run
+
+Hypster lets a developer describe not just one config, but the possible valid
+configurations of a system: choices, defaults, bounds, branches, nested
+components, and dependencies between those choices.
+
+Payoff:
+
+- The codebase remembers alternatives instead of deleting them after each
+  experiment.
+- Teams can revisit old choices when models, data, costs, latency, or product
+  requirements change.
+- Experimentation becomes systematic instead of a chain of manual edits.
+
+README language:
+
+- Define the valid ways your workflow can run using simple Python functions.
+- Turn hard-coded pipeline choices into an explorable set of valid
+  configurations.
+
+### Hierarchical And Modular Configuration Management
+
+Hypster is strongest when a system has parts: LLMs, embedders, retrievers,
+rerankers, prompts, vector stores, evaluation judges, deployment modes, or
+sub-pipelines.
+
+Payoff:
+
+- Small configs can be reused inside larger parent configs.
+- Nested config paths mirror the architecture of the system.
+- Component choices can be swapped without rewriting the whole pipeline.
+- A parent config can pass values into child configs when dependencies exist.
+
+README language:
+
+- Compose nested configs for models, prompts, retrievers, environments, and app
+  modes.
+- Reuse configuration modules across workflows instead of duplicating setup code.
+
+### Plain Python Authoring
+
+Hypster configuration functions are ordinary Python functions. This matters
+because real AI systems need conditionals, loops, imports, classes, registries,
+and direct object construction.
+
+Payoff:
+
+- Developers can use normal control flow for branch-specific parameters.
+- Complex objects can be created directly where their configuration lives.
+- A config can evolve with the codebase instead of becoming an awkward parallel
+  representation.
+- IDEs, type hints, refactors, tests, and code review still work naturally.
+
+README language:
+
+- Use normal Python control flow to describe conditional configuration.
+- Build real objects, graphs, and workflows from the selected values.
+
+### Configuration And Execution Stay Decoupled
+
+Hypster works well beside graph, DAG, pipeline, or workflow execution systems.
+The config function chooses the concrete components, parameters, branches, and
+dependencies; the execution framework runs the selected workflow.
+
+Payoff:
+
+- The same execution graph can be instantiated with different components or
+  values.
+- Pipeline structure can be selected by configuration without scattering branch
+  logic through runtime code.
+- Config functions can act as factories for objects, subgraphs, clients, prompts,
+  and other dependencies.
+- The configuration tree can mirror the workflow architecture without becoming
+  the execution engine itself.
+
+README language:
+
+- Configure the family of possible workflows, then run the selected workflow in
+  your execution layer.
+- Use Hypster as the configuration layer for graph, DAG, pipeline, and agent
+  workflows.
+
+### Explore Before You Run
+
+Hypster can show the active parameter tree before a concrete run. This includes
+reachable branches, defaults, options, bounds, and nested scopes.
+
+Payoff:
+
+- Developers understand which knobs exist for a branch before executing it.
+- Users can inspect configs from CLI, notebook UI, or future app/control-plane
+  surfaces.
+- AI agents can inspect a bounded action surface before selecting values.
+- Unknown or unreachable overrides become easier to catch.
+
+README language:
+
+- Explore active branches, defaults, bounds, and options before you instantiate
+  anything.
+- Make complex configuration inspectable for people, tools, and agents.
+
+### Reproducibility And Observability
+
+The `instantiate_with_params` branch adds a dedicated API for returning the
+normal instantiated value plus a replayable params sidecar.
+
+Payoff:
+
+- Log the exact selected values for MLflow, W&B, Langfuse, or similar tools.
+- Include defaults that were not explicitly overridden by the user.
+- Replay the run by passing the recorded params back into `instantiate`.
+- Treat config values as first-class experiment metadata, not incidental logs.
+
+README language:
+
+- Capture the selected parameters behind each run for replay and observability.
+- Log concrete run configuration to MLflow, W&B, Langfuse, or your own tracing
+  stack.
+
+### Hyperparameter Optimization
+
+Hypster's define-by-run style fits conditional and hierarchical HPO. Only the
+active branch exposes the parameters that should be suggested.
+
+Payoff:
+
+- Optimize across workflow structure, component choice, and numeric values.
+- Avoid flattening a complex system into a brittle parameter table.
+- Tune complete pipelines, not just model hyperparameters.
+- Reuse the same config function for manual runs and automated search.
+
+README language:
+
+- Reuse the same config for manual runs, notebooks, experiments, and HPO.
+- Optimize component choices and hyperparameters across nested workflows.
+
+### Reduced Duplication And Drift
+
+Complex AI projects often duplicate configuration across notebooks, scripts,
+YAML files, CLI args, production code, and experiment trackers.
+
+Payoff:
+
+- One source of truth for defaults, options, and valid branches.
+- Less copy-paste between local experiments and production runs.
+- Fewer "magic numbers" hidden in pipeline construction.
+- Cleaner code review because config decisions are explicit.
+
+README language:
+
+- Keep complex AI applications configurable without duplicating logic across
+  files and scripts.
+
+### Knowledge Accumulation
+
+The "100s of pipelines" article frames the core pain well: teams often preserve
+only the final pipeline, losing the ideas tested along the way.
+
+Payoff:
+
+- Tested alternatives remain represented as choices in the config system.
+- Future experiments can recombine known-good components.
+- Teams can answer "how did we arrive here?" with a configuration trail.
+- Changing requirements no longer require restarting the exploration process
+  from scratch.
+
+README language:
+
+- Preserve the decision space behind your pipeline, not just the latest
+  hard-coded version.
+
+### Future-Proofing
+
+AI systems change constantly: models improve, APIs shift, data changes, costs
+move, latency targets tighten, evaluation sets grow, and product needs split by
+segment.
+
+Payoff:
+
+- Add a new model/provider/component as another valid option.
+- Re-evaluate combinations when requirements change.
+- Keep the system adaptable without reworking the core execution logic.
+
+README language:
+
+- Add new components and re-evaluate old decisions as your AI stack changes.
+
+### Interactive Configuration
+
+Interactive exploration matters because configuration is often a product-facing
+or research-facing activity, not just a developer-only activity.
+
+Payoff:
+
+- Notebook users can tune a branch visually.
+- Non-core contributors can see available options and relationships.
+- Future UI/control-plane work can be generated from the config schema.
+- Conditional branches can appear and disappear as selections change.
+
+README language:
+
+- Explore and instantiate configs interactively when notebooks or review tools
+  are the right surface.
+
+### Agent-Ready Configuration
+
+AI agents need bounded, inspectable, safe-ish action surfaces. Hypster configs
+can expose the legal variants of a workflow without asking the agent to rewrite
+code.
+
+Payoff:
+
+- Agents can inspect available parameters and options.
+- Agents can choose a configuration for a task, user, dataset, budget, or risk
+  level.
+- Agents can run experiments by varying values inside an explicit boundary.
+- Agents can produce replayable params for follow-up runs.
+
+README language:
+
+- Give agents a typed, inspectable way to choose workflow variants without
+  editing pipeline code.

--- a/dev/positioning/positioning-language.md
+++ b/dev/positioning/positioning-language.md
@@ -1,0 +1,142 @@
+# Positioning Language
+
+This file is a scratchpad for public copy.
+
+## Favorite Core Sentence
+
+Hypster is a hierarchical, modular configuration management framework for
+Python, built for complex AI and ML workflows.
+
+## Slightly Warmer Version
+
+Hypster helps you manage complex AI and ML configuration with plain Python
+functions, nested reusable configs, branch-aware exploration, and
+optimization-ready parameters.
+
+## README Opening Candidate
+
+Hypster is a hierarchical, modular configuration management framework for
+Python, built for complex AI and ML workflows. Define the valid ways your system
+can run using plain Python functions, compose reusable configs for nested
+components, explore the active configuration tree, and instantiate or optimize
+one concrete setup when you need it.
+
+## First Benefit Bullets
+
+- Define the valid ways your workflow can run using simple Python functions.
+- Compose nested configs for models, prompts, retrievers, environments, and app
+  modes.
+- Explore active branches, defaults, bounds, and options before you instantiate
+  anything.
+- Reuse the same config for manual runs, notebooks, experiments, and HPO.
+- Capture selected params for replay, observability, and experiment tracking.
+- Keep complex AI applications configurable without duplicating logic across
+  files and scripts.
+
+## Tagline Options
+
+- Hierarchical configuration management for complex AI workflows.
+- Modular configuration management in plain Python.
+- Define, explore, compose, and optimize AI workflow configurations.
+- Build configurable AI systems from reusable Python configs.
+- Turn one hard-coded AI pipeline into a family of valid workflows.
+- Configuration management for AI systems that keep changing.
+- Pythonic configuration for nested, conditional AI workflows.
+
+## Plain Explanations For "Configuration Space"
+
+Use "configuration space" after one of these:
+
+- the valid ways your system can run,
+- the set of supported workflow variants,
+- the family of possible pipelines,
+- the choices, defaults, bounds, branches, and nested components your workflow
+  supports.
+
+Good sentence:
+
+Hypster lets you define the valid ways your system can run. That definition is
+your configuration space: the choices, defaults, bounds, branches, and nested
+components that can produce a concrete workflow.
+
+## Words That Feel Right
+
+- hierarchical,
+- modular,
+- nested,
+- composable,
+- branch-aware,
+- explore,
+- instantiate,
+- selected params,
+- replayable,
+- valid configurations,
+- concrete workflow,
+- Python functions,
+- normal Python control flow,
+- configurable systems,
+- workflow variants,
+- reusable components,
+- decision space.
+
+## Words To Use Carefully
+
+- configuration space: good, but explain it.
+- framework: okay, but pair it with concrete benefits.
+- HPO: useful but too narrow as the headline.
+- hyper-workflow: interesting for philosophy pages, probably too abstract for
+  first README line.
+- superposition: fun in articles, probably not README-first.
+- no-code: possible platform angle, not the core dev README message.
+
+## Phrases To Avoid
+
+- "Not a DSL" or other negative framing.
+- "Magic" without showing the mechanism.
+- "Simple" without acknowledging real AI systems are complex.
+- "Just YAML but better."
+- "Best configuration framework" style claims.
+
+## Positive Differentiation
+
+Instead of saying:
+
+- "Unlike YAML..."
+
+Say:
+
+- "Use Python control flow for branch-specific configuration."
+- "Build real objects and workflows directly from selected values."
+- "Compose child configs under parent configs using dotted paths."
+
+Instead of saying:
+
+- "Unlike HPO tools..."
+
+Say:
+
+- "Use the same config for manual runs and automated optimization."
+- "Tune workflow structure and parameter values together."
+
+Instead of saying:
+
+- "Unlike experiment trackers..."
+
+Say:
+
+- "Emit replayable selected params for your experiment tracker."
+- "Attach complete config metadata to metrics, traces, and artifacts."
+
+## Short README Section Sketch
+
+```md
+## Why Hypster?
+
+Real AI systems rarely have one stable configuration. They have model choices,
+provider choices, retrieval modes, prompt variants, evaluation settings,
+environment modes, and product-specific branches.
+
+Hypster lets those choices live in Python as a reusable, inspectable
+configuration tree. Explore the tree, instantiate one concrete setup, log the
+selected params, or hand the same config to an HPO backend.
+```

--- a/dev/positioning/reproducibility-observability.md
+++ b/dev/positioning/reproducibility-observability.md
@@ -1,0 +1,109 @@
+# Reproducibility And Observability
+
+This is the positioning story around `instantiate_with_params`, experiment
+tracking, and replay.
+
+## Current Status
+
+`instantiate_with_params` exists on the `codex/reproducible-instantiation-params`
+branch, not in the current `master` checkout I inspected.
+
+On that branch:
+
+- `instantiate_with_params(func, values=...)` returns an `InstantiationOutput`.
+- `InstantiationOutput.value` is the same runtime value the normal config would
+  return.
+- `InstantiationOutput.params` is a dictionary of selected parameter values.
+- `params` includes reachable defaults, not only user-provided overrides.
+- Passing `run.params` back into `instantiate(func, values=run.params)` replays
+  the same selected configuration.
+- Unknown/unreachable values raise by default on that branch, because `values`
+  is treated as a reproducibility surface.
+
+## Why This Matters
+
+Most observability and experiment tools want key-value metadata:
+
+- MLflow params.
+- W&B config.
+- Langfuse trace/session metadata.
+- OpenTelemetry span attributes.
+- Custom run records in a database.
+
+Hypster can produce those values from the same config function that builds the
+runtime object or workflow.
+
+## User Benefit
+
+Without this:
+
+- A run might log only explicit overrides.
+- Defaults can be lost.
+- Branch-specific values can be forgotten.
+- A logged run may be hard to replay.
+- Unknown values may be silently accepted by a wrapper layer.
+
+With this:
+
+- Every reached `hp.*` parameter can be logged.
+- The logged params are replayable.
+- Defaults become observable.
+- Config metadata is attached to metrics, traces, artifacts, and evaluation
+  records.
+- Strict unknown-value handling protects logged runs from accidental typos or
+  stale branch params.
+
+## Suggested Language
+
+README bullet:
+
+- Capture a replayable params record for each run, including defaults, for
+  MLflow, W&B, Langfuse, or your own observability stack.
+
+Short section:
+
+Hypster can return a selected-params sidecar when you instantiate a config. Log
+that sidecar with your experiment tracker, attach it to traces, or pass it back
+into `instantiate()` to replay the same configuration later.
+
+More technical but still positioning:
+
+`instantiate_with_params()` turns configuration into structured run metadata:
+the concrete value your application needs plus the selected parameter dictionary
+your observability stack needs.
+
+## Example Shape
+
+This is intentionally illustrative. Public docs should update it to the current
+API before publishing.
+
+```python
+run = instantiate_with_params(rag_config, values={
+    "retrieval.top_k_pages": 50,
+    "generation.llm.model": "gpt-5.2",
+})
+
+graph = run.value
+params = run.params
+
+mlflow.log_params(params)
+```
+
+## Observability Integrations To Mention
+
+- MLflow: experiment params, metrics, artifacts, traces.
+- W&B: run config and sweeps.
+- Langfuse: trace/session metadata for LLM workflows.
+- OpenTelemetry: span attributes for config-relevant execution.
+- Custom data warehouse: store params beside evaluation outcomes.
+
+## Product Framing
+
+Reproducibility is not only "save config to disk." For Hypster, it means:
+
+- the active branch is known,
+- every reached parameter has a selected value,
+- defaults are captured,
+- unknown values are rejected when strictness matters,
+- the run can be replayed,
+- the configuration can be compared against other runs.

--- a/dev/positioning/reproducibility-observability.md
+++ b/dev/positioning/reproducibility-observability.md
@@ -5,11 +5,6 @@ tracking, and replay.
 
 ## Current Status
 
-`instantiate_with_params` exists on the `codex/reproducible-instantiation-params`
-branch, not in the current `master` checkout I inspected.
-
-On that branch:
-
 - `instantiate_with_params(func, values=...)` returns an `InstantiationOutput`.
 - `InstantiationOutput.value` is the same runtime value the normal config would
   return.
@@ -73,9 +68,6 @@ the concrete value your application needs plus the selected parameter dictionary
 your observability stack needs.
 
 ## Example Shape
-
-This is intentionally illustrative. Public docs should update it to the current
-API before publishing.
 
 ```python
 run = instantiate_with_params(rag_config, values={

--- a/dev/positioning/source-notes.md
+++ b/dev/positioning/source-notes.md
@@ -1,0 +1,164 @@
+# Source Notes
+
+This file maps positioning ideas back to sources.
+
+## Current Hypster Docs
+
+Local paths inspected:
+
+- `README.md`
+- `docs/README.md`
+- `docs/SUMMARY.md`
+- `docs/getting-started/defining-a-configuration-space.md`
+- `docs/getting-started/exploring-a-configuration-space.md`
+- `docs/getting-started/interactive-instantiation-ui.md`
+- `docs/in-depth/nest.md`
+- `docs/in-depth/basic-best-practices.md`
+- `docs/in-depth/performing-hyperparameter-optimization.md`
+- placeholder reproducibility pages under `docs/reproducibility/`
+
+Extracted ideas:
+
+- Hypster is currently described as a lightweight config framework for AI/ML.
+- Strong docs concepts: config functions, `explore`, `instantiate`, nested
+  configs, values/overrides, HPO, Pythonic best practices.
+- Current docs already support "regular Python function" language.
+- `explore` is a major differentiator because it prints and returns structured
+  parameter metadata.
+- `hp.nest` is central to the hierarchical/modular story.
+
+Open issues before public positioning:
+
+- Reproducibility pages are placeholders.
+- Interactive docs say the UI was removed, but source/tests include
+  `interactive_explore`.
+- Some philosophy pages are placeholders.
+
+## "Introducing HyPSTER" Article
+
+URL:
+
+https://medium.com/@giladrubin/introducing-hypster-a-pythonic-framework-for-managing-configurations-to-build-highly-optimized-ai-5ee004dbd6a5
+
+Extracted ideas:
+
+- AI workflows balance speed, cost, and performance.
+- Projects need multiple modes: dev/prod, local/remote, different workflow
+  types, and specialized sub-workflows.
+- Hypster is for managing those modes while optimizing each context.
+- Benefits include swappable/hierarchical configurations, Pythonic authoring,
+  nested/conditional logic, DRY config design, UI-centric exploration, and HPO.
+- The article emphasizes the "superposition" idea: one function defines many
+  possible concrete configurations.
+
+Legacy API notes:
+
+- Uses `@config`, `hp.number`, automatic naming, `final_vars`, `save`, and
+  `load`, which should not be copied directly into current public docs without
+  updating.
+
+## "Don't Build One AI Pipeline. Build 100s Instead."
+
+URL:
+
+https://pub.towardsai.net/dont-build-one-ai-pipeline-build-100s-instead-9c905569e9d6
+
+Extracted ideas:
+
+- A single hard-coded AI pipeline causes rigidity, slow iteration, lost
+  knowledge, unintentional overfitting, and missed configurations.
+- Version control and experiment tracking often preserve only tested snapshots,
+  not the broader space of valid alternatives.
+- The proposed shift is from one pipeline to a space of potential pipelines.
+- Configuration functions contain hyperparameters, conditional dependencies,
+  and hierarchical/swappable configurations.
+- Benefits: improved code quality, knowledge accumulation, manageable nested
+  configurations, accelerated development, optimized pipelines, flexibility, and
+  future-proofing.
+- Strong positioning phrase to adapt: creation of a pipeline is driven by
+  configuration, not hard-coded logic.
+
+Public copy translation:
+
+- "Turn a hard-coded pipeline into a family of valid workflows."
+- "Keep alternatives alive as configurable choices."
+- "Optimize whole workflow structure, not just model hyperparameters."
+
+## "Implementing Modular RAG With Haystack And Hypster"
+
+URL:
+
+https://medium.com/data-science/implementing-modular-rag-with-haystack-and-hypster-d2f0ecc88b8f
+
+Extracted ideas:
+
+- Modular RAG is a natural showcase because different modules can be swapped,
+  nested, and connected conditionally.
+- Hypster config can alter pipeline topology: enrichment on/off, retriever
+  choices, reranker branches, provider choices, and nested LLM configs.
+- Dot notation makes nested overrides understandable.
+- The article frames this as building a codebase that accommodates multiple
+  potential workflows.
+- Benefits named: HPO, diverse scenario-specific configs, agentic tool use, and
+  production A/B testing.
+
+Public copy translation:
+
+- "RAG is not one pipeline; it is a family of valid retrieval/generation
+  workflows."
+- "Use nested configs for indexing, retrieval, generation, and evaluation."
+- "Let query type, customer segment, or product mode choose a concrete workflow."
+
+## Reproducible Instantiation Branch
+
+Branch inspected:
+
+- `codex/reproducible-instantiation-params`
+
+Files inspected via `git show`/`git grep`:
+
+- `src/hypster/core.py`
+- `src/hypster/__init__.py`
+- `docs/getting-started/instantiating-a-configuration-space.md`
+- `docs/adr/0001-strict-unknown-values.md`
+- `tests/test_instantiate_with_params.py`
+
+Extracted ideas:
+
+- `instantiate_with_params` returns `InstantiationOutput(value, params)`.
+- `params` contains selected reachable params, including defaults.
+- `params` can replay the run via `instantiate(..., values=run.params)`.
+- Strict unknown handling is part of reproducibility because stale or unreachable
+  values should not be silently logged.
+- This API is ideal for MLflow, W&B, Langfuse, OpenTelemetry, or custom
+  observability metadata.
+
+Public copy caveat:
+
+- Do not put this in public README as current API until the branch lands on the
+  release branch.
+
+## Architecture Learning: Hypster Plus Execution Graphs
+
+Extracted ideas:
+
+- Hypster is strongest as the configuration layer beside a graph, DAG, pipeline,
+  or workflow execution layer.
+- Parent workflow configs can nest child workflow configs.
+- Config choices can bind dependencies into graph nodes.
+- Config values can select optional nodes, graph branches, providers, prompts,
+  and runtime components.
+- Config functions can act as factories for components and subgraphs.
+- Introspection can power CLI, notebook, or UI surfaces that show configurable
+  parameters before a workflow is run.
+- Evaluation and observability can be branch-specific workflow behavior, not
+  separate duplicated pipelines.
+
+Public copy translation:
+
+- "Hypster configures the family of possible workflows; your execution layer
+  runs the selected workflow."
+- "Use config functions as factories for components, dependencies, and
+  sub-workflows."
+- "Let the configuration tree mirror your workflow architecture."
+- "Keep configuration selection separate from runtime execution."

--- a/dev/positioning/source-notes.md
+++ b/dev/positioning/source-notes.md
@@ -15,7 +15,7 @@ Local paths inspected:
 - `docs/in-depth/nest.md`
 - `docs/in-depth/basic-best-practices.md`
 - `docs/in-depth/performing-hyperparameter-optimization.md`
-- placeholder reproducibility pages under `docs/reproducibility/`
+- reproducibility pages under `docs/reproducibility/`
 
 Extracted ideas:
 
@@ -29,10 +29,7 @@ Extracted ideas:
 
 Open issues before public positioning:
 
-- Reproducibility pages are placeholders.
-- Interactive docs say the UI was removed, but source/tests include
-  `interactive_explore`.
-- Some philosophy pages are placeholders.
+- Some philosophy pages may still need deeper narrative polish.
 
 ## "Introducing HyPSTER" Article
 
@@ -109,13 +106,7 @@ Public copy translation:
 - "Use nested configs for indexing, retrieval, generation, and evaluation."
 - "Let query type, customer segment, or product mode choose a concrete workflow."
 
-## Reproducible Instantiation Branch
-
-Branch inspected:
-
-- `codex/reproducible-instantiation-params`
-
-Files inspected via `git show`/`git grep`:
+## Reproducible Instantiation
 
 - `src/hypster/core.py`
 - `src/hypster/__init__.py`
@@ -132,11 +123,6 @@ Extracted ideas:
   values should not be silently logged.
 - This API is ideal for MLflow, W&B, Langfuse, OpenTelemetry, or custom
   observability metadata.
-
-Public copy caveat:
-
-- Do not put this in public README as current API until the branch lands on the
-  release branch.
 
 ## Architecture Learning: Hypster Plus Execution Graphs
 

--- a/dev/positioning/use-cases.md
+++ b/dev/positioning/use-cases.md
@@ -1,0 +1,196 @@
+# Use Cases
+
+This page collects use cases and scenarios. It is intentionally broad and raw.
+
+## AI And ML Workflow Modes
+
+- Development vs production.
+- Local vs remote.
+- Fast/cheap vs accurate/expensive.
+- Test data vs real data.
+- Mock components vs live services.
+- Offline evaluation vs online serving.
+- Batch evaluation vs single request execution.
+- Different country, customer, tenant, population, or domain variants.
+
+Hypster angle:
+
+Use one config function to expose modes and branch-specific values, then
+instantiate the concrete mode needed for a run.
+
+## RAG Systems
+
+Good fit because RAG has many naturally configurable parts:
+
+- Ingestion/conversion provider.
+- Chunking strategy and chunk size.
+- Embedding provider/model.
+- Vector database or document store.
+- Retriever type: dense, sparse, hybrid, semantic.
+- Join strategy and weighting.
+- Reranker on/off and reranker provider.
+- Prompt template and prompt building mode.
+- Generation model, temperature, reasoning effort, max tokens.
+- Diagram/image handling.
+- Citation mode.
+
+Hypster angle:
+
+Represent the RAG system as a family of valid pipelines rather than one
+hard-coded pipeline. Use nested configs for indexing, retrieval, generation,
+validation, and evaluation.
+
+## Modular RAG
+
+From the Modular RAG article:
+
+- Build indexing, retrieval, and generation as separate configurable modules.
+- Use nesting to compose them into a parent RAG config.
+- Allow a parent config to pass dependent values into child configs, such as an
+  embedding dimension or diagram mode.
+- Use config values to change pipeline topology, not only scalar parameters.
+
+Hypster angle:
+
+RAG is not one pipeline. It is a design space of valid pipelines, and Hypster
+lets that design space live in Python.
+
+## Graph And Pipeline Execution
+
+Use cases:
+
+- Build a workflow graph from selected config values.
+- Bind configured dependencies into nodes.
+- Nest sub-workflow configs under parent workflow configs.
+- Select optional nodes or branches based on config values.
+- Reuse one graph definition with many valid component combinations.
+- Keep graph execution separate from configuration selection.
+
+Hypster angle:
+
+Hypster is the configuration layer, not the execution layer. It chooses the
+concrete graph, components, and bound dependencies; a graph, DAG, pipeline, or
+agent runtime executes the selected workflow.
+
+## Hyperparameter Optimization
+
+Use cases:
+
+- Model selection.
+- Retrieval top-k values.
+- Chunk size and overlap.
+- Reranking provider and model.
+- Prompt template variants.
+- LLM temperature, max tokens, and reasoning effort.
+- Evaluation judge settings.
+- End-to-end pipeline choices where structure and numeric values interact.
+
+Hypster angle:
+
+Use one config function for manual instantiation and automatic search. The
+config's branch logic determines which parameters exist for a trial.
+
+## Experiment Tracking And Observability
+
+Use cases:
+
+- Log selected params to MLflow/W&B/Langfuse.
+- Replay a run using recorded params.
+- Store defaults as well as explicit overrides.
+- Link evaluation metrics and traces to the configuration that produced them.
+- Compare branches across evaluation runs.
+
+Hypster angle:
+
+`instantiate_with_params` can produce a replayable params sidecar for the
+observability layer, while returning the same runtime value the app needs.
+
+## Production A/B Testing
+
+Use cases:
+
+- Route a percentage of traffic to different model providers.
+- Run different retrieval strategies for different query types.
+- Assign high-recall/high-cost configs to enterprise users and cheaper configs
+  to low-risk paths.
+- Test prompt variants per request.
+- Switch between multimodal and text-only generation.
+
+Hypster angle:
+
+An API request can specify a config, or a router can choose one. The same
+execution code receives a concrete workflow.
+
+## Evaluation Pipelines
+
+Use cases:
+
+- Retrieval recall evaluation.
+- LLM-as-judge generation scoring.
+- Batch evaluation over query sets.
+- Holdout/validation split selection.
+- Optional MLflow logging.
+- Optional artifact construction and image extraction.
+- Prompt improvement loops.
+
+Hypster angle:
+
+Evaluation is itself a configurable workflow. Optional logging and artifacts can
+be branch-specific nodes, not separate duplicated pipelines.
+
+## Developer Tools And CLIs
+
+Use cases:
+
+- `params` command that lists configurable values.
+- `run` command that accepts overrides.
+- `info` command that instantiates a graph and reports inputs/outputs.
+- Local exploration of conditional branches.
+
+Hypster angle:
+
+The config function becomes the source for both runtime construction and tool
+introspection.
+
+## Notebook Workflows
+
+Use cases:
+
+- Data scientists select models, retrieval options, and evaluation settings
+  interactively.
+- Branch-specific widgets appear only when relevant.
+- Results update as parameter values change.
+
+Hypster angle:
+
+Interactive configuration is the natural bridge between Python code and
+exploratory model/system work.
+
+## AI Agent Tool Use
+
+Use cases:
+
+- Agent chooses a RAG variant for a query.
+- Agent selects cheap vs accurate mode based on budget.
+- Agent runs a batch experiment overnight.
+- Agent inspects schema before deciding values.
+- Agent logs params and metrics for follow-up reasoning.
+
+Hypster angle:
+
+Expose workflow variants as a typed, inspectable parameter tree rather than
+asking the agent to modify code or invent JSON from memory.
+
+## No-Code Or Low-Code Control Planes
+
+Use cases:
+
+- Build a UI from config schema.
+- Let operators choose workflow settings safely.
+- Clone/import/export project configurations.
+- Compare configurations side by side.
+- Restrict available options by tenant or role.
+
+Hypster angle:
+
+Hypster can be the Python-side source of truth underneath a UI or control plane.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,15 +19,15 @@ layout:
 
 <div data-full-width="false"><figure><picture><source srcset=".gitbook/assets/hypster_text_white_text.png" media="(prefers-color-scheme: dark)"><img src=".gitbook/assets/hypster_with_text (1).png" alt=""></picture><figcaption></figcaption></figure></div>
 
+### Hypster is a lightweight configuration framework for managing and **optimizing AI & ML workflows**
+
 ## Key Features
 
-* :snake: **Pure Python, Not a DSL**: Use normal functions, `if` statements, loops, helper functions, imports, and real object construction
-* :nesting\_dolls: **Hierarchical, Conditional Configurations**: Support for nested and swappable runtime components
+* :snake: **Pythonic API**: Intuitive & minimal syntax that feels natural to Python developers
+* :nesting\_dolls: **Hierarchical, Conditional Configurations**: Support for nested and swappable configurations
 * :triangular\_ruler: **Type Safety**: Built-in type hints and validation
 * :mag: **Schema Exploration**: Inspect parameters, defaults, and active branches with `explore()`
 * :test_tube: **Hyperparameter Optimization Built-In**: Native, first-class optuna support
-
-Hypster configs are ordinary Python functions rather than a separate configuration language. That keeps them flexible and readable, but it also means Hypster discovers the available parameters by executing the function. Keep config functions fast and side-effect-free: avoid paid API calls, network calls, file writes, training, database access, and costly initialization in code paths used by `explore()`, HPO, or interactive UIs.
 
 > Show your support by giving us a [star](https://github.com/gilad-rubin/hypster)! ⭐
 


### PR DESCRIPTION
## Summary

- Add `dev/positioning/` as a raw workspace for Hypster benefits, audiences, use cases, README language, and source notes.
- Add an `AGENTS.md` pointer so future agents check the positioning notes before changing README/docs messaging.
- Update the positioning notes to match current `master` APIs like `interact`, `instantiate_with_params`, and `hypster[viz]`.

## Before / After

Before, agents only had version-handling guidance:

```md
## Version Handling
- `hypster.__version__` is intentionally defined in `src/hypster/_version.py` ...
```

After, README/docs messaging has a local source of truth:

```md
## Positioning And README Work
- Use `dev/positioning/` as the source of raw positioning notes before changing the GitHub README, docs front page, or product messaging.
```

## Validation

- Pre-commit hooks passed during commit: trailing whitespace, end-of-file fixer, YAML check, large-file check.
- No runtime tests run; docs/positioning-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added internal positioning and strategy docs covering audiences, benefits, use cases, reproducibility/observability, positioning language, source notes, and a product-truths checklist to align messaging.
  * Updated public README and docs README to refine the "Key Features" wording (now emphasizing a "Pythonic API" and clarifying feature bullets).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypster/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->