### PR TITLE
[codex] Add generic parameter metadata to schemas

### DIFF
--- a/docs/how-to/build-an-interactive-ui.md
+++ b/docs/how-to/build-an-interactive-ui.md
@@ -73,7 +73,7 @@ fields = list(flatten_fields(metadata["parameters"]))
 ```
 {% endcode %}
 
-Each field has `path`, `kind`, `default_value`, `selected_value`, optional `options`, optional `minimum`, and optional `maximum`.
+Each field has `path`, `kind`, `default_value`, `selected_value`, optional `options`, optional `minimum`, optional `maximum`, optional `description`, and optional `metadata`. Use `metadata={...}` on parameter calls for JSON-compatible hints consumed by your UI, such as editor type, audience, or tags.
 
 Schema metadata is JSON-serializable. After exploring the vector branch with values such as `{"backend": "vector", "features": ["cache", None], "retrieval.index": "embeddings-v3", "retrieval.top_k": 12, "retrieval.score_threshold": 0.35}`, the payload looks like this shape:
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -220,9 +220,10 @@ Each schema parameter contains:
 | `options` | Select or multi-select options when available. |
 | `minimum` / `maximum` | Numeric bounds when available. |
 | `description` | Optional human-readable help text from `description=`. |
+| `metadata` | Optional opaque UI/tooling hints from `metadata=`; omitted when absent or empty. |
 | `children` | Nested parameters for groups. |
 
-`ConfigSchema.to_dict()` is intended for rendering and inspection, not as a complete validation schema. It exposes the active branch, selected values, options, numeric bounds, descriptions, and nested groups. It does not currently expose every HP call option, such as `allow_none`, `options_only`, or `strict`.
+`ConfigSchema.to_dict()` is intended for rendering and inspection, not as a complete validation schema. It exposes the active branch, selected values, options, numeric bounds, descriptions, optional metadata, and nested groups. It does not currently expose every HP call option, such as `allow_none`, `options_only`, or `strict`.
 
 UI builders should use schema metadata to render controls, then round-trip user input through `explore(..., values=..., return_schema=True)` and `instantiate(..., values=...)` for authoritative validation. For dict-backed selects, `options` contains replayable keys, not mapped runtime objects.
 
@@ -232,10 +233,10 @@ All parameter names must be valid Python identifier-style strings: use letters, 
 
 {% code overflow="wrap" %}
 ```python
-hp.int(default, *, name, min=None, max=None, strict=False, allow_none=False, hpo_spec=None, description=None)
-hp.float(default, *, name, min=None, max=None, strict=False, allow_none=False, hpo_spec=None, description=None)
-hp.text(default, *, name, allow_none=False, description=None)
-hp.bool(default, *, name, allow_none=False, description=None)
+hp.int(default, *, name, min=None, max=None, strict=False, allow_none=False, hpo_spec=None, description=None, metadata=None)
+hp.float(default, *, name, min=None, max=None, strict=False, allow_none=False, hpo_spec=None, description=None, metadata=None)
+hp.text(default, *, name, allow_none=False, description=None, metadata=None)
+hp.bool(default, *, name, allow_none=False, description=None, metadata=None)
 ```
 {% endcode %}
 
@@ -248,13 +249,14 @@ hp.bool(default, *, name, allow_none=False, description=None)
 
 Use `allow_none=True` when `None` is a real scalar value.
 Numeric coercion is consistent for top-level parameters and nested paths.
+Use `metadata={...}` for opaque JSON-compatible hints that should appear on schema nodes without affecting selected values or runtime return objects.
 
 ## HP Select Methods
 
 {% code overflow="wrap" %}
 ```python
-hp.select(options, *, name, default=NO_DEFAULT, options_only=False, allow_none=False, hpo_spec=None, description=None)
-hp.multi_select(options, *, name, default=None, options_only=False, allow_none=False, description=None)
+hp.select(options, *, name, default=NO_DEFAULT, options_only=False, allow_none=False, hpo_spec=None, description=None, metadata=None)
+hp.multi_select(options, *, name, default=None, options_only=False, allow_none=False, description=None, metadata=None)
 ```
 {% endcode %}
 
@@ -291,10 +293,10 @@ By default, `options_only=False`, so custom scalar values outside the listed opt
 
 {% code overflow="wrap" %}
 ```python
