### PR TITLE
chore(deps): separate Dependabot groups and fix CodSpeed v4 config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 
-multi-ecosystem-groups:
-  weekly-dependencies:
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -9,20 +10,22 @@ multi-ecosystem-groups:
       timezone: "Etc/UTC"
     labels:
       - "dependencies"
-
-updates:
-  - package-ecosystem: "uv"
-    directory: "/"
     patterns:
       - "*"
-    multi-ecosystem-group: "weekly-dependencies"
     cooldown:
       default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+      timezone: "Etc/UTC"
+    labels:
+      - "dependencies"
+      - "github-actions"
     patterns:
       - "*"
-    multi-ecosystem-group: "weekly-dependencies"
     cooldown:
       default-days: 7

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -25,7 +25,8 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v3
+        uses: CodSpeedHQ/action@v4
         with:
+          mode: simulation
           run: uv run pytest tests/ --codspeed
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
## Summary

- stop grouping `uv` and `github-actions` updates into one multi-ecosystem Dependabot PR
- keep both ecosystems on the same weekly cadence, but let them open separately
- add a dedicated `github-actions` label for workflow/action update PRs
- make `.github/workflows/codspeed.yml` compatible with `CodSpeedHQ/action@v4` by setting an explicit `mode: simulation`

## Why

- the previous grouped PR mixed low-risk lockfile refreshes with major GitHub Action upgrades
- that made routine dependency maintenance noisy and harder to merge safely
- the same grouped PR also showed that `CodSpeedHQ/action@v4` now requires an explicit `mode`, so future action upgrades would fail without this workflow change

## Risk Review

- changed only `.github/dependabot.yml` and `.github/workflows/codspeed.yml`
- no source files, lockfile contents, package registries, permissions, or secrets changed
- the workflow change is limited to the CodSpeed action configuration and does not alter the benchmark command

## Validation

- GitHub Actions should re-run automatically for this PR after the workflow update

## Human Attention

- this PR does not take the broader GitHub Actions major-version bundle from the old Dependabot PR
- it only makes the existing CodSpeed workflow compatible with the documented v4 requirement for an explicit mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation to inline weekly schedules, labels, and patterns per update entry for clearer update handling.
  * Updated performance workflow to use the newer CodSpeed action (v4) and run in simulation mode for safer evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->