### PR TITLE
fix(react): stale editingIndex when list mutations cross the edited row

### DIFF
--- a/packages/react/src/use-rules-field.ts
+++ b/packages/react/src/use-rules-field.ts
@@ -49,6 +49,8 @@ export function useRulesField({
   const removeRule = (index: number) => {
     onChange(rules.filter((_, i) => i !== index));
     if (editingIndex === index) setEditingIndex(null);
+    else if (editingIndex !== null && editingIndex > index)
+      setEditingIndex(editingIndex - 1);
   };
 
   const addRule = () => {

--- a/packages/react/src/use-schema-field.ts
+++ b/packages/react/src/use-schema-field.ts
@@ -57,7 +57,12 @@ export function useSchemaField({
     if (!moved) return;
     next.splice(to, 0, moved);
     onChange(next);
+    if (editingIndex === null) return;
     if (editingIndex === from) setEditingIndex(to);
+    else if (from < editingIndex && to >= editingIndex)
+      setEditingIndex(editingIndex - 1);
+    else if (from > editingIndex && to <= editingIndex)
+      setEditingIndex(editingIndex + 1);
   };
 
   return {


### PR DESCRIPTION
## What

Fixes the stale-`editingIndex` bug class in the React hooks, in both places it exists:

**`useSchemaField.moveField`** — flagged independently by three review bots on #72. The hook repaired `editingIndex` only when the *moved* row was the edited one; a move that crossed over the edited row shifted it silently:

```ts
// fields [A, B, C], user is editing B (editingIndex = 1)
moveField(0, 2)   // drag A to the end -> [B, C, A]
// editingIndex stayed 1 -> the open editor now points at C
```

Now `editingIndex` shifts by ∓1 when `from`/`to` straddle it — mirroring the logic `removeField` already had.

**`useRulesField.removeRule`** — the same class one hook over: removing a rule *above* the edited one left `editingIndex` one row off. Two-line repair, identical to what `useSchemaField.removeField` already does correctly.

## Testing

The react package has no test harness (build = `tsc` only, verified clean). The fix is behavior-preserving for all non-crossing mutations; the crossing cases are enumerated in the diff — each branch is a one-line index shift.

## Context

Closes out the substantive bot finding from #72 review chatter.