### PR TITLE
[codex] Simplify execution arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-06-04
+
+### Breaking Changes
+- Replaced public `args=` and `kwargs=` forwarding with direct keyword execution arguments across `instantiate`, `instantiate_with_params`, `explore`, `interact`, `hp.nest`, and Optuna `suggest_values`.
+- Renamed `explore(return_info=True)` to `explore(return_schema=True)`.
+- Changed Optuna `suggest_values` to take the config function positionally: `suggest_values(trial, config, **kwargs)`.
+
+### Added
+- Documented **Execution Arguments** as keyword-only dependencies forwarded into configuration functions without being included in selected params.
+- Added an ADR for the direct keyword execution-arguments API decision.
+
 ## [0.5.3] - 2026-05-24
 
 ### Changed

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,10 @@ Hypster is a Python configuration context for defining parameterized config func
 A Python function that receives `hp` and returns the configured object or data for a run.
 _Avoid_: config space when referring to the executable function itself
 
+**Execution Arguments**:
+Ordinary keyword arguments forwarded into a **Configuration Function** during execution.
+_Avoid_: values, selected params
+
 **Values**:
 User-provided parameter overrides passed into a configuration function.
 _Avoid_: params, selected params
@@ -98,8 +102,11 @@ _Avoid_: exploration error, validation error
 
 ## Relationships
 
-- A **Configuration Function** can be executed with **Values**.
+- A **Configuration Function** can be executed with **Values** and **Execution Arguments**.
 - A **Configuration Function** produces one **Instantiation Value** per execution.
+- **Execution Arguments** are direct keyword arguments at Hypster execution boundaries.
+- Hypster-owned execution control names, such as `values`, are reserved and cannot be used as direct **Execution Arguments**.
+- **Execution Arguments** are not **Values** and are not included in **Selected Params**.
 - `instantiate` returns only the **Instantiation Value**; `instantiate_with_params` returns an **Instantiation Output**.
 - An **Instantiation Output** is a lightweight container with `value` and `params` attributes; `params` is a caller-owned plain dictionary copy.
 - `instantiate_with_params` accepts the same execution arguments and unknown-parameter policy as `instantiate`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -201,7 +201,7 @@ _Avoid_: exploration error, validation error
 - Show dictionary-backed `select` with logging-safe choices mapped to complex values.
 - Show `allow_none=True` examples for scalar params and select choices.
 - Document that `allow_none=True` supports `multi_select` choices but not nullable elements for `multi_int`, `multi_float`, `multi_text`, or `multi_bool`; include the error guidance.
