### PR TITLE
Add metadata= to hp.nest: group-level metadata on the explore schema

### DIFF
--- a/docs/in-depth/nest.md
+++ b/docs/in-depth/nest.md
@@ -33,6 +33,7 @@ hp.nest(
     *,
     name,
     values=None,
+    metadata=None,
     **kwargs,
 )
 ```
@@ -43,6 +44,7 @@ hp.nest(
 | `child` | Config function whose first parameter is `hp`. |
 | `name` | Scope name. Must be a valid Python identifier. |
 | `values` | Child-local values merged into the nested call. |
+| `metadata` | Opaque JSON-compatible hints recorded on the nested group's schema node. |
 | `**kwargs` | Execution arguments forwarded to the child. |
 
 ## Child-Local Values
@@ -145,6 +147,25 @@ This value raises by default because `settings.threads` is unreachable on the `r
 instantiate(app_config, values={"backend": "remote", "settings.threads": 8})
 ```
 {% endcode %}
+
+## Group Metadata
+
+`metadata=` attaches opaque, JSON-compatible hints to the nested group itself — the same mechanism `metadata=` provides on parameter calls, one level up. `explore(..., return_schema=True)` records it on the group's schema node, where a form renderer can read it; it never affects instantiation, selected params, or replay.
+
+{% code overflow="wrap" %}
+```python
+def retriever(hp: HP) -> dict:
+    return {"top_k": hp.int(5, name="top_k")}
+
+def pipeline(hp: HP) -> dict:
+    return hp.nest(retriever, name="retriever", metadata={"ui": "sidebar"})
+
+schema = explore(pipeline, return_schema=True)
+schema.parameters[0].metadata  # {"ui": "sidebar"}
+```
+{% endcode %}
+
+Invalid (non-JSON-compatible) metadata raises a `ValueError` naming the offending key, at `explore` and `instantiate` alike.
 
 ## Name Collisions
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -328,12 +328,13 @@ hp.nest(
     name,
     values=None,
     description=None,
+    metadata=None,
     **kwargs,
 )
 ```
 {% endcode %}
 