-hp.multi_int(default, *, name, min=None, max=None, strict=False, allow_none=False, description=None)
-hp.multi_float(default, *, name, min=None, max=None, strict=False, allow_none=False, description=None)
-hp.multi_text(default, *, name, allow_none=False, description=None)
-hp.multi_bool(default, *, name, allow_none=False, description=None)
+hp.multi_int(default, *, name, min=None, max=None, strict=False, allow_none=False, description=None, metadata=None)
+hp.multi_float(default, *, name, min=None, max=None, strict=False, allow_none=False, description=None, metadata=None)
+hp.multi_text(default, *, name, allow_none=False, description=None, metadata=None)
+hp.multi_bool(default, *, name, allow_none=False, description=None, metadata=None)
 ```
 {% endcode %}
 

--- a/src/hypster/core.py
+++ b/src/hypster/core.py
@@ -45,6 +45,7 @@ class ParamsTracker:
         minimum: Optional[int | float] = None,
         maximum: Optional[int | float] = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.params[path] = selected_value
 

--- a/src/hypster/explore.py
+++ b/src/hypster/explore.py
@@ -66,13 +66,14 @@ class ParameterInfo:
     minimum: Optional[int | float] = None
     maximum: Optional[int | float] = None
     description: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
     children: List["ParameterInfo"] = field(default_factory=list)
 
     def is_group(self) -> bool:
         return self.kind == "group"
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        result = {
             "name": self.name,
             "path": self.path,
             "kind": self.kind,
@@ -85,6 +86,9 @@ class ParameterInfo:
             "display_label": _humanize_name(self.name),
             "children": [child.to_dict() for child in self.children],
         }
+        if self.metadata is not None:
+            result["metadata"] = self.metadata
+        return result
 
     def defaults(self) -> Dict[str, Any]:
         if self.is_group():
@@ -177,6 +181,7 @@ class SchemaTracer(HP):
         minimum: Optional[int | float] = None,
         maximum: Optional[int | float] = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         parent_path = path.rpartition(".")[0]
         container = self._schema.parameters if not parent_path else self._ensure_group_path(parent_path).children
@@ -191,6 +196,7 @@ class SchemaTracer(HP):
             minimum=minimum,
             maximum=maximum,
             description=description,
+            metadata=metadata,
         )
         existing = self._nodes_by_path.get(path)
         if existing is None:
@@ -205,6 +211,7 @@ class SchemaTracer(HP):
         existing.minimum = minimum
         existing.maximum = maximum
         existing.description = description
+        existing.metadata = metadata
 
     def build_schema(self, root_name: str) -> ConfigSchema:
         self._schema.name = root_name

--- a/src/hypster/hp.py
+++ b/src/hypster/hp.py
@@ -14,7 +14,7 @@ from .hp_calls import (
     SelectValidator,
     TextValidator,
 )
-from .utils import normalize_values, validate_identifier_name, validate_select_choice
+from .utils import normalize_values, validate_identifier_name, validate_metadata, validate_select_choice
 
 if TYPE_CHECKING:  # only for type hints; avoid runtime imports
     from .hpo.types import HpoCategorical, HpoFloat, HpoInt
@@ -35,6 +35,7 @@ class ParameterTracker(Protocol):
         minimum: Optional[Union[int, float]] = None,
         maximum: Optional[Union[int, float]] = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None: ...
 
 
@@ -97,6 +98,7 @@ class HP:
         minimum: Optional[Union[int, float]] = None,
         maximum: Optional[Union[int, float]] = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         if self.parameter_tracker is None:
             return
@@ -113,6 +115,7 @@ class HP:
                 minimum=minimum,
                 maximum=maximum,
                 description=description,
+                metadata=metadata,
             )
 
     def _record_nest(self, *, path: str, name: str, description: Optional[str] = None) -> None:
@@ -164,6 +167,7 @@ class HP:
         track_called: bool = False,
         use_validator_name: bool = True,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Any:
         full_path = self._get_full_param_path(name)
 
@@ -208,6 +212,7 @@ class HP:
         ):
             validator.validate_bounds(validated_value, min, max, full_path)
 
+        metadata = validate_metadata(metadata, param_path=full_path)
         self._record_parameter(
             path=full_path,
             name=name,
@@ -217,6 +222,7 @@ class HP:
             minimum=min,
             maximum=max,
             description=description,
+            metadata=metadata,
         )
 
         return validated_value
@@ -234,6 +240,7 @@ class HP:
         max: Optional[Union[int, float]] = None,
         allow_none: bool = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> List[Any]:
         full_path = self._get_full_param_path(name)
 
@@ -267,6 +274,7 @@ class HP:
         if min is not None or max is not None:
             multi_validator.validate_bounds(validated_values, min, max, full_path)
 
+        metadata = validate_metadata(metadata, param_path=full_path)
         self._record_parameter(
             path=full_path,
             name=name,
@@ -276,6 +284,7 @@ class HP:
             minimum=min,
             maximum=max,
             description=description,
+            metadata=metadata,
         )
 
         return validated_values
@@ -289,6 +298,7 @@ class HP:
         options_only: bool = False,
         allow_none: bool = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Any:
         validator = SelectValidator()
         full_path = self._get_full_param_path(name)
@@ -309,6 +319,7 @@ class HP:
         if found:
             validate_select_choice(value, param_path=full_path, allow_none=allow_none)
             validated_key = validator.validate_value(value, option_keys, options_only, full_path)
+            metadata = validate_metadata(metadata, param_path=full_path)
             self._record_parameter(
                 path=full_path,
                 name=name,
@@ -317,6 +328,7 @@ class HP:
                 selected_value=validated_key,
                 options=option_keys,
                 description=description,
+                metadata=metadata,
             )
             return option_map.get(validated_key, validated_key) if is_mapping else validated_key
         else:
@@ -328,6 +340,7 @@ class HP:
                 )
             validate_select_choice(actual_default, param_path=full_path, allow_none=allow_none)
             validated_key = validator.validate_value(actual_default, option_keys, options_only, full_path)
+            metadata = validate_metadata(metadata, param_path=full_path)
             self._record_parameter(
                 path=full_path,
                 name=name,
@@ -336,6 +349,7 @@ class HP:
                 selected_value=validated_key,
                 options=option_keys,
                 description=description,
+                metadata=metadata,
             )
             return option_map.get(validated_key, validated_key) if is_mapping else validated_key
 
@@ -348,6 +362,7 @@ class HP:
         options_only: bool = False,
         allow_none: bool = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> List[Any]:
         validator = SelectValidator()
         full_path = self._get_full_param_path(name)
@@ -375,6 +390,7 @@ class HP:
                 validated_key = validator.validate_value(item, option_keys, options_only, f"{full_path}[{i}]")
                 validated_keys.append(validated_key)
 
+            metadata = validate_metadata(metadata, param_path=full_path)
             self._record_parameter(
                 path=full_path,
                 name=name,
@@ -383,6 +399,7 @@ class HP:
                 selected_value=validated_keys,
                 options=option_keys,
                 description=description,
+                metadata=metadata,
             )
             return [option_map.get(k, k) for k in validated_keys] if is_mapping else validated_keys
         else:
@@ -392,6 +409,7 @@ class HP:
                 validated_key = validator.validate_value(item, option_keys, options_only, f"{full_path}[{i}]")
                 validated_keys.append(validated_key)
 
+            metadata = validate_metadata(metadata, param_path=full_path)
             self._record_parameter(
                 path=full_path,
                 name=name,
@@ -400,6 +418,7 @@ class HP:
                 selected_value=validated_keys,
                 options=option_keys,
                 description=description,
+                metadata=metadata,
             )
             return [option_map.get(k, k) for k in validated_keys] if is_mapping else validated_keys
 
@@ -418,6 +437,7 @@ class HP:
         use_validator_name: bool = True
         allow_none: bool = False
         description: Optional[str] = None
+        metadata: Optional[Dict[str, Any]] = None
 
     @dataclass(frozen=True)
     class MultiValueSpec:
@@ -431,6 +451,7 @@ class HP:
         max: Optional[Union[int, float]] = None
         allow_none: bool = False
         description: Optional[str] = None
+        metadata: Optional[Dict[str, Any]] = None
 
     @dataclass(frozen=True)
     class SelectSingleSpec:
@@ -440,6 +461,7 @@ class HP:
         options_only: bool = False
         allow_none: bool = False
         description: Optional[str] = None
+        metadata: Optional[Dict[str, Any]] = None
 
     @dataclass(frozen=True)
     class SelectMultiSpec:
@@ -449,6 +471,7 @@ class HP:
         options_only: bool = False
         allow_none: bool = False
         description: Optional[str] = None
+        metadata: Optional[Dict[str, Any]] = None
 
     # --- Unified executors ---
     def _execute_single(self, spec: "HP.SingleValueSpec") -> Any:
@@ -465,6 +488,7 @@ class HP:
             track_called=spec.track_called,
             use_validator_name=spec.use_validator_name,
             description=spec.description,
+            metadata=spec.metadata,
         )
 
     def _execute_multi(self, spec: "HP.MultiValueSpec") -> List[Any]:
@@ -479,6 +503,7 @@ class HP:
             max=spec.max,
             allow_none=spec.allow_none,
             description=spec.description,
+            metadata=spec.metadata,
         )
 
     def _execute_select_single(self, spec: "HP.SelectSingleSpec") -> Any:
@@ -489,6 +514,7 @@ class HP:
             options_only=spec.options_only,
             allow_none=spec.allow_none,
             description=spec.description,
+            metadata=spec.metadata,
         )
 
     def _execute_select_multi(self, spec: "HP.SelectMultiSpec") -> List[Any]:
@@ -499,6 +525,7 @@ class HP:
             options_only=spec.options_only,
             allow_none=spec.allow_none,
             description=spec.description,
+            metadata=spec.metadata,
         )
 
     # Composition
@@ -619,6 +646,7 @@ class HP:
         allow_none: Literal[False] = False,
         hpo_spec: "HpoInt | None" = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> int: ...
 
     @overload
@@ -633,6 +661,7 @@ class HP:
         allow_none: Literal[True],
         hpo_spec: "HpoInt | None" = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[int]: ...
 
     def _int(
@@ -646,6 +675,7 @@ class HP:
         allow_none: bool = False,
         hpo_spec: "HpoInt | None" = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[int]:
         """Integer parameter with optional bounds validation."""
         spec = HP.SingleValueSpec(
@@ -659,6 +689,7 @@ class HP:
             max=max,
             allow_none=allow_none,
             description=description,
+            metadata=metadata,
             track_called=True,
             use_validator_name=True,
         )
@@ -676,6 +707,7 @@ class HP:
         allow_none: Literal[False] = False,
         hpo_spec: "HpoFloat | None" = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> float: ...
 
     @overload
@@ -690,6 +722,7 @@ class HP:
         allow_none: Literal[True],
         hpo_spec: "HpoFloat | None" = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[float]: ...
 
     def _float(
@@ -703,6 +736,7 @@ class HP:
         allow_none: bool = False,
         hpo_spec: "HpoFloat | None" = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[float]:
         """Float parameter with optional bounds validation."""
         spec = HP.SingleValueSpec(
@@ -716,6 +750,7 @@ class HP:
             max=max,
             allow_none=allow_none,
             description=description,
+            metadata=metadata,
             track_called=True,
             use_validator_name=True,
         )
@@ -729,6 +764,7 @@ class HP:
         name: str,
         allow_none: Literal[False] = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str: ...
 
     @overload
@@ -739,6 +775,7 @@ class HP:
         name: str,
         allow_none: Literal[True],
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[str]: ...
 
     def _text(
@@ -748,6 +785,7 @@ class HP:
         name: str,
         allow_none: bool = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[str]:
         """Text parameter."""
         spec = HP.SingleValueSpec(
@@ -758,6 +796,7 @@ class HP:
             supports_strict=False,
             allow_none=allow_none,
             description=description,
+            metadata=metadata,
             track_called=True,
             use_validator_name=True,
         )
@@ -771,6 +810,7 @@ class HP:
         name: str,
         allow_none: Literal[False] = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> bool: ...
 
     @overload
@@ -781,6 +821,7 @@ class HP:
         name: str,
         allow_none: Literal[True],
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[bool]: ...
 
     def _bool(
@@ -790,6 +831,7 @@ class HP:
         name: str,
         allow_none: bool = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[bool]:
         """Boolean parameter."""
         spec = HP.SingleValueSpec(
@@ -800,6 +842,7 @@ class HP:
             supports_strict=False,
             allow_none=allow_none,
             description=description,
+            metadata=metadata,
             track_called=True,
             use_validator_name=True,
         )
@@ -815,6 +858,7 @@ class HP:
         allow_none: bool = False,
         hpo_spec: "HpoCategorical | None" = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """Selection parameter from options."""
         spec = HP.SelectSingleSpec(
@@ -824,6 +868,7 @@ class HP:
             options_only=options_only,
             allow_none=allow_none,
             description=description,
+            metadata=metadata,
         )
         return self._execute_select_single(spec)
 
@@ -837,6 +882,7 @@ class HP:
         strict: bool = False,
         allow_none: bool = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> List[int]:
         """Multi-integer parameter with optional bounds validation."""
         spec = HP.MultiValueSpec(
@@ -850,6 +896,7 @@ class HP:
             max=max,
             allow_none=allow_none,
             description=description,
+            metadata=metadata,
         )
         return self._execute_multi(spec)
 
@@ -863,6 +910,7 @@ class HP:
         strict: bool = False,
         allow_none: bool = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> List[float]:
         """Multi-float parameter with optional bounds validation."""
         spec = HP.MultiValueSpec(
@@ -876,6 +924,7 @@ class HP:
             max=max,
             allow_none=allow_none,
             description=description,
+            metadata=metadata,
         )
         return self._execute_multi(spec)
 
@@ -886,6 +935,7 @@ class HP:
         name: str,
         allow_none: bool = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> List[str]:
         """Multi-text parameter."""
         spec = HP.MultiValueSpec(
@@ -896,6 +946,7 @@ class HP:
             supports_strict=False,
             allow_none=allow_none,
             description=description,
+            metadata=metadata,
         )
         return self._execute_multi(spec)
 
@@ -906,6 +957,7 @@ class HP:
         name: str,
         allow_none: bool = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> List[bool]:
         """Multi-boolean parameter."""
         spec = HP.MultiValueSpec(
@@ -916,6 +968,7 @@ class HP:
             supports_strict=False,
             allow_none=allow_none,
             description=description,
+            metadata=metadata,
         )
         return self._execute_multi(spec)
 
@@ -928,6 +981,7 @@ class HP:
         options_only: bool = False,
         allow_none: bool = False,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> List[Any]:
         """Multi-selection parameter from options."""
         spec = HP.SelectMultiSpec(
@@ -937,6 +991,7 @@ class HP:
             options_only=options_only,
             allow_none=allow_none,
             description=description,
+            metadata=metadata,
         )
         return self._execute_select_multi(spec)
 

--- a/src/hypster/hpo/optuna.py
+++ b/src/hypster/hpo/optuna.py
@@ -11,7 +11,7 @@ except Exception:  # pragma: no cover
 from .._sentinels import NO_DEFAULT as _NO_DEFAULT
 from ..core import _handle_unknown_parameters, _reject_removed_execution_argument_containers
 from ..hp_calls import FloatValidator, IntValidator
-from ..utils import normalize_values, validate_identifier_name, validate_select_choice
+from ..utils import normalize_values, validate_identifier_name, validate_metadata, validate_select_choice
 from .types import HpoCategorical, HpoFloat, HpoInt
 
 
@@ -98,6 +98,8 @@ class _HPProxy:
         strict: bool = False,
         allow_none: bool = False,
         hpo_spec: HpoInt | None = None,
+        description: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> int:
         full = self._full(name)
         _validate_int_spec(full, hpo_spec)
@@ -119,8 +121,10 @@ class _HPProxy:
             validator = IntValidator()
             val = validator.validate_value(self.overrides[full], full, strict=strict)
             validator.validate_bounds(val, min, max, full)
+            metadata = validate_metadata(metadata, param_path=full)
             self.collector[full] = val
             return val
+        metadata = validate_metadata(metadata, param_path=full)
         low = default if min is None else min
         high = default if max is None else max
         step = hpo_spec.step if hpo_spec else None
@@ -142,6 +146,8 @@ class _HPProxy:
         strict: bool = False,
         allow_none: bool = False,
         hpo_spec: HpoFloat | None = None,
+        description: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> float:
         full = self._full(name)
         log = _float_log_flag(full, hpo_spec)
@@ -163,8 +169,10 @@ class _HPProxy:
             validator = FloatValidator()
             val = validator.validate_value(self.overrides[full], full, strict=strict)
             validator.validate_bounds(val, min, max, full)
+            metadata = validate_metadata(metadata, param_path=full)
             self.collector[full] = val
             return val
+        metadata = validate_metadata(metadata, param_path=full)
         low = default if min is None else min
         high = default if max is None else max
         step = hpo_spec.step if hpo_spec else None
@@ -182,6 +190,8 @@ class _HPProxy:
         options_only: bool = False,
         allow_none: bool = False,
         hpo_spec: HpoCategorical | None = None,
+        description: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> Any:
         full = self._full(name)
         _validate_categorical_spec(full, hpo_spec)
@@ -204,12 +214,14 @@ class _HPProxy:
                 raise ValueError(
                     f"Parameter '{full}': '{key_or_val}' not in allowed options. Available: [{options_str}]"
                 )
+            metadata = validate_metadata(metadata, param_path=full)
             if isinstance(options, Mapping) and key_or_val in options:
                 self.collector[full] = key_or_val
                 return options[key_or_val]
             self.collector[full] = key_or_val
             return key_or_val
 
+        metadata = validate_metadata(metadata, param_path=full)
         if isinstance(options, Mapping):
             key = self.trial.suggest_categorical(full, keys)
             self.collector[full] = key
@@ -226,6 +238,7 @@ class _HPProxy:
         *,
         name: str,
         values: Dict[str, Any] | None = None,
+        description: str | None = None,
         **kwargs: Any,
     ) -> Any:
         validate_identifier_name(name, kind="nest name")

--- a/src/hypster/utils.py
+++ b/src/hypster/utils.py
@@ -2,10 +2,13 @@
 
 import inspect
 import keyword
+import math
 from collections.abc import Mapping
 from difflib import SequenceMatcher
 from functools import lru_cache
 from typing import Any, Callable, Dict, List, Optional, Tuple
+
+_MAX_METADATA_DEPTH = 100
 
 
 def suggest_similar_names(unknown: str, known: List[str], threshold: float = 0.6) -> List[Tuple[str, float]]:
@@ -164,6 +167,73 @@ def _validate_select_choice_uncached(value: Any, *, param_path: str, allow_none:
         "How to fix: Use dict-backed select so the key is simple and the mapped value can be complex. "
         "Example: hp.select({'small': {'layers': 2}}, name='model')."
     )
+
+
+def validate_metadata(metadata: Any, *, param_path: str) -> Optional[Dict[str, Any]]:
+    """Validate and normalize opaque parameter metadata for schema consumers."""
+    if metadata is None:
+        return None
+    if not isinstance(metadata, Mapping):
+        raise ValueError(
+            f"Parameter '{param_path}': metadata must be a dictionary with string keys and JSON-compatible values."
+        )
+    normalized = _validate_metadata_mapping(metadata, param_path=param_path, location="metadata", depth=0)
+    return normalized or None
+
+
+def _validate_metadata_mapping(
+    metadata: Mapping[Any, Any],
+    *,
+    param_path: str,
+    location: str,
+    depth: int,
+) -> Dict[str, Any]:
+    _validate_metadata_depth(param_path=param_path, location=location, depth=depth)
+    normalized: Dict[str, Any] = {}
+    for key, value in metadata.items():
+        if not isinstance(key, str):
+            raise ValueError(
+                f"Parameter '{param_path}': {location} keys must be strings for JSON object compatibility."
+            )
+        normalized[key] = _validate_metadata_value(
+            value,
+            param_path=param_path,
+            location=f"{location}[{key!r}]",
+            depth=depth + 1,
+        )
+    return normalized
+
+
+def _validate_metadata_value(value: Any, *, param_path: str, location: str, depth: int) -> Any:
+    _validate_metadata_depth(param_path=param_path, location=location, depth=depth)
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"Parameter '{param_path}': {location} must be a finite float for JSON compatibility.")
+        return value
+    if isinstance(value, Mapping):
+        return _validate_metadata_mapping(value, param_path=param_path, location=location, depth=depth + 1)
+    if isinstance(value, (list, tuple)):
+        return [
+            _validate_metadata_value(
+                item,
+                param_path=param_path,
+                location=f"{location}[{index}]",
+                depth=depth + 1,
+            )
+            for index, item in enumerate(value)
+        ]
+    raise ValueError(
+        f"Parameter '{param_path}': {location} must be JSON-compatible (None, bool, int, float, str, list, or dict)."
+    )
+
+
+def _validate_metadata_depth(*, param_path: str, location: str, depth: int) -> None:
+    if depth > _MAX_METADATA_DEPTH:
+        raise ValueError(
+            f"Parameter '{param_path}': {location} exceeds maximum metadata nesting depth of {_MAX_METADATA_DEPTH}."
+        )
 
 
 def normalize_values(values: Optional[Mapping[str, Any]]) -> Dict[str, Any]:

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -153,6 +153,141 @@ def test_explore_includes_descriptions_and_display_labels() -> None:
     assert top_k["description"] == "Number of documents to return."
 
 
+def test_explore_includes_metadata_when_provided_and_omits_when_absent() -> None:
+    prompt_metadata = {
+        "editor": "prompt",
+        "audience": "domain_expert",
+        "tags": ["prompt", "metadata"],
+        "layout": {"rows": 12},
+        "examples": ("short", "detailed"),
+    }
+
+    def config(hp: HP) -> Dict[str, Any]:
+        metadata_prompt = hp.text(
+            "Extract concise document metadata for retrieval indexing.",
+            name="metadata_prompt",
+            description="Prompt used before chunking.",
+            metadata=prompt_metadata,
+        )
+        chunk_size = hp.int(512, name="chunk_size")
+        empty_label = hp.text("none", name="empty_label", metadata={})
+        return {"metadata_prompt": metadata_prompt, "chunk_size": chunk_size, "empty_label": empty_label}
+
+    result = hypster.instantiate(config)
+    info = explore(config, return_schema=True)
+
+    assert result == {
+        "metadata_prompt": "Extract concise document metadata for retrieval indexing.",
+        "chunk_size": 512,
+        "empty_label": "none",
+    }
+    assert info is not None
+    schema = info.to_dict()
+    prompt = schema["parameters"][0]
+    chunk_size = schema["parameters"][1]
+    empty_label = schema["parameters"][2]
+
+    assert prompt["metadata"] == {
+        "editor": "prompt",
+        "audience": "domain_expert",
+        "tags": ["prompt", "metadata"],
+        "layout": {"rows": 12},
+        "examples": ["short", "detailed"],
+    }
+    assert prompt["description"] == "Prompt used before chunking."
+    assert "metadata" not in chunk_size
+    assert "metadata" not in empty_label
+    assert json.dumps(schema)
+
+
+def test_metadata_is_available_on_all_parameter_primitives() -> None:
+    def config(hp: HP) -> Dict[str, Any]:
+        return {
+            "count": hp.int(1, name="count", metadata={"primitive": "int"}),
+            "temperature": hp.float(0.2, name="temperature", metadata={"primitive": "float"}),
+            "prompt": hp.text("hello", name="prompt", metadata={"primitive": "text"}),
+            "enabled": hp.bool(True, name="enabled", metadata={"primitive": "bool"}),
+            "mode": hp.select(["fast", "safe"], name="mode", metadata={"primitive": "select"}),
+            "layers": hp.multi_int([64, 32], name="layers", metadata={"primitive": "multi_int"}),
+            "weights": hp.multi_float([0.2, 0.8], name="weights", metadata={"primitive": "multi_float"}),
+            "labels": hp.multi_text(["a", "b"], name="labels", metadata={"primitive": "multi_text"}),
+            "flags": hp.multi_bool([True, False], name="flags", metadata={"primitive": "multi_bool"}),
+            "features": hp.multi_select(["cache", "trace"], name="features", metadata={"primitive": "multi_select"}),
+        }
+
+    info = explore(config, return_schema=True)
+
+    assert info is not None
+    assert {node["path"]: node["metadata"]["primitive"] for node in info.to_dict()["parameters"]} == {
+        "count": "int",
+        "temperature": "float",
+        "prompt": "text",
+        "enabled": "bool",
+        "mode": "select",
+        "layers": "multi_int",
+        "weights": "multi_float",
+        "labels": "multi_text",
+        "flags": "multi_bool",
+        "features": "multi_select",
+    }
+
+
+@pytest.mark.parametrize(
+    ("metadata", "match"),
+    [
+        (["prompt"], "metadata must be a dictionary"),
+        ({1: "prompt"}, "keys must be strings"),
+        ({"editor": object()}, r"metadata\['editor'\] must be JSON-compatible"),
+        ({"weight": float("inf")}, "finite float"),
+    ],
+)
+def test_metadata_must_be_json_compatible(metadata: object, match: str) -> None:
+    def config(hp: HP) -> str:
+        return hp.text("hello", name="prompt", metadata=metadata)
+
+    with pytest.raises(ValueError, match=match):
+        explore(config, return_schema=True)
+    with pytest.raises(ValueError, match=match):
+        hypster.instantiate(config)
+
+
+def test_metadata_rejects_excessive_nesting() -> None:
+    nested: Any = "leaf"
+    for _ in range(102):
+        nested = [nested]
+
+    def config(hp: HP) -> str:
+        return hp.text("hello", name="prompt", metadata={"nested": nested})
+
+    with pytest.raises(ValueError, match="maximum metadata nesting depth"):
+        explore(config, return_schema=True)
+
+
+def test_metadata_rejects_excessive_mapping_nesting() -> None:
+    nested: Any = "leaf"
+    for _ in range(60):
+        nested = {"child": nested}
+
+    def config(hp: HP) -> str:
+        return hp.text("hello", name="prompt", metadata={"nested": nested})
+
+    with pytest.raises(ValueError, match="maximum metadata nesting depth"):
+        explore(config, return_schema=True)
+
+
+def test_value_errors_are_reported_before_metadata_errors() -> None:
+    def numeric(hp: HP) -> int:
+        return hp.int(1, name="count", min=0, max=2, metadata={"bad": object()})
+
+    def categorical(hp: HP) -> str:
+        return hp.select(["a"], name="mode", options_only=True, metadata={"bad": object()})
+
+    with pytest.raises(ValueError, match="exceeds maximum"):
+        explore(numeric, values={"count": 99}, return_schema=True)
+    with pytest.raises(ValueError, match="not in allowed options"):
+        explore(categorical, values={"mode": "b"}, return_schema=True)
+
+
 def test_explore_tracks_nested_defaults_with_prefixed_paths() -> None:
     def gemini(hp: HP) -> Dict[str, Any]:
         model = hp.select(["flash-lite", "pro"], name="model", default="flash-lite")
@@ -262,7 +397,7 @@ def test_explore_validates_on_unknown_before_execution() -> None:
         return {"x": hp.int(1, name="x")}
 
     with pytest.raises(ValueError, match="on_unknown must be one of"):
-        explore(config, on_unknown="silent")  # type: ignore[arg-type]
+        explore(config, on_unknown="silent")
 
     assert calls == []
 

--- a/tests/test_hpo_optuna_edge.py
+++ b/tests/test_hpo_optuna_edge.py
@@ -110,6 +110,33 @@ def test_hpo_nested_overrides_are_validated_like_instantiation_values():
         suggest_values(TrialSpy(), config)
 
 
+def test_hpo_proxy_rejects_invalid_metadata():
+    def config(hp: HP):
+        return hp.int(1, name="depth", min=0, max=10, hpo_spec=HpoInt(), metadata={"bad": object()})
+
+    with pytest.raises(ValueError, match=r"metadata\['bad'\] must be JSON-compatible"):
+        suggest_values(TrialSpy(), config)
+
+
+def test_hpo_override_errors_are_reported_before_metadata_errors():
+    def config(hp: HP):
+        return hp.nest(
+            lambda hp: hp.int(
+                0,
+                name="depth",
+                min=0,
+                max=10,
+                hpo_spec=HpoInt(),
+                metadata={"bad": object()},
+            ),
+            name="tree",
+            values={"depth": 999},
+        )
+
+    with pytest.raises(ValueError, match="exceeds maximum bound 10"):
+        suggest_values(TrialSpy(), config)
+
+
 def test_hpo_nested_overrides_raise_for_unknown_child_parameters():
     def config(hp: HP):
         return hp.nest(

--- a/tests/test_hpo_optuna_integration.py
+++ b/tests/test_hpo_optuna_integration.py
@@ -134,6 +134,40 @@ def test_optuna_suggest_values_forwards_execution_kwargs() -> None:
     assert values == {"rf.n_estimators": 150, "rf.max_depth": 8.0}
 
 
+def test_optuna_proxy_accepts_metadata_on_supported_parameter_calls() -> None:
+    def config(hp: HP):
+        n = hp.int(
+            1,
+            name="n",
+            min=0,
+            max=10,
+            hpo_spec=HpoInt(),
+            description="Trial-backed integer.",
+            metadata={"ui": "slider"},
+        )
+        x = hp.float(
+            0.1,
+            name="x",
+            min=0.0,
+            max=1.0,
+            hpo_spec=HpoFloat(),
+            description="Trial-backed float.",
+            metadata={"ui": "number"},
+        )
+        choice = hp.select(
+            ["a", "b"],
+            name="choice",
+            hpo_spec=HpoCategorical(),
+            description="Trial-backed choice.",
+            metadata={"ui": "radio"},
+        )
+        return {"n": n, "x": x, "choice": choice}
+
+    values = suggest_values(FakeTrial({"n": 3, "x": 0.4, "choice": "b"}), config)
+
+    assert values == {"n": 3, "x": 0.4, "choice": "b"}
+
+
 def test_optuna_nested_proxy_forwards_execution_kwargs() -> None:
     def child(hp: HP, min_depth: int) -> int:
         return hp.int(min_depth, name="depth", min=min_depth, max=10, hpo_spec=HpoInt())


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add JSON-friendly parameter metadata to schema nodes
<code>✨ Enhancement</code> <code>🧪 Tests</code> <code>📝 Documentation</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Summary

Adds a generic, JSON-friendly `metadata=` channel to HyPSTER parameter primitives and preserves it on reachable schema nodes from `explore(..., return_schema=True).to_dict()`.

Closes #57.

## Before / After

Before, schema nodes could expose labels, descriptions, defaults, selected values, options, and bounds, but downstream tools had no opaque hint channel:

```python
metadata_prompt = hp.text(
    "Extract concise document metadata for retrieval indexing.",
    name="metadata_prompt",
    description="Prompt used before chunking.",
)
```

After, all normal parameter primitives accept `metadata=`. The value is validated as JSON-friendly data, normalized, omitted when absent or empty, and does not affect runtime selected values:

```python
metadata_prompt = hp.text(
    "Extract concise document metadata for retrieval indexing.",
    name="metadata_prompt",
    description="Prompt used before chunking.",
    metadata={
        "editor": "prompt",
        "audience": "domain_expert",
        "tags": ["prompt", "metadata"],
    },
)

schema = explore(config, return_schema=True).to_dict()
assert schema["parameters"][0]["metadata"] == {
    "editor": "prompt",
    "audience": "domain_expert",
    "tags": ["prompt", "metadata"],
}
```

## Details

- Threads normalized metadata through `HP` parameter tracking into `ParameterInfo` and schema serialization.
- Adds metadata validation for string-keyed dictionaries containing JSON-compatible scalars, lists/tuples, and nested dictionaries.
- Treats empty metadata as absent and guards excessive nesting with a clear `ValueError`.
- Keeps runtime instantiation semantics unchanged; metadata is a schema/tooling side channel.
- Allows the Optuna proxy to accept and validate metadata so annotated configs continue to work with HPO suggestion flows.
- Documents the new schema field and parameter signatures.

## Validation

- `pre-commit` hooks during commit: ruff, ruff-format, whitespace/end-of-file checks, mypy
- `uv run pytest` passed: 127 tests
- Earlier package check: `uv run mypy src` passed

Note: `uv run mypy src tests` still reports existing negative-test typing patterns unrelated to this change.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add optional <b><i>metadata=</i></b> to all HP parameter primitives for UI/tooling hints.
• Validate/normalize metadata as JSON-compatible data and omit when empty.
• Preserve metadata through explore schema serialization and Optuna HPO proxy.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
A["HP parameter calls"] --> B["utils.validate_metadata"] --> C["ParameterTracker.record_parameter"] --> D["SchemaTracer / ParameterInfo"] --> E["ConfigSchema.to_dict()"]
A --> F["Optuna _HPProxy"] --> B
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Validate via json.dumps instead of structural checks</b></summary>

- ➕ Less custom validation code to maintain
- ➕ Matches the exact serializer used by downstream tools
- ➖ Error messages typically less precise (harder to pinpoint failing path)
- ➖ Doesn&#x27;t enforce string keys explicitly unless interpreted from JSON output
- ➖ May still allow undesired types that stringify unexpectedly (e.g., custom repr fallback)

</details>

<details>
<summary><b>2. Allow opaque metadata without runtime validation</b></summary>

- ➕ Zero runtime overhead and fewer breaking errors for users
- ➕ Maximum flexibility for advanced tooling
- ➖ Schema consumers can fail later with harder-to-debug errors
- ➖ Inconsistent behavior across explore/instantiate/HPO paths if each serializes differently

</details>

<details>
<summary><b>3. Add metadata only to schema tracer (explore), not instantiate</b></summary>

- ➕ Keeps runtime instantiation path strict and minimal
- ➕ Avoids potential behavior changes for users who only instantiate
- ➖ Developers often call instantiate() during development; invalid metadata would go unnoticed
- ➖ Splits semantics across APIs (same config behaves differently under explore vs instantiate)

</details>

**Recommendation:** Keep the PR’s approach: validate and normalize metadata at the HP call site and thread it through schema + HPO. This provides consistent semantics across instantiate/explore/suggest_values, ensures metadata is truly JSON-friendly (including finite floats and bounded nesting), and keeps schema output deterministic by omitting empty metadata.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (5)</summary>

<blockquote>
<details>
<summary><strong>core.py</strong> <code>Widen parameter tracking hook to accept metadata</code> <code>+1/-0</code></summary>

<br/>

>Widen parameter tracking hook to accept metadata
>
><pre>
>• Extends &#x27;ParamsTracker.record_parameter(...)&#x27; signature with an optional &#x27;metadata&#x27; argument. Tracking behavior remains unchanged (still stores selected values by path).
></pre>
>
><a href='https://github.com/gilad-rubin/hypster/pull/58/files#diff-744b3231a08b859513d9e2c12839b605512b37e0fa9fb181f62f044f5785530b'>src/hypster/core.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>explore.py</strong> <code>Persist and serialize metadata on schema nodes</code> <code>+8/-1</code></summary>

<br/>

>Persist and serialize metadata on schema nodes
>
><pre>
>• Adds &#x27;metadata&#x27; to &#x27;ParameterInfo&#x27; and threads it through &#x27;SchemaTracer.record_parameter&#x27;. &#x27;ParameterInfo.to_dict()&#x27; now conditionally emits &#x27;metadata&#x27; when non-null.
></pre>
>
><a href='https://github.com/gilad-rubin/hypster/pull/58/files#diff-c9c4ec44377ba46756a8c522d3343dd19588b552791638c6b44d14e1f44966bc'>src/hypster/explore.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>hp.py</strong> <code>Add &#x27;metadata=&#x27; to HP primitives and validate it</code> <code>+56/-1</code></summary>

<br/>

>Add &#x27;metadata=&#x27; to HP primitives and validate it
>
><pre>
>• Extends all scalar, multi-value, and select primitives (plus executor specs) to accept &#x27;metadata&#x27;. Normalizes/validates metadata via &#x27;validate_metadata(...)&#x27; and records it alongside other schema fields without affecting selected values.
></pre>
>
><a href='https://github.com/gilad-rubin/hypster/pull/58/files#diff-07bbf59242839ef4ca88484271abea59ad4bfdb8c77a5369d4f937837dba7b79'>src/hypster/hp.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>optuna.py</strong> <code>Support metadata validation in Optuna proxy calls</code> <code>+14/-1</code></summary>

<br/>

>Support metadata validation in Optuna proxy calls
>
><pre>
>• Adds &#x27;description&#x27; and &#x27;metadata&#x27; parameters to Optuna-backed &#x27;int/float/select&#x27; proxy methods and validates metadata consistently. Ensures override/validation errors surface before metadata errors where applicable.
></pre>
>
><a href='https://github.com/gilad-rubin/hypster/pull/58/files#diff-72cba0a7c4e7f69176281a35fec8fd78784687f69696c957193ad6dc98f9a471'>src/hypster/hpo/optuna.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>utils.py</strong> <code>Introduce JSON-compatible metadata validator with depth guard</code> <code>+70/-0</code></summary>

<br/>

>Introduce JSON-compatible metadata validator with depth guard
>
><pre>
>• Implements &#x27;validate_metadata(...)&#x27; to enforce string-keyed mappings with JSON-compatible values, normalizing tuples to lists and rejecting non-finite floats. Adds a maximum nesting depth to prevent pathological structures and returns &#x27;None&#x27; for empty metadata.
></pre>
>
><a href='https://github.com/gilad-rubin/hypster/pull/58/files#diff-e0a66d7fbf615b5d38acde454a9b1e525d07977d698ac3892da81e7c4c0750c6'>src/hypster/utils.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>test_explore.py</strong> <code>Add schema/instantiate tests for metadata behavior</code> <code>+123/-0</code></summary>

<br/>

>Add schema/instantiate tests for metadata behavior
>
><pre>
>• Adds coverage that metadata is preserved in schema output, omitted when absent/empty, and JSON-serializable. Tests metadata availability across all primitives and validates error ordering and invalid metadata cases (types, keys, floats, nesting).
></pre>
>
><a href='https://github.com/gilad-rubin/hypster/pull/58/files#diff-789440ddeb8b34b4830eec99f087aaff0d33e39045a2f5f904509d65a30add07'>tests/test_explore.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>test_hpo_optuna_edge.py</strong> <code>Add Optuna proxy edge-case tests for metadata validation</code> <code>+27/-0</code></summary>

<br/>

>Add Optuna proxy edge-case tests for metadata validation
>
><pre>
>• Ensures the HPO proxy rejects invalid metadata and that value/override errors are raised before metadata validation errors when both would fail.
></pre>
>
><a href='https://github.com/gilad-rubin/hypster/pull/58/files#diff-378fcf49a3f97c57c1abd8593d2c76bec9b716b6646c7618160705d7a40f4562'>tests/test_hpo_optuna_edge.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>test_hpo_optuna_integration.py</strong> <code>Verify Optuna suggest_values accepts metadata on supported calls</code> <code>+34/-0</code></summary>

<br/>

>Verify Optuna suggest_values accepts metadata on supported calls
>
><pre>
>• Adds an integration test confirming &#x27;suggest_values(...)&#x27; works when &#x27;metadata=&#x27; is provided on trial-backed &#x27;int&#x27;, &#x27;float&#x27;, and &#x27;select&#x27; parameters.
></pre>
>
><a href='https://github.com/gilad-rubin/hypster/pull/58/files#diff-462b32c0dc18a90a35d2ee79033d16291ed207f072e29011403e535e51d4ec97'>tests/test_hpo_optuna_integration.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>build-an-interactive-ui.md</strong> <code>Document schema field &#x27;metadata&#x27; for UI rendering</code> <code>+1/-1</code></summary>

<br/>

>Document schema field &#x27;metadata&#x27; for UI rendering
>
><pre>
>• Updates the interactive UI guide to mention &#x27;description&#x27; and new &#x27;metadata&#x27; fields on schema nodes. Adds guidance to use &#x27;metadata={...}&#x27; for JSON-compatible UI hints.
></pre>
>
><a href='https://github.com/gilad-rubin/hypster/pull/58/files#diff-4df93d89cebf4be3dab290ea9fbe3bbdcb2e1fa808756c0cfe38b5e1b44245b3'>docs/how-to/build-an-interactive-ui.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>api.md</strong> <code>Extend public API docs with &#x27;metadata=&#x27; and schema field</code> <code>+13/-11</code></summary>

<br/>

>Extend public API docs with &#x27;metadata=&#x27; and schema field
>
><pre>
>• Documents the new &#x27;metadata&#x27; field in ParameterInfo and clarifies it is omitted when absent/empty. Updates HP method signatures to include &#x27;metadata=None&#x27; and adds usage guidance.
></pre>
>
><a href='https://github.com/gilad-rubin/hypster/pull/58/files#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797'>docs/reference/api.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional metadata argument to parameter constructors and schema nodes for passing JSON-compatible UI/tooling hints (no effect on returned values).

* **Documentation**
  * Updated guides and API reference to document metadata usage, serialization, and omission when empty.

* **Validation**
  * Metadata is validated for JSON compatibility and nesting limits; invalid metadata yields clear, location-aware errors.

* **Tests**
  * Added unit and integration tests covering metadata propagation, validation, and HPO integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->