-- Show that `instantiate_with_params` accepts the same execution arguments as `instantiate`, including `args`, `kwargs`, and `on_unknown`.
+- Show that `instantiate_with_params` accepts the same direct **Execution Arguments** and `on_unknown` policy as `instantiate`.
 - Replace the old "nested dict wins" docs with guidance that dotted and nested forms are both supported, but duplicate **Parameter Paths** fail.
 - Document that unknown/unreachable errors are based on the current execution path and that users should run `explore(config, values=...)` to inspect branches.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ llm = instantiate(
 response = llm.invoke("How's your day going?")
 ```
 
-Use `explore(..., values=...)` to inspect a specific conditional branch before you instantiate it, or `explore(..., return_info=True)` to get a JSON-serializable schema object.
+Use `explore(..., values=...)` to inspect a specific conditional branch before you instantiate it, or `explore(..., return_schema=True)` to get a JSON-serializable schema object.
 
 ## AI-readable docs
 
@@ -132,7 +132,7 @@ def model_cfg(hp: HP) -> ClassifierMixin:
 
 
 def objective(trial: optuna.Trial) -> float:
-    values = suggest_values(trial, config=model_cfg)
+    values = suggest_values(trial, model_cfg)
     model = instantiate(model_cfg, values=values)
     return train_and_score(model)
 

--- a/docs/adr/0003-direct-keyword-execution-arguments.md
+++ b/docs/adr/0003-direct-keyword-execution-arguments.md
@@ -1,0 +1,10 @@
+# Direct Keyword Execution Arguments
+
+Hypster execution APIs should forward ordinary config dependencies as direct keyword **Execution Arguments** instead of teaching separate `args=` and `kwargs=` containers. This is a breaking greenfield cleanup: Hypster-owned controls such as `values`, `on_unknown`, `return_schema`, `auto_apply`, `name`, and `description` remain reserved at their execution boundary, while all other direct keywords are forwarded into the **Configuration Function** and are never included in **Selected Params**.
+
+## Consequences
+
+- `instantiate`, `instantiate_with_params`, `explore`, `interact`, `hp.nest`, and HPO `suggest_values` use the same direct-keyword forwarding model.
+- Public `args=` and `kwargs=` forwarding are removed rather than kept as compatibility aliases.
+- `explore(return_info=True)` is renamed to `explore(return_schema=True)` so the flag matches the **Explore Schema** domain term.
+- This change should ship as a breaking pre-1.0 minor release.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -19,10 +19,10 @@ def config(hp: HP) -> Path:
 The same function can serve several jobs:
 
 * `explore(config)` prints the active parameter tree.
-* `explore(config, return_info=True)` returns a schema object for tools and UIs.
+* `explore(config, return_schema=True)` returns a schema object for tools and UIs.
 * `instantiate(config, values={...})` returns the runtime object.
 * `instantiate_with_params(config, values={...})` returns the runtime object plus replayable selected params.
-* `suggest_values(trial, config=config)` lets Optuna choose values for the reachable parameters.
+* `suggest_values(trial, config)` lets Optuna choose values for the reachable parameters.
 
 ## Example Map
 
@@ -32,7 +32,7 @@ The same function can serve several jobs:
 | [Data Processing](data-processing.md) | Ingestion, cleaning, feature flags, and export options in one pipeline config. |
 | [AI Workflows](ai-workflows.md) | Provider selection, RAG knobs, prompt settings, and dict-backed complex choices. |
 | [Nested Workflows](nested-workflows.md) | Reusable child configs, conditional nesting, deep value paths, and branch exploration. |
-| [Interactive UI From Schema](interactive-ui.md) | Generate form state from `explore(..., return_info=True)` and feed it back to `instantiate`. |
+| [Interactive UI From Schema](interactive-ui.md) | Generate form state from `explore(..., return_schema=True)` and feed it back to `instantiate`. |
 | [Experiment Tracking](experiment-tracking.md) | Capture selected params for logs, cards, and replay. |
 
 ## A Small End-to-End Pattern

--- a/docs/examples/interactive-ui.md
+++ b/docs/examples/interactive-ui.md
@@ -2,7 +2,7 @@
 
 Hypster ships a notebook UI through `interact()`. This example shows the lower-level schema path for custom Streamlit, Gradio, Panel, web app, or internal dashboard UIs.
 
-The public schema hook is `explore(config, return_info=True)`: it returns metadata that you can map to controls and then replay through `instantiate()`.
+The public schema hook is `explore(config, return_schema=True)`: it returns metadata that you can map to controls and then replay through `instantiate()`.
 
 ## Turn A Config Into Field Metadata
 
@@ -34,7 +34,7 @@ def flatten_parameters(parameters):
             fields.append(parameter)
     return fields
 
-schema = explore(app_config, return_info=True)
+schema = explore(app_config, return_schema=True)
 fields = flatten_parameters(schema.to_dict()["parameters"])
 
 for field in fields:
@@ -55,7 +55,7 @@ ui_values = {
     "timeout": 30.0,
 }
 
-schema = explore(app_config, values=ui_values, return_info=True)
+schema = explore(app_config, values=ui_values, return_schema=True)
 cfg = instantiate(app_config, values=ui_values)
 
 assert schema.defaults()["provider"] == "local"
@@ -103,4 +103,4 @@ def render_field(st, field):
 ```
 {% endcode %}
 
-For conditional UIs, rerun `explore(config, values=current_ui_values, return_info=True)` whenever a branch-selecting value changes. That keeps the rendered fields aligned with the active branch.
+For conditional UIs, rerun `explore(config, values=current_ui_values, return_schema=True)` whenever a branch-selecting value changes. That keeps the rendered fields aligned with the active branch.

--- a/docs/examples/nested-workflows.md
+++ b/docs/examples/nested-workflows.md
@@ -36,7 +36,7 @@ def trainer_config(hp: HP, epochs_default: int = 10) -> Trainer:
 
 def experiment_config(hp: HP) -> TrainingExperiment:
     dataset = hp.select(["mnist", "cifar10"], name="dataset", default="mnist", options_only=True)
-    trainer = hp.nest(trainer_config, name="trainer", kwargs={"epochs_default": 20})
+    trainer = hp.nest(trainer_config, name="trainer", epochs_default=20)
     return TrainingExperiment(dataset=dataset, trainer=trainer)
 ```
 {% endcode %}

--- a/docs/getting-started/exploring-a-configuration-space.md
+++ b/docs/getting-started/exploring-a-configuration-space.md
@@ -74,18 +74,18 @@ app_config
 
 ## Get Structured Metadata
 
-Use `return_info=True` when you want to inspect the schema in code:
+Use `return_schema=True` when you want to inspect the schema in code:
 
 {% code overflow="wrap" %}
 ```python
-info = explore(app_config, return_info=True)
+info = explore(app_config, return_schema=True)
 
 print(info.defaults())
 print(info.to_dict())
 ```
 {% endcode %}
 
-For programmatic inspection before instantiation, use `schema = explore(config, return_info=True)` and read `schema.to_dict()["parameters"]`. Use plain `explore(config)` when a printed tree is enough.
+For programmatic inspection before instantiation, use `schema = explore(config, return_schema=True)` and read `schema.to_dict()["parameters"]`. Use plain `explore(config)` when a printed tree is enough.
 
 `defaults()` returns a flat dictionary of the active branch's default parameter values:
 
@@ -104,7 +104,7 @@ For programmatic inspection before instantiation, use `schema = explore(config, 
 | Use | API |
 | --- | --- |
 | Print the active tree | `explore(config)` |
-| Build a UI or schema export | `explore(config, return_info=True)` |
+| Build a UI or schema export | `explore(config, return_schema=True)` |
 | Inspect a conditional branch | `explore(config, values={...})` |
 | Get the runtime object | `instantiate(config, values={...})` |
 

--- a/docs/getting-started/instantiating-a-configuration-space.md
+++ b/docs/getting-started/instantiating-a-configuration-space.md
@@ -134,9 +134,9 @@ assert instantiate(config, values=run.params) == run.value
 ```
 {% endcode %}
 
-## Passing Args/Kwargs To Nested Configs
+## Passing Execution Arguments To Nested Configs
 
-When using `hp.nest`, you can pass `args=` and `kwargs=` to the child function.
+When using `hp.nest`, pass child execution arguments directly as keyword arguments.
 
 {% code overflow="wrap" %}
 ```python
@@ -145,8 +145,8 @@ def child(hp: HP, multiplier: int, offset: int = 0) -> int:
     return base * multiplier + offset
 
 def parent(hp: HP):
-    calc1 = hp.nest(child, name="calc1", args=(2,))
-    calc2 = hp.nest(child, name="calc2", args=(3,), kwargs={"offset": 10})
+    calc1 = hp.nest(child, name="calc1", multiplier=2)
+    calc2 = hp.nest(child, name="calc2", multiplier=3, offset=10)
     return {"calc1": calc1, "calc2": calc2}
 
 result = instantiate(parent)

--- a/docs/getting-started/instantiating-a-configuration-space.md
+++ b/docs/getting-started/instantiating-a-configuration-space.md
@@ -54,7 +54,7 @@ assert replayed.model == run.value.model
 ```
 {% endcode %}
 
-`instantiate_with_params()` accepts the same `values`, `args`, `kwargs`, and `on_unknown` arguments as `instantiate()`. It does not change what your config returns; it adds a sidecar for logging and replay.
+`instantiate_with_params()` accepts the same `values` and `on_unknown` arguments as `instantiate()`, plus any direct execution arguments your config requires. It does not change what your config returns; it adds a sidecar for logging and replay.
 
 ## Unknown Parameters
 

--- a/docs/getting-started/interactive-instantiation-ui.md
+++ b/docs/getting-started/interactive-instantiation-ui.md
@@ -131,4 +131,4 @@ result2 = interact(model_config, values=result.params)
 ```
 {% endcode %}
 
-For framework-specific UIs outside notebooks, use the schema returned by `explore(..., return_info=True)`. See [Build an Interactive UI](../how-to/build-an-interactive-ui.md).
+For framework-specific UIs outside notebooks, use the schema returned by `explore(..., return_schema=True)`. See [Build an Interactive UI](../how-to/build-an-interactive-ui.md).

--- a/docs/how-to/build-an-interactive-ui.md
+++ b/docs/how-to/build-an-interactive-ui.md
@@ -2,7 +2,7 @@
 
 Use [`interact()`](../getting-started/interactive-instantiation-ui.md) when you want Hypster's built-in notebook widget. This guide is for custom Streamlit, Gradio, Panel, web app, or internal dashboard UIs.
 
-Use `explore(config, return_info=True)` to discover fields, render controls in your UI framework, then pass the collected values to `instantiate()`.
+Use `explore(config, return_schema=True)` to discover fields, render controls in your UI framework, then pass the collected values to `instantiate()`.
 
 `explore()` executes the config function to discover the active branch. A custom UI may call it on every branch-changing edit, so keep config functions cheap and side-effect-free for interactive use; avoid paid API calls, database calls, file writes, training loops, and costly resource initialization in paths that the UI will explore.
 
@@ -53,7 +53,7 @@ def search_config(hp: HP) -> SearchRuntime:
     return SearchRuntime(retrieval=retrieval, features=features)
 
 
-schema = explore(search_config, return_info=True)
+schema = explore(search_config, return_schema=True)
 metadata = schema.to_dict()
 ```
 {% endcode %}
@@ -206,7 +206,7 @@ When a branch-selecting field changes, call `explore()` again with current UI va
 {% code overflow="wrap" %}
 ```python
 ui_values = {"backend": "vector"}
-schema = explore(search_config, values=ui_values, return_info=True)
+schema = explore(search_config, values=ui_values, return_schema=True)
 fields = list(flatten_fields(schema.to_dict()["parameters"]))
 
 assert [field["path"] for field in fields] == [
@@ -227,10 +227,10 @@ def reachable_paths(schema):
     return {field["path"] for field in flatten_fields(schema.to_dict()["parameters"])}
 
 def refresh_schema(config, current_values):
-    schema = explore(config, values=current_values, on_unknown="ignore", return_info=True)
+    schema = explore(config, values=current_values, on_unknown="ignore", return_schema=True)
     reachable = reachable_paths(schema)
     pruned_values = {path: value for path, value in current_values.items() if path in reachable}
-    schema = explore(config, values=pruned_values, return_info=True)
+    schema = explore(config, values=pruned_values, return_schema=True)
     return schema, pruned_values
 ```
 {% endcode %}

--- a/docs/how-to/compose-nested-configs.md
+++ b/docs/how-to/compose-nested-configs.md
@@ -76,7 +76,7 @@ The nested scope name is a prefix, not a leaf value. `values={"tokenizer": "word
 
 When you pass child-local values through `hp.nest(child, name="child", values=...)`, Hypster validates those explicit child values after the child runs. Typos and inactive child-branch keys raise instead of being ignored.
 
-## Pass Args And Kwargs To Children
+## Pass Execution Arguments To Children
 
 {% code overflow="wrap" %}
 ```python
@@ -88,8 +88,8 @@ def sampler_config(hp: HP, default_batch_size: int) -> BatchSampler:
     return BatchSampler(batch_size=batch_size, shuffle=shuffle)
 
 def training_config(hp: HP) -> TrainingInputs:
-    train = hp.nest(sampler_config, name="train", args=(128,))
-    eval = hp.nest(sampler_config, name="eval", kwargs={"default_batch_size": 256})
+    train = hp.nest(sampler_config, name="train", default_batch_size=128)
+    eval = hp.nest(sampler_config, name="eval", default_batch_size=256)
     return TrainingInputs(train=train, eval=eval)
 ```
 {% endcode %}

--- a/docs/how-to/create-a-replayable-config.md
+++ b/docs/how-to/create-a-replayable-config.md
@@ -36,7 +36,7 @@ Use structured metadata when another tool needs to render fields:
 
 {% code overflow="wrap" %}
 ```python
-schema = explore(data_config, return_info=True)
+schema = explore(data_config, return_schema=True)
 fields = schema.to_dict()["parameters"]
 ```
 {% endcode %}

--- a/docs/how-to/perform-hyperparameter-optimization.md
+++ b/docs/how-to/perform-hyperparameter-optimization.md
@@ -80,7 +80,7 @@ def train_and_score(model: ClassifierMixin) -> float:
     return float(scores.mean())
 
 def objective(trial: optuna.Trial) -> float:
-    values = suggest_values(trial, config=model_config)
+    values = suggest_values(trial, model_config)
     run = instantiate_with_params(model_config, values=values)
     trial.set_user_attr("hypster_params", run.params)
     return train_and_score(run.value)
@@ -112,7 +112,7 @@ def forest_only_config(hp: HP) -> RandomForestClassifier:
     )
 
 def objective(trial: optuna.Trial) -> float:
-    values = suggest_values(trial, config=forest_only_config)
+    values = suggest_values(trial, forest_only_config)
     run = instantiate_with_params(forest_only_config, values=values)
     return train_and_score(run.value)
 ```

--- a/docs/in-depth/nest.md
+++ b/docs/in-depth/nest.md
@@ -33,8 +33,7 @@ hp.nest(
     *,
     name,
     values=None,
-    args=(),
-    kwargs=None,
+    **kwargs,
 )
 ```
 {% endcode %}
@@ -44,8 +43,7 @@ hp.nest(
 | `child` | Config function whose first parameter is `hp`. |
 | `name` | Scope name. Must be a valid Python identifier. |
 | `values` | Child-local values merged into the nested call. |
-| `args` | Positional arguments passed to the child. |
-| `kwargs` | Keyword arguments passed to the child. |
+| `**kwargs` | Execution arguments forwarded to the child. |
 
 ## Child-Local Values
 
@@ -91,7 +89,7 @@ instantiate(parent_with_typo)
 
 Use child-local `values=` for parent-owned policy, test fixtures, or internal composition defaults that should win over caller-provided nested values.
 
-## Args And Kwargs
+## Execution Arguments
 
 {% code overflow="wrap" %}
 ```python
@@ -101,8 +99,8 @@ def sampler_config(hp: HP, default_batch_size: int) -> BatchSampler:
     return BatchSampler(batch_size=batch_size, shuffle=shuffle)
 
 def data_config(hp: HP) -> DataLoaders:
-    train = hp.nest(sampler_config, name="train", args=(128,))
-    eval = hp.nest(sampler_config, name="eval", kwargs={"default_batch_size": 256})
+    train = hp.nest(sampler_config, name="train", default_batch_size=128)
+    eval = hp.nest(sampler_config, name="eval", default_batch_size=256)
     return DataLoaders(train=train, eval=eval)
 ```
 {% endcode %}

--- a/docs/in-depth/performing-hyperparameter-optimization.md
+++ b/docs/in-depth/performing-hyperparameter-optimization.md
@@ -7,7 +7,7 @@ For the task recipe, see [Perform Hyperparameter Optimization](../how-to/perform
 ## Mental Model
 
 1. A config function calls `hp.int`, `hp.float`, and `hp.select`.
-2. `suggest_values(trial, config=...)` runs that config with a trial-backed `HP` proxy.
+2. `suggest_values(trial, ...)` runs that config with a trial-backed `HP` proxy.
 3. The proxy asks Optuna for values and returns a `values` dictionary.
 4. You pass that dictionary to `instantiate(config, values=values)`.
 5. Your objective evaluates the instantiated runtime object.

--- a/docs/integrations/optuna.md
+++ b/docs/integrations/optuna.md
@@ -61,7 +61,7 @@ def model_config(hp: HP) -> ClassifierMixin:
     return hp.nest(selected_config, name="model")
 
 def objective(trial: optuna.Trial) -> float:
-    values = suggest_values(trial, config=model_config)
+    values = suggest_values(trial, model_config)
     model = instantiate(model_config, values=values)
     return train_and_score(model)
 

--- a/docs/philosophy/use-cases.md
+++ b/docs/philosophy/use-cases.md
@@ -33,7 +33,7 @@ See [AI Workflows](../examples/ai-workflows.md).
 
 ## Internal Tools And UIs
 
-* Generate form controls from `explore(..., return_info=True)`.
+* Generate form controls from `explore(..., return_schema=True)`.
 * Submit UI state as `values=`.
 * Recompute the schema when a branch-selecting value changes.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -27,7 +27,7 @@ The `hp: HP` annotation is recommended but not mandatory. If the first parameter
 
 Reference examples use small return values for compactness. In application docs and production code, the usual pattern is to return the initialized object your application will use.
 
-Config functions may accept extra positional or keyword arguments. Pass those through `args=` and `kwargs=`.
+Config functions may accept extra keyword-only execution arguments. Pass those directly; Hypster-owned names such as `values`, `on_unknown`, `return_schema`, `auto_apply`, `name`, and `description` are reserved at their API boundaries.
 
 ## instantiate
 
@@ -37,9 +37,8 @@ instantiate(
     func,
     *,
     values=None,
-    args=(),
-    kwargs=None,
     on_unknown="raise",
+    **kwargs,
 )
 ```
 {% endcode %}
@@ -50,9 +49,8 @@ Executes a config function and returns whatever the function returns.
 | --- | --- |
 | `func` | Config function whose first argument is `hp`. |
 | `values` | Optional dictionary of parameter paths to overrides. Nested dictionaries are flattened to dotted paths. |
-| `args` | Extra positional arguments passed to `func`. |
-| `kwargs` | Extra keyword arguments passed to `func`. |
 | `on_unknown` | One of `"raise"`, `"warn"`, or `"ignore"`. Defaults to `"raise"`. |
+| `**kwargs` | Extra execution arguments forwarded to `func`. |
 
 `values=` keys must match parameters reached during the run. Unknown values and inactive-branch values raise by default.
 
@@ -64,9 +62,8 @@ instantiate_with_params(
     func,
     *,
     values=None,
-    args=(),
-    kwargs=None,
     on_unknown="raise",
+    **kwargs,
 )
 ```
 {% endcode %}
@@ -110,22 +107,21 @@ explore(
     func,
     *,
     values=None,
-    args=(),
-    kwargs=None,
     on_unknown="raise",
-    return_info=False,
+    return_schema=False,
+    **kwargs,
 )
 ```
 {% endcode %}
 
 Traces a config function with a schema-recording `HP`. This executes the function to discover the active branch.
 
-* With `return_info=False`, prints a tree and returns `None`.
-* With `return_info=True`, returns a `ConfigSchema`.
+* With `return_schema=False`, prints a tree and returns `None`.
+* With `return_schema=True`, returns a `ConfigSchema`.
 
 {% code overflow="wrap" %}
 ```python
-schema = explore(config, return_info=True)
+schema = explore(config, return_schema=True)
 print(schema.defaults())
 print(schema.to_dict())
 ```
@@ -133,7 +129,7 @@ print(schema.to_dict())
 
 ## ConfigSchema
 
-Returned by `explore(..., return_info=True)`.
+Returned by `explore(..., return_schema=True)`.
 
 | Method | Meaning |
 | --- | --- |
@@ -149,10 +145,9 @@ interact(
     func,
     *,
     values=None,
-    args=(),
-    kwargs=None,
     on_unknown="raise",
     auto_apply=True,
+    **kwargs,
 ) -> InteractiveResult
 ```
 {% endcode %}
@@ -179,9 +174,9 @@ current_params = result.params
 | --- | --- |
 | `func` | Config function whose first argument is `hp`. |
 | `values` | Optional starting values, using the same flat or nested path forms as `instantiate()`. |
-| `args` / `kwargs` | Extra arguments forwarded to the config function. |
 | `on_unknown` | Unknown-value policy used while exploring and applying widget state. |
 | `auto_apply` | When `True`, valid widget edits update `.value` and `.params` immediately. When `False`, edits stay draft-only until Apply succeeds. |
+| `**kwargs` | Extra execution arguments forwarded to the config function. |
 
 ## InteractiveResult
 
@@ -229,7 +224,7 @@ Each schema parameter contains:
 
 `ConfigSchema.to_dict()` is intended for rendering and inspection, not as a complete validation schema. It exposes the active branch, selected values, options, numeric bounds, descriptions, and nested groups. It does not currently expose every HP call option, such as `allow_none`, `options_only`, or `strict`.
 
-UI builders should use schema metadata to render controls, then round-trip user input through `explore(..., values=..., return_info=True)` and `instantiate(..., values=...)` for authoritative validation. For dict-backed selects, `options` contains replayable keys, not mapped runtime objects.
+UI builders should use schema metadata to render controls, then round-trip user input through `explore(..., values=..., return_schema=True)` and `instantiate(..., values=...)` for authoritative validation. For dict-backed selects, `options` contains replayable keys, not mapped runtime objects.
 
 ## HP Scalar Methods
 
@@ -314,9 +309,8 @@ hp.nest(
     *,
     name,
     values=None,
-    args=(),
-    kwargs=None,
     description=None,
+    **kwargs,
 )
 ```
 {% endcode %}

--- a/docs/reference/optuna-hpo.md
+++ b/docs/reference/optuna-hpo.md
@@ -21,7 +21,7 @@ from hypster.hpo.types import HpoCategorical, HpoFloat, HpoInt
 
 {% code overflow="wrap" %}
 ```python
-suggest_values(trial, *, config, args=(), kwargs=None) -> dict
+suggest_values(trial, config, **kwargs) -> dict
 ```
 {% endcode %}
 
@@ -29,7 +29,7 @@ Runs `config` with a trial-backed `HP` proxy and returns a `values` dictionary t
 
 {% code overflow="wrap" %}
 ```python
-values = suggest_values(trial, config=model_config)
+values = suggest_values(trial, model_config)
 cfg = instantiate(model_config, values=values)
 ```
 {% endcode %}
@@ -140,7 +140,7 @@ def weighted_choice_config(hp: HP):
 ```
 {% endcode %}
 
-Both fail during `suggest_values(trial, config=...)` before a values dictionary is returned. Show the error as configuration feedback:
+Both fail during `suggest_values(trial, ...)` before a values dictionary is returned. Show the error as configuration feedback:
 
 {% code overflow="wrap" %}
 ```text

--- a/docs/reproducibility/observing-past-runs.md
+++ b/docs/reproducibility/observing-past-runs.md
@@ -49,7 +49,7 @@ Do not replay with `on_unknown="ignore"` until you have decided which old values
 
 {% code overflow="wrap" %}
 ```python
-schema = explore(config, values=past_params, return_info=True)
+schema = explore(config, values=past_params, return_schema=True)
 current_branch_defaults = schema.defaults()
 ```
 {% endcode %}

--- a/docs/reproducibility/serialization.md
+++ b/docs/reproducibility/serialization.md
@@ -46,11 +46,11 @@ def model_config(hp: HP):
 
 ## Schema Serialization
 
-`explore(config, return_info=True).to_dict()` returns JSON-serializable schema metadata for UIs, catalogs, and validation tools.
+`explore(config, return_schema=True).to_dict()` returns JSON-serializable schema metadata for UIs, catalogs, and validation tools.
 
 {% code overflow="wrap" %}
 ```python
-schema = explore(config, return_info=True).to_dict()
+schema = explore(config, return_schema=True).to_dict()
 json.dumps(schema)
 ```
 {% endcode %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hypster"
-version = "0.5.3"
+version = "0.6.0"
 description = "A flexible configuration system for Python projects"
 authors = [
     {name = "Gilad Rubin", email = "me@giladrubin.com"}

--- a/src/hypster/_version.py
+++ b/src/hypster/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "0.5.3"
+__version__ = "0.6.0"

--- a/src/hypster/core.py
+++ b/src/hypster/core.py
@@ -2,7 +2,7 @@
 
 import warnings
 from dataclasses import dataclass, field
-from typing import Any, Dict, Generic, Literal, Optional, Protocol, TypeVar
+from typing import Any, Dict, Generic, Iterable, Literal, Optional, Protocol, TypeVar
 
 from .hp import HP
 from .hp_calls import HPCallError
@@ -57,6 +57,20 @@ def _reject_removed_execution_argument_containers(execution_kwargs: Dict[str, An
         )
 
 
+def _reject_reserved_execution_arguments(
+    api_name: str,
+    execution_kwargs: Dict[str, Any],
+    reserved_names: Iterable[str],
+    guidance: str,
+) -> None:
+    reserved = sorted(name for name in reserved_names if name in execution_kwargs)
+    if not reserved:
+        return
+
+    names = ", ".join(f"{name}=" for name in reserved)
+    raise TypeError(f"{api_name} reserves {names} for Hypster execution controls. {guidance}")
+
+
 def instantiate(
     func: ConfigFunc[T],
     *,
@@ -70,7 +84,7 @@ def instantiate(
     Args:
         func: Config function with first param hp: HP
         values: Parameter values by name
-        kwargs: Additional keyword arguments for func
+        **kwargs: Execution arguments forwarded directly to func
         on_unknown: How to handle unknown/unreachable parameters:
             - 'raise': Raise ValueError (default)
             - 'warn': Issue warning and continue

--- a/src/hypster/core.py
+++ b/src/hypster/core.py
@@ -2,7 +2,7 @@
 
 import warnings
 from dataclasses import dataclass, field
-from typing import Any, Dict, Generic, Literal, Optional, Protocol, Tuple, TypeVar
+from typing import Any, Dict, Generic, Literal, Optional, Protocol, TypeVar
 
 from .hp import HP
 from .hp_calls import HPCallError
@@ -49,13 +49,20 @@ class ParamsTracker:
         self.params[path] = selected_value
 
 
+def _reject_removed_execution_argument_containers(execution_kwargs: Dict[str, Any]) -> None:
+    if "args" in execution_kwargs or "kwargs" in execution_kwargs:
+        raise TypeError(
+            "This Hypster execution API no longer accepts args= or kwargs=. "
+            "Pass execution arguments as direct keyword arguments."
+        )
+
+
 def instantiate(
     func: ConfigFunc[T],
     *,
     values: Optional[Dict[str, Any]] = None,
-    args: Tuple[Any, ...] = (),
-    kwargs: Optional[Dict[str, Any]] = None,
     on_unknown: UnknownPolicy = "raise",
+    **kwargs: Any,
 ) -> T:
     """
     Execute a config function with the given values.
@@ -63,7 +70,6 @@ def instantiate(
     Args:
         func: Config function with first param hp: HP
         values: Parameter values by name
-        args: Additional positional arguments for func
         kwargs: Additional keyword arguments for func
         on_unknown: How to handle unknown/unreachable parameters:
             - 'raise': Raise ValueError (default)
@@ -77,7 +83,7 @@ def instantiate(
         ValueError: If func doesn't have hp: HP as first parameter
         ValueError: If unknown parameters in values and on_unknown='raise'
     """
-    return _run_config(func, values=values, args=args, kwargs=kwargs, on_unknown=on_unknown)
+    return _run_config(func, values=values, kwargs=kwargs, on_unknown=on_unknown)
 
 
 def _validate_on_unknown(on_unknown: str) -> None:
@@ -90,7 +96,6 @@ def _run_config(
     func: ConfigFunc[T],
     *,
     values: Optional[Dict[str, Any]] = None,
-    args: Tuple[Any, ...] = (),
     kwargs: Optional[Dict[str, Any]] = None,
     on_unknown: UnknownPolicy = "raise",
     parameter_tracker: Optional[Any] = None,
@@ -101,11 +106,12 @@ def _run_config(
 
     normalized_values = normalize_values(values)
     kwargs = kwargs or {}
+    _reject_removed_execution_argument_containers(kwargs)
     hp = HP(normalized_values, parameter_tracker=parameter_tracker)
     original_called_params = hp.called_params.copy()
 
     try:
-        result = func(hp, *args, **kwargs)
+        result = func(hp, **kwargs)
         called_params = hp.called_params - original_called_params
         leaf_params = called_params - hp.nested_scope_paths
         _handle_unknown_parameters(normalized_values, leaf_params, on_unknown)
@@ -159,9 +165,8 @@ def instantiate_with_params(
     func: ConfigFunc[T],
     *,
     values: Optional[Dict[str, Any]] = None,
-    args: Tuple[Any, ...] = (),
-    kwargs: Optional[Dict[str, Any]] = None,
     on_unknown: UnknownPolicy = "raise",
+    **kwargs: Any,
 ) -> InstantiationOutput[T]:
     """
     Execute a config function and return its value with selected params.
@@ -172,7 +177,6 @@ def instantiate_with_params(
     result = _run_config(
         func,
         values=values,
-        args=args,
         kwargs=kwargs,
         on_unknown=on_unknown,
         parameter_tracker=tracker,

--- a/src/hypster/explore.py
+++ b/src/hypster/explore.py
@@ -9,6 +9,7 @@ from .core import (
     ConfigFunc,
     _handle_unknown_parameters,
     _reject_removed_execution_argument_containers,
+    _reject_reserved_execution_arguments,
     _validate_on_unknown,
 )
 from .hp import HP
@@ -243,8 +244,12 @@ def explore(
     validate_config_func_signature(func)
     _validate_on_unknown(on_unknown)
     _reject_removed_execution_argument_containers(kwargs)
-    if "return_info" in kwargs:
-        raise TypeError("explore() no longer accepts return_info=. Use return_schema=True.")
+    _reject_reserved_execution_arguments(
+        "explore()",
+        kwargs,
+        {"return_info"},
+        "Use return_schema=True to return a ConfigSchema, or rename this execution argument.",
+    )
 
     normalized_values: Dict[str, Any] = normalize_values(values)
     tracer = SchemaTracer(normalized_values)

--- a/src/hypster/explore.py
+++ b/src/hypster/explore.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional
 
-from .core import ConfigFunc, _handle_unknown_parameters, _validate_on_unknown
+from .core import (
+    ConfigFunc,
+    _handle_unknown_parameters,
+    _reject_removed_execution_argument_containers,
+    _validate_on_unknown,
+)
 from .hp import HP
 from .hp_calls import HPCallError
 from .utils import normalize_values, validate_config_func_signature
@@ -231,21 +236,22 @@ def explore(
     func: ConfigFunc[Any],
     *,
     values: Optional[Dict[str, Any]] = None,
-    args: Tuple[Any, ...] = (),
-    kwargs: Optional[Dict[str, Any]] = None,
     on_unknown: Literal["warn", "raise", "ignore"] = "raise",
-    return_info: bool = False,
+    return_schema: bool = False,
+    **kwargs: Any,
 ) -> Optional[ConfigSchema]:
     validate_config_func_signature(func)
     _validate_on_unknown(on_unknown)
+    _reject_removed_execution_argument_containers(kwargs)
+    if "return_info" in kwargs:
+        raise TypeError("explore() no longer accepts return_info=. Use return_schema=True.")
 
     normalized_values: Dict[str, Any] = normalize_values(values)
     tracer = SchemaTracer(normalized_values)
-    kwargs = kwargs or {}
     original_called_params = tracer.called_params.copy()
 
     try:
-        func(tracer, *args, **kwargs)
+        func(tracer, **kwargs)
     except HPCallError as e:
         raise ValueError(str(e)) from e
 
@@ -255,7 +261,7 @@ def explore(
 
     schema = tracer.build_schema(getattr(func, "__name__", func.__class__.__name__))
 
-    if return_info:
+    if return_schema:
         return schema
 
     print(schema.format_tree())

--- a/src/hypster/hp.py
+++ b/src/hypster/hp.py
@@ -508,9 +508,8 @@ class HP:
         *,
         name: str,
         values: Optional[Dict[str, Any]] = None,
-        args: tuple = (),
-        kwargs: Optional[Dict[str, Any]] = None,
         description: Optional[str] = None,
+        **kwargs: Any,
     ) -> Any:
         """Nest another configuration function."""
         from .utils import validate_config_func_signature
@@ -561,11 +560,12 @@ class HP:
         self.called_params.add(full_path)
         self.nested_scope_paths.add(full_path)
 
-        # Prepare arguments
-        kwargs = kwargs or {}
+        from .core import _reject_removed_execution_argument_containers
+
+        _reject_removed_execution_argument_containers(kwargs)
 
         # Call the nested function
-        result = child(nested_hp, *args, **kwargs)
+        result = child(nested_hp, **kwargs)
 
         if explicit_values:
             from .core import _handle_unknown_parameters

--- a/src/hypster/hpo/optuna.py
+++ b/src/hypster/hpo/optuna.py
@@ -9,7 +9,7 @@ except Exception:  # pragma: no cover
     _optuna = None
 
 from .._sentinels import NO_DEFAULT as _NO_DEFAULT
-from ..core import _handle_unknown_parameters
+from ..core import _handle_unknown_parameters, _reject_removed_execution_argument_containers
 from ..hp_calls import FloatValidator, IntValidator
 from ..utils import normalize_values, validate_identifier_name, validate_select_choice
 from .types import HpoCategorical, HpoFloat, HpoInt
@@ -226,8 +226,7 @@ class _HPProxy:
         *,
         name: str,
         values: Dict[str, Any] | None = None,
-        args: tuple = (),
-        kwargs: Dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> Any:
         validate_identifier_name(name, kind="nest name")
         overrides = dict(self.overrides)
@@ -239,13 +238,13 @@ class _HPProxy:
                 overrides[prefixed_key] = v
                 prefixed_values[prefixed_key] = v
         nested = _HPProxy(self.trial, self.collector, ns=self.ns + [name], overrides=overrides)
-        kwargs = kwargs or {}
-        result = child(nested, *args, **kwargs)
+        _reject_removed_execution_argument_containers(kwargs)
+        result = child(nested, **kwargs)
         _handle_unknown_parameters(prefixed_values, set(self.collector), "raise")
         return result
 
 
-def suggest_values(trial: Any, *, config, args: tuple = (), kwargs: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def suggest_values(trial: Any, config, /, **kwargs: Any) -> Dict[str, Any]:
     """Run the config with a trial-backed HP to produce a values dict.
 
     This respects conditionals: only parameters touched in the executed path
@@ -255,6 +254,6 @@ def suggest_values(trial: Any, *, config, args: tuple = (), kwargs: Dict[str, An
     # We intentionally do not import or require optuna here for testability.
     collector: Dict[str, Any] = {}
     hp = _HPProxy(trial, collector)
-    kwargs = kwargs or {}
-    config(hp, *args, **kwargs)
+    _reject_removed_execution_argument_containers(kwargs)
+    config(hp, **kwargs)
     return collector

--- a/src/hypster/interactive/session.py
+++ b/src/hypster/interactive/session.py
@@ -8,6 +8,7 @@ from hypster.core import (
     ConfigFunc,
     UnknownPolicy,
     _reject_removed_execution_argument_containers,
+    _reject_reserved_execution_arguments,
     instantiate_with_params,
 )
 from hypster.explore import ConfigSchema, ParameterInfo, explore
@@ -76,6 +77,12 @@ class InteractiveSession(Generic[T]):
     def __post_init__(self) -> None:
         self._kwargs = dict(self.execution_kwargs or {})
         _reject_removed_execution_argument_containers(self._kwargs)
+        _reject_reserved_execution_arguments(
+            "interact()",
+            self._kwargs,
+            {"return_schema", "return_info"},
+            "Rename these execution arguments before using interact().",
+        )
         self._draft_values: Dict[str, Any] = {}
         self._applied_values: Dict[str, Any] = {}
         self._params: Dict[str, Any] = {}

--- a/src/hypster/interactive/session.py
+++ b/src/hypster/interactive/session.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import importlib.util
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, Mapping, Optional, Tuple, TypeVar
+from typing import Any, Dict, Generic, Mapping, Optional, TypeVar
 
-from hypster.core import ConfigFunc, UnknownPolicy, instantiate_with_params
+from hypster.core import (
+    ConfigFunc,
+    UnknownPolicy,
+    _reject_removed_execution_argument_containers,
+    instantiate_with_params,
+)
 from hypster.explore import ConfigSchema, ParameterInfo, explore
 from hypster.utils import normalize_values
 
@@ -64,13 +69,13 @@ class InteractiveError:
 class InteractiveSession(Generic[T]):
     func: ConfigFunc[T]
     values: Optional[Mapping[str, Any]] = None
-    args: Tuple[Any, ...] = ()
-    kwargs: Optional[Dict[str, Any]] = None
+    execution_kwargs: Optional[Dict[str, Any]] = None
     on_unknown: UnknownPolicy = "raise"
     auto_apply: bool = True
 
     def __post_init__(self) -> None:
-        self._kwargs = dict(self.kwargs or {})
+        self._kwargs = dict(self.execution_kwargs or {})
+        _reject_removed_execution_argument_containers(self._kwargs)
         self._draft_values: Dict[str, Any] = {}
         self._applied_values: Dict[str, Any] = {}
         self._params: Dict[str, Any] = {}
@@ -233,22 +238,20 @@ class InteractiveSession(Generic[T]):
         schema = explore(
             self.func,
             values=values,
-            args=self.args,
-            kwargs=self._kwargs,
             on_unknown=self.on_unknown,
-            return_info=True,
+            return_schema=True,
+            **self._kwargs,
         )
         if schema is None:
-            raise RuntimeError("explore(..., return_info=True) did not return a schema")
+            raise RuntimeError("explore(..., return_schema=True) did not return a schema")
         return schema
 
     def _apply(self, schema: ConfigSchema, selected_values: Dict[str, Any]) -> None:
         output = instantiate_with_params(
             self.func,
             values=selected_values,
-            args=self.args,
-            kwargs=self._kwargs,
             on_unknown=self.on_unknown,
+            **self._kwargs,
         )
 
         self._schema = schema
@@ -303,17 +306,15 @@ def interact(
     func: ConfigFunc[T],
     *,
     values: Optional[Mapping[str, Any]] = None,
-    args: Tuple[Any, ...] = (),
-    kwargs: Optional[Dict[str, Any]] = None,
     on_unknown: UnknownPolicy = "raise",
     auto_apply: bool = True,
+    **kwargs: Any,
 ) -> InteractiveResult[T]:
     _ensure_viz_extra()
     session: InteractiveSession[T] = InteractiveSession(
         func=func,
         values=values,
-        args=args,
-        kwargs=kwargs,
+        execution_kwargs=kwargs,
         on_unknown=on_unknown,
         auto_apply=auto_apply,
     )

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -54,7 +54,7 @@ def test_explore_returns_schema_info_and_defaults() -> None:
         temperature = hp.float(0.0, name="temperature", min=0.0, max=2.0)
         return {"batching": batching, "temperature": temperature}
 
-    info = explore(config, return_info=True)
+    info = explore(config, return_schema=True)
 
     assert info is not None
     assert info.defaults() == {
@@ -95,6 +95,30 @@ def test_explore_returns_schema_info_and_defaults() -> None:
     }
 
 
+def test_explore_forwards_execution_kwargs_to_config() -> None:
+    def config(hp: HP, default_batching: str) -> Dict[str, Any]:
+        batching = hp.select(["single", "split"], name="batching", default=default_batching)
+        return {"batching": batching}
+
+    info = explore(config, return_schema=True, default_batching="single")
+
+    assert info is not None
+    assert info.defaults() == {"batching": "single"}
+
+
+def test_explore_rejects_old_return_info_flag() -> None:
+    calls = []
+
+    def config(hp: HP, **execution_kwargs: object) -> Dict[str, int]:
+        calls.append(execution_kwargs)
+        return {"x": hp.int(1, name="x")}
+
+    with pytest.raises(TypeError, match="return_schema=True"):
+        explore(config, return_info=True)
+
+    assert calls == []
+
+
 def test_explore_includes_descriptions_and_display_labels() -> None:
     def retrieval(hp: HP) -> Dict[str, Any]:
         top_k = hp.int(
@@ -115,7 +139,7 @@ def test_explore_includes_descriptions_and_display_labels() -> None:
             )
         }
 
-    info = explore(config, return_info=True)
+    info = explore(config, return_schema=True)
 
     assert info is not None
     schema = info.to_dict()
@@ -148,7 +172,7 @@ def test_explore_tracks_nested_defaults_with_prefixed_paths() -> None:
             "system_prompt": hp.text("", name="system_prompt"),
         }
 
-    info = explore(root, return_info=True)
+    info = explore(root, return_schema=True)
 
     assert info is not None
     assert info.defaults() == {
@@ -186,7 +210,7 @@ def test_explore_values_select_a_different_branch() -> None:
     info = explore(
         query_llm,
         values={"provider": "openai", "openai.temperature": 0.7},
-        return_info=True,
+        return_schema=True,
     )
 
     assert info is not None
@@ -256,7 +280,7 @@ def test_explore_to_dict_is_json_serializable() -> None:
         )
         return {"provider": provider}
 
-    info = explore(config, return_info=True)
+    info = explore(config, return_schema=True)
 
     assert info is not None
     assert info.to_dict() == {

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -113,7 +113,7 @@ def test_explore_rejects_old_return_info_flag() -> None:
         calls.append(execution_kwargs)
         return {"x": hp.int(1, name="x")}
 
-    with pytest.raises(TypeError, match="return_schema=True"):
+    with pytest.raises(TypeError, match=r"explore\(\) reserves return_info=.*return_schema=True"):
         explore(config, return_info=True)
 
     assert calls == []

--- a/tests/test_function_signature.py
+++ b/tests/test_function_signature.py
@@ -42,8 +42,24 @@ def test_extra_args_allowed() -> None:
         base = hp.int(10, name="base")
         return base * multiplier
 
-    result = instantiate(config, kwargs={"multiplier": 3})
+    result = instantiate(config, multiplier=3)
     assert result == 30
+
+
+def test_removed_execution_argument_containers_are_rejected() -> None:
+    calls = []
+
+    def config(hp: HP, **execution_kwargs: object) -> int:
+        calls.append(execution_kwargs)
+        return hp.int(10, name="base")
+
+    with pytest.raises(TypeError, match="no longer accepts args= or kwargs="):
+        instantiate(config, args=(3,))
+
+    with pytest.raises(TypeError, match="no longer accepts args= or kwargs="):
+        instantiate(config, kwargs={"multiplier": 3})
+
+    assert calls == []
 
 
 def test_keyword_only_hp_is_rejected_during_signature_validation() -> None:

--- a/tests/test_hpo_optuna_edge.py
+++ b/tests/test_hpo_optuna_edge.py
@@ -27,7 +27,7 @@ def cfg(hp: HP):
 
 def test_include_max_reduces_high():
     t = TrialSpy()
-    values = suggest_values(t, config=cfg)
+    values = suggest_values(t, cfg)
     assert values["n"] == 0
     name, low, high, step, log = t.calls[0]
     assert (name, low, step, log) == ("n", 0, 2, False)
@@ -39,7 +39,7 @@ def test_include_max_false_keeps_largest_valid_stepped_value_below_max():
         return hp.int(0, name="n", min=0, max=10, hpo_spec=HpoInt(step=3, include_max=False))
 
     t = TrialSpy()
-    values = suggest_values(t, config=config)
+    values = suggest_values(t, config)
 
     assert values["n"] == 0
     name, low, high, step, log = t.calls[0]
@@ -51,13 +51,13 @@ def test_hpo_proxy_rejects_invalid_names_and_nullable_numeric_params():
         return hp.int(1, name="bad-name")
 
     with pytest.raises(ValueError, match="valid Python identifiers"):
-        suggest_values(TrialSpy(), config=bad_name)
+        suggest_values(TrialSpy(), bad_name)
 
     def nullable_int(hp: HP):
         return hp.int(None, name="depth", allow_none=True)
 
     with pytest.raises(ValueError, match="not supported"):
-        suggest_values(TrialSpy(), config=nullable_int)
+        suggest_values(TrialSpy(), nullable_int)
 
 
 def test_hpo_proxy_rejects_complex_select_choices_with_dict_guidance():
@@ -69,7 +69,7 @@ def test_hpo_proxy_rejects_complex_select_choices_with_dict_guidance():
         return hp.select([{"layers": 2}], name="model")
 
     with pytest.raises(ValueError, match="Use dict-backed select"):
-        suggest_values(CategoricalTrial(), config=config)
+        suggest_values(CategoricalTrial(), config)
 
 
 def test_hpo_proxy_rejects_unsupported_optuna_spec_fields_instead_of_ignoring_them():
@@ -77,7 +77,7 @@ def test_hpo_proxy_rejects_unsupported_optuna_spec_fields_instead_of_ignoring_th
         return hp.int(1, name="depth", min=1, max=16, hpo_spec=HpoInt(scale="log", base=2.0))
 
     with pytest.raises(ValueError, match="base"):
-        suggest_values(TrialSpy(), config=int_with_custom_log_base)
+        suggest_values(TrialSpy(), int_with_custom_log_base)
 
     def normal_float(hp: HP):
         return hp.float(
@@ -89,13 +89,13 @@ def test_hpo_proxy_rejects_unsupported_optuna_spec_fields_instead_of_ignoring_th
         )
 
     with pytest.raises(ValueError, match="normal"):
-        suggest_values(TrialSpy(), config=normal_float)
+        suggest_values(TrialSpy(), normal_float)
 
     def weighted_categorical(hp: HP):
         return hp.select(["a", "b"], name="choice", hpo_spec=HpoCategorical(weights=[0.9, 0.1]))
 
     with pytest.raises(ValueError, match="weights"):
-        suggest_values(TrialSpy(), config=weighted_categorical)
+        suggest_values(TrialSpy(), weighted_categorical)
 
 
 def test_hpo_nested_overrides_are_validated_like_instantiation_values():
@@ -107,7 +107,7 @@ def test_hpo_nested_overrides_are_validated_like_instantiation_values():
         )
 
     with pytest.raises(ValueError, match="exceeds maximum bound 10"):
-        suggest_values(TrialSpy(), config=config)
+        suggest_values(TrialSpy(), config)
 
 
 def test_hpo_nested_overrides_raise_for_unknown_child_parameters():
@@ -119,4 +119,4 @@ def test_hpo_nested_overrides_raise_for_unknown_child_parameters():
         )
 
     with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
-        suggest_values(TrialSpy(), config=config)
+        suggest_values(TrialSpy(), config)

--- a/tests/test_hpo_optuna_integration.py
+++ b/tests/test_hpo_optuna_integration.py
@@ -74,7 +74,7 @@ def model_cfg(hp: HP):
 
 def test_optuna_suggest_values_rf_branch_and_instantiate():
     trial = FakeTrial({"family": "rf", "rf.n_estimators": 200, "rf.max_depth": 12.5})
-    values = suggest_values(trial, config=model_cfg)
+    values = suggest_values(trial, model_cfg)
     assert values["family"] == "rf"
     assert values["rf.n_estimators"] == 200
     assert values["rf.max_depth"] == 12.5
@@ -89,7 +89,7 @@ def test_optuna_suggest_values_rf_branch_and_instantiate():
 
 def test_optuna_suggest_values_lr_branch_and_log_float():
     trial = FakeTrial({"family": "lr", "lr.C": 0.01, "lr.solver": "saga"})
-    values = suggest_values(trial, config=model_cfg)
+    values = suggest_values(trial, model_cfg)
     assert values["family"] == "lr"
     assert values["lr.C"] == 0.01
     assert values["lr.solver"] == "saga"
@@ -112,10 +112,35 @@ def test_nested_overrides_passed_to_child():
         )
 
     trial = FakeTrial()
-    values = suggest_values(trial, config=parent)
+    values = suggest_values(trial, parent)
     assert values["tree.depth"] == 6  # took override, no suggestion
     # no int call for tree.depth recorded
     assert not any(c for c in trial.calls if c["fn"] == "int" and c["name"] == "tree.depth")
 
     out = instantiate(parent, values=values)
     assert out == 6
+
+
+def test_optuna_suggest_values_forwards_execution_kwargs() -> None:
+    def config(hp: HP, branch: str):
+        if branch == "rf":
+            return hp.nest(rf_cfg, name="rf")
+        return hp.nest(lr_cfg, name="lr")
+
+    trial = FakeTrial({"rf.n_estimators": 150, "rf.max_depth": 8.0})
+
+    values = suggest_values(trial, config, branch="rf")
+
+    assert values == {"rf.n_estimators": 150, "rf.max_depth": 8.0}
+
+
+def test_optuna_nested_proxy_forwards_execution_kwargs() -> None:
+    def child(hp: HP, min_depth: int) -> int:
+        return hp.int(min_depth, name="depth", min=min_depth, max=10, hpo_spec=HpoInt())
+
+    def parent(hp: HP) -> int:
+        return hp.nest(child, name="tree", min_depth=4)
+
+    values = suggest_values(FakeTrial(), parent)
+
+    assert values == {"tree.depth": 4}

--- a/tests/test_instantiate_with_params.py
+++ b/tests/test_instantiate_with_params.py
@@ -36,6 +36,17 @@ def test_instantiate_with_params_returns_value_and_replayable_selected_params() 
     assert instantiate(config, values=output.params) == output.value
 
 
+def test_instantiate_with_params_forwards_execution_kwargs_without_recording_them() -> None:
+    def config(hp: HP, multiplier: int) -> Dict[str, int]:
+        base = hp.int(10, name="base")
+        return {"result": base * multiplier}
+
+    output = instantiate_with_params(config, multiplier=4)
+
+    assert output.value == {"result": 40}
+    assert output.params == {"base": 10}
+
+
 def test_instantiate_with_params_validates_on_unknown_before_execution() -> None:
     calls = []
 
@@ -44,6 +55,6 @@ def test_instantiate_with_params_validates_on_unknown_before_execution() -> None
         return {"x": hp.int(1, name="x")}
 
     with pytest.raises(ValueError, match="on_unknown must be one of"):
-        instantiate_with_params(config, on_unknown="silent")  # type: ignore[arg-type]
+        instantiate_with_params(config, on_unknown="silent")
 
     assert calls == []

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -55,6 +55,22 @@ def test_interact_forwards_execution_kwargs_to_exploration_and_instantiation() -
     assert result.params == {"base": 2}
 
 
+def test_interact_rejects_schema_control_execution_kwargs() -> None:
+    calls = []
+
+    def config(hp: HP, **execution_kwargs: object) -> Dict[str, int]:
+        calls.append(execution_kwargs)
+        return {"base": hp.int(2, name="base")}
+
+    with pytest.raises(TypeError, match=r"interact\(\) reserves return_schema="):
+        interact(config, return_schema=True)
+
+    with pytest.raises(TypeError, match=r"interact\(\) reserves return_info="):
+        interact(config, return_info=True)
+
+    assert calls == []
+
+
 def test_interact_action_updates_value_and_params() -> None:
     def openai(hp: HP) -> Dict[str, Any]:
         return {

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -44,6 +44,17 @@ def test_interact_returns_live_result_matching_instantiate_with_params() -> None
     assert result.params == expected.params
 
 
+def test_interact_forwards_execution_kwargs_to_exploration_and_instantiation() -> None:
+    def config(hp: HP, multiplier: int) -> Dict[str, int]:
+        base = hp.int(2, name="base")
+        return {"result": base * multiplier}
+
+    result = interact(config, multiplier=5)
+
+    assert result.value == {"result": 10}
+    assert result.params == {"base": 2}
+
+
 def test_interact_action_updates_value_and_params() -> None:
     def openai(hp: HP) -> Dict[str, Any]:
         return {

--- a/tests/test_nesting.py
+++ b/tests/test_nesting.py
@@ -36,8 +36,8 @@ def test_nest_with_args_kwargs() -> None:
         return base * multiplier + offset
 
     def parent(hp: HP) -> Dict[str, int]:
-        result1 = hp.nest(child, name="calc1", args=(2,))
-        result2 = hp.nest(child, name="calc2", args=(3,), kwargs={"offset": 10})
+        result1 = hp.nest(child, name="calc1", multiplier=2)
+        result2 = hp.nest(child, name="calc2", multiplier=3, offset=10)
         return {"calc1": result1, "calc2": result2}
 
     result = instantiate(parent)
@@ -121,7 +121,7 @@ def test_nested_scope_value_is_not_a_parameter_leaf() -> None:
         instantiate_with_params(parent, values={"child": 123})
 
     with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
-        explore(parent, values={"child": 123}, return_info=True)
+        explore(parent, values={"child": 123}, return_schema=True)
 
 
 def test_explicit_nested_values_raise_for_unknown_child_parameters() -> None:
@@ -135,4 +135,4 @@ def test_explicit_nested_values_raise_for_unknown_child_parameters() -> None:
         instantiate(parent)
 
     with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
-        explore(parent, return_info=True)
+        explore(parent, return_schema=True)

--- a/uv.lock
+++ b/uv.lock
@@ -388,7 +388,7 @@ wheels = [
 
 [[package]]
 name = "hypster"
-version = "0.5.3"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Implements the direct keyword **Execution Arguments** API from #46 and records it as the 0.6.0 breaking release.

Closes #46.

## Before / After

Before:

```python
run = instantiate_with_params(
    generation_graph_config,
    values=selected_config,
    kwargs={"ag_ui_writer": writer},
)

schema = explore(config, return_info=True)
values = suggest_values(trial, config=model_config)
child = hp.nest(child_config, name="child", kwargs={"default_batch_size": 256})
```

After:

```python
run = instantiate_with_params(
    generation_graph_config,
    values=selected_config,
    ag_ui_writer=writer,
)

schema = explore(config, return_schema=True)
values = suggest_values(trial, model_config)
child = hp.nest(child_config, name="child", default_batch_size=256)
```

## What Changed

- Replaced public `args=` / `kwargs=` forwarding with direct keyword execution arguments across `instantiate`, `instantiate_with_params`, `explore`, `interact`, `hp.nest`, and Optuna `suggest_values`.
- Kept removed containers guarded so old `args=` / `kwargs=` calls fail before user config code executes.
- Renamed `explore(return_info=True)` to `explore(return_schema=True)`.
- Changed Optuna `suggest_values` to `suggest_values(trial, config, **kwargs)`.
- Added behavior tests for core execution, selected params, explore, interact, nesting, and HPO.
- Updated docs, glossary, ADR, changelog, `pyproject.toml`, `src/hypster/_version.py`, and `uv.lock` for 0.6.0.

## Validation

- `uv run pytest tests/test_version.py`
- `uv run pytest`
- `uv run ruff check`
- `uv run mypy src`
- Pre-commit hook: ruff, ruff-format, whitespace/end-of-file checks, large-file check, mypy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Simplified execution-argument forwarding: removed legacy args/kwargs containers in favor of direct keyword execution arguments across the public APIs; one flag was renamed for schema retrieval; HPO helper now takes the config positionally.

* **Documentation**
  * Updated guides, examples, and reference docs and added an ADR explaining the new execution-arguments model.

* **Tests**
  * Updated and added tests to cover new calling conventions and rejection of legacy containers.

* **Chore**
  * Bumped package version and updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->