-Executes another config function under a named path.
+Executes another config function under a named path. Use `metadata={...}` for opaque JSON-compatible hints that appear on the nested group's schema node, matching `metadata=` on the parameter calls.
 
 {% code overflow="wrap" %}
 ```python

--- a/src/hypster/explore.py
+++ b/src/hypster/explore.py
@@ -165,9 +165,18 @@ class SchemaTracer(HP):
             self._schema = tracker._schema
             self._nodes_by_path = tracker._nodes_by_path
 
-    def record_nest(self, *, path: str, name: str, description: Optional[str] = None) -> None:
+    def record_nest(
+        self,
+        *,
+        path: str,
+        name: str,
+        description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
         group = self._ensure_group(path, name)
         group.description = description
+        if metadata is not None:
+            group.metadata = metadata
 
     def record_parameter(
         self,

--- a/src/hypster/hp.py
+++ b/src/hypster/hp.py
@@ -118,13 +118,20 @@ class HP:
                 metadata=metadata,
             )
 
-    def _record_nest(self, *, path: str, name: str, description: Optional[str] = None) -> None:
+    def _record_nest(
+        self,
+        *,
+        path: str,
+        name: str,
+        description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
         if self.parameter_tracker is None:
             return
 
         record = getattr(self.parameter_tracker, "record_nest", None)
         if callable(record):
-            record(path=path, name=name, description=description)
+            record(path=path, name=name, description=description, metadata=metadata)
 
     def _get_value_for_param(self, name: str) -> tuple[Any, bool]:
         """Get value for parameter, returns (value, found)."""
@@ -536,6 +543,7 @@ class HP:
         name: str,
         values: Optional[Dict[str, Any]] = None,
         description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> Any:
         """Nest another configuration function."""
@@ -574,8 +582,10 @@ class HP:
         if explicit_values:
             nested_values.update(explicit_values)
 
+        metadata = validate_metadata(metadata, param_path=full_path)
+
         # Create new HP instance for nested call with namespace
-        self._record_nest(path=full_path, name=name, description=description)
+        self._record_nest(path=full_path, name=name, description=description, metadata=metadata)
 
         nested_hp = self.__class__(nested_values, parameter_tracker=self.parameter_tracker)
         nested_hp.namespace_stack = self.namespace_stack + [name]

--- a/tests/test_nesting.py
+++ b/tests/test_nesting.py
@@ -136,3 +136,88 @@ def test_explicit_nested_values_raise_for_unknown_child_parameters() -> None:
 
     with pytest.raises(ValueError, match="Unknown or unreachable parameters"):
         explore(parent, return_schema=True)
+
+
+def test_nest_metadata_appears_on_group_node() -> None:
+    """Metadata passed to hp.nest lands on the group ParameterInfo in the explored schema."""
+
+    def child(hp: HP) -> Dict[str, int]:
+        return {"x": hp.int(10, name="x")}
+
+    def parent(hp: HP) -> Dict[str, int]:
+        return hp.nest(child, name="child", metadata={"ui": True})
+
+    info = explore(parent, return_schema=True)
+
+    assert info is not None
+    group = info.parameters[0]
+    assert group.is_group()
+    assert group.metadata == {"ui": True}
+
+
+def test_nest_metadata_changes_the_explored_schema() -> None:
+    """Falsifier: two different metadata dicts must produce two different schema outputs."""
+
+    def child(hp: HP) -> Dict[str, int]:
+        return {"x": hp.int(10, name="x")}
+
+    def parent(hp: HP, nest_metadata: Dict[str, Any]) -> Dict[str, int]:
+        return hp.nest(child, name="child", metadata=nest_metadata)
+
+    schema_a = explore(parent, return_schema=True, nest_metadata={"ui": "wizard"})
+    schema_b = explore(parent, return_schema=True, nest_metadata={"ui": "sidebar"})
+
+    assert schema_a is not None and schema_b is not None
+    group_a = schema_a.to_dict()["parameters"][0]
+    group_b = schema_b.to_dict()["parameters"][0]
+    assert group_a["metadata"] == {"ui": "wizard"}
+    assert group_b["metadata"] == {"ui": "sidebar"}
+    assert group_a["metadata"] != group_b["metadata"]
+
+
+def test_nest_without_metadata_leaves_group_metadata_unset() -> None:
+    def child(hp: HP) -> Dict[str, int]:
+        return {"x": hp.int(10, name="x")}
+
+    def parent(hp: HP) -> Dict[str, int]:
+        return hp.nest(child, name="child")
+
+    info = explore(parent, return_schema=True)
+
+    assert info is not None
+    group = info.parameters[0]
+    assert group.is_group()
+    assert group.metadata is None
+    assert "metadata" not in info.to_dict()["parameters"][0]
+
+
+def test_nest_metadata_must_be_json_compatible() -> None:
+    def child(hp: HP) -> Dict[str, int]:
+        return {"x": hp.int(10, name="x")}
+
+    def parent(hp: HP) -> Dict[str, int]:
+        return hp.nest(child, name="child", metadata={"editor": object()})
+
+    with pytest.raises(ValueError, match=r"metadata\['editor'\] must be JSON-compatible"):
+        explore(parent, return_schema=True)
+
+    with pytest.raises(ValueError, match=r"metadata\['editor'\] must be JSON-compatible"):
+        instantiate(parent)
+
+
+def test_nest_metadata_does_not_affect_selected_params_or_replay() -> None:
+    def child(hp: HP) -> Dict[str, int]:
+        return {"x": hp.int(10, name="x")}
+
+    def parent_plain(hp: HP) -> Dict[str, int]:
+        return hp.nest(child, name="child")
+
+    def parent_with_metadata(hp: HP) -> Dict[str, int]:
+        return hp.nest(child, name="child", metadata={"ui": True})
+
+    plain = instantiate_with_params(parent_plain)
+    with_metadata = instantiate_with_params(parent_with_metadata)
+
+    assert with_metadata.params == plain.params
+    assert with_metadata.value == plain.value
+    assert instantiate(parent_with_metadata, values=with_metadata.params) == with_metadata.value


### PR DESCRIPTION
## What

`hp.nest(child, name=..., metadata={...})` — opaque, JSON-compatible hints recorded on the nested **group's** schema node, mirroring the `metadata=` that parameter calls already support. `explore(..., return_schema=True)` exposes it via the group's `ParameterInfo.metadata` / `to_dict()`; form renderers read it for group-level UI hints (e.g. `{"ui": "sidebar"}`).

- Validated with the existing `validate_metadata` — a non-JSON-compatible value raises a `ValueError` naming the key, at `explore` and `instantiate` alike.
- Instantiation, selected params, and replay are unaffected (asserted byte-identical with and without metadata).
- Docs: `HP.nest` signature + argument row in `reference/api.md`, a new **Group Metadata** section in `in-depth/nest.md`.

## Testing

- 5 new tests in `tests/test_nesting.py`, including the behavioral falsifier: two different metadata dicts must produce two **different explored schemas** (not merely record a call).
- Full suite: 170 passed. `pre-commit` (ruff, ruff-format, whitespace, mypy) green on every changed file.

## Context

This is the second half of the working-tree WIP deliberately split out of #72 (`hp.schema`): the two features share no code path, so they land as separate reviewable units.