### PR TITLE
docs: close six seeded coverage gaps (FieldSpec ops, partial, branch-conditional on_unknown, metadata, ConfigFunc, ADR nav)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -69,3 +69,5 @@
 * [Origin Story](philosophy/origin-story.md)
 * [Articles](philosophy/articles.md)
 * [ADR: Strict Unknown Values](adr/0001-strict-unknown-values.md)
+* [ADR: Interactive Snapshot and Modern Notebook Renderer](adr/0002-interactive-snapshot-and-modern-notebook-renderer.md)
+* [ADR: Direct Keyword Execution Arguments](adr/0003-direct-keyword-execution-arguments.md)

--- a/docs/in-depth/hp-call-types/README.md
+++ b/docs/in-depth/hp-call-types/README.md
@@ -46,3 +46,29 @@ For `hp.rules`, declare condition and payload fields with `hypster.field` and us
 * Numeric parameters reject `True` and `False` even though Python treats `bool` as a subclass of `int`.
 
 See [Public API](../../reference/api.md) for exact signatures.
+
+## Custom Metadata On A Basic Parameter
+
+Every basic `hp.*` call accepts `metadata={...}` for opaque, JSON-compatible hints. `explore(..., return_schema=True)` carries them straight to that parameter's schema node, unread and unvalidated beyond JSON-compatibility:
+
+{% code overflow="wrap" %}
+```python
+from hypster import HP, explore
+
+def app_config(hp: HP) -> dict:
+    tier = hp.select(
+        ["basic", "advanced"],
+        name="tier",
+        default="basic",
+        metadata={"ui_group": "advanced", "help_url": "https://example.com/docs/tier"},
+    )
+    return {"tier": tier}
+
+schema = explore(app_config, return_schema=True)
+param = schema.to_dict()["parameters"][0]
+
+assert param["metadata"] == {"ui_group": "advanced", "help_url": "https://example.com/docs/tier"}
+```
+{% endcode %}
+
+This is the same `metadata=` mechanism `hp.nest(..., metadata=...)` uses for a nested group's schema node — see [Nested Configurations](../nest.md) for the group-level form.

--- a/docs/in-depth/hp-call-types/rules.md
+++ b/docs/in-depth/hp-call-types/rules.md
@@ -72,10 +72,56 @@ Use `field.*` constructors to declare the condition vocabulary and payload shape
 | `field.select(options, name=...)` | Single categorical condition field. |
 | `field.multi_select(options, name=...)` | Multi-value categorical condition field. |
 | `field.bool(name=...)` | Boolean condition or payload field. |
+| `field.multi_bool(name=...)` | Multi-value boolean field. |
 | `field.text(name=..., multiline=False)` | Text payloads, including prompt blocks. |
+| `field.multi_text(name=...)` | List-of-text payload field. |
 | `field.int(name=...)` / `field.float(name=...)` | Numeric condition or payload fields. |
+| `field.multi_int(name=...)` / `field.multi_float(name=...)` | List-of-numeric payload fields. |
 
 Field specs are schema declarations, not selected params. They appear in `explore(..., return_schema=True)` under the rules parameter metadata so UIs can render the rule builder.
+
+## FieldSpec Methods And Default Operators
+
+Every `field.*` constructor returns a `FieldSpec` with a fixed `type`. That `type` picks a default `operators` tuple, and each `FieldSpec` method builds a `Leaf` using one specific operator string. The method name and the operator string it writes are not always the same word:
+
+| Method | Leaf operator built | Available on default operators for |
+| --- | --- | --- |
+| `.eq(value)` | `"="` | `select`, `int`, `float`, `text` |
+| `.neq(value)` | `"!="` | `select`, `int`, `float` |
+| `.is_in(values)` | `"in"` | `select`, `multi_select`, `multi_bool`, `multi_int`, `multi_float`, `multi_text` |
+| `.not_in(values)` | `"not_in"` | `select`, `multi_select` |
+| `.is_true()` | `"is"` with value `True` | `bool` |
+| `.is_false()` | `"is"` with value `False` | `bool` |
+| `.gt(value)` | `">"` | `int`, `float` |
+| `.lt(value)` | `"<"` | `int`, `float` |
+| `.contains(value)` | `"contains"` | `text`, `multi_int`, `multi_float`, `multi_text` |
+
+Default operators per type (`FieldSpec.operators`, populated from each `field.*` constructor):
+
+| Type | Default `operators` |
+| --- | --- |
+| `select` | `=`, `!=`, `in`, `not_in` |
+| `multi_select` | `in`, `not_in` |
+| `bool` | `is` |
+| `multi_bool` | `in` |
+| `int` | `>`, `<`, `=`, `!=` |
+| `multi_int` | `in`, `contains` |
+| `float` | `>`, `<`, `=`, `!=` |
+| `multi_float` | `in`, `contains` |
+| `text` | `=`, `contains` |
+| `multi_text` | `in`, `contains` |
+
+`.is_true()` and `.is_false()` both build an `"is"` leaf, differing only in the boolean value. There is no `.neq_in()`; the negated-membership method is `.not_in(values)`.
+
+`FieldSpec` methods do not check the `operators` tuple before building a `Leaf`. Calling a method whose operator is outside the type's own default list (for example `.gt(...)` on a `field.text(...)`) still returns a `Leaf` with that operator string instead of raising:
+
+```python
+from hypster import field
+
+label = field.text(name="label")
+label.gt("x")
+# Leaf(field='label', operator='>', value='x')
+```
 
 ## Composite Payloads
 

--- a/docs/in-depth/values-and-overrides.md
+++ b/docs/in-depth/values-and-overrides.md
@@ -135,6 +135,46 @@ Use `explore(model_config, values={"family": "forest"})` to inspect the branch b
 
 Prefer the default for experiments and production replay. Softer policies are useful when migrating old payloads or rendering exploratory UIs.
 
+### Conditional Options Under Each Policy
+
+A later `hp.select`'s option list can depend on an earlier one, so a parameter name can exist in one branch and not another. Overriding a parameter that only exists in a branch you did not take is the same "unreachable" case as above, worked through under each `on_unknown` policy:
+
+{% code overflow="wrap" %}
+```python
+from hypster import HP, instantiate
+
+def pipeline_config(hp: HP) -> dict:
+    stage = hp.select(["ingest", "transform"], name="stage", default="ingest", options_only=True)
+    if stage == "ingest":
+        source = hp.select(["csv", "json"], name="source", default="csv", options_only=True)
+        return {"stage": stage, "source": source}
+    else:
+        strategy = hp.select(["normalize", "aggregate"], name="strategy", default="normalize", options_only=True)
+        return {"stage": stage, "strategy": strategy}
+```
+{% endcode %}
+
+Taking the `"ingest"` branch and overriding `strategy` — a parameter that only exists on the untaken `"transform"` branch:
+
+{% code overflow="wrap" %}
+```python
+# on_unknown="raise" (default): raises
+instantiate(pipeline_config, values={"stage": "ingest", "strategy": "aggregate"})
+# ValueError: Unknown or unreachable parameters
+
+# on_unknown="warn": warns, then returns the ingest branch's own default for "source"
+instantiate(pipeline_config, values={"stage": "ingest", "strategy": "aggregate"}, on_unknown="warn")
+# UserWarning: Unknown or unreachable parameters
+# => {"stage": "ingest", "source": "csv"}
+
+# on_unknown="ignore": same result, no warning
+instantiate(pipeline_config, values={"stage": "ingest", "strategy": "aggregate"}, on_unknown="ignore")
+# => {"stage": "ingest", "source": "csv"}
+```
+{% endcode %}
+
+Under `"warn"` and `"ignore"`, the override for the untaken branch is dropped, not redirected or coerced onto the active branch: the active branch (`"ingest"`) still resolves `source` to its own default, `"csv"`. Nothing about `strategy="aggregate"` leaks into the result.
+
 ## Select Keys vs Complex Values
 
 Nested dictionaries inside `values=` are interpreted as nested parameter paths. If you need a select option whose runtime value is a dictionary, use dict-backed `select`:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -295,7 +295,7 @@ hp.bool(default, *, name, allow_none=False, description=None, metadata=None)
 
 Use `allow_none=True` when `None` is a real scalar value.
 Numeric coercion is consistent for top-level parameters and nested paths.
-Use `metadata={...}` for opaque JSON-compatible hints that should appear on schema nodes without affecting selected values or runtime return objects; see [Custom Metadata On A Basic Parameter](../in-depth/hp-call-types/README.md#custom-metadata-on-a-basic-parameter) for the worked example.
+Use `metadata={...}` for opaque JSON-compatible hints that should appear on schema nodes without affecting selected values or runtime return objects; see [HP Call Types](../in-depth/hp-call-types/README.md) for the worked example.
 Use `hp.text(..., multiline=True)` for prompt blocks and other long text; schemas record this as `metadata={"multiline": True}` so UIs can render a larger editor.
 
 ## HP Select Methods
@@ -426,7 +426,7 @@ def config(hp: HP) -> list[Rule[str]]:
 
 The config return value contains `Rule` objects. Selected params contain JSON-friendly dictionaries suitable for logging and replay. `explore(..., return_schema=True)` records rules as `kind="rules"` with `metadata["field_specs"]`, `metadata["then_specs"]`, and `metadata["combinators"]` for notebook and custom UI renderers.
 
-For the `FieldSpec` condition-builder methods (`.eq`, `.is_in`, `.gt`, …) and each field type's default operators, see [FieldSpec Methods And Default Operators](../in-depth/hp-call-types/rules.md#fieldspec-methods-and-default-operators).
+For the `FieldSpec` condition-builder methods (`.eq`, `.is_in`, `.gt`, …) and each field type's default operators, see [Rules](../in-depth/hp-call-types/rules.md).
 
 ## HP.schema
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -7,13 +7,16 @@ This page lists the public API exposed by `hypster`.
 from hypster import (
     HP,
     And,
+    ConfigFunc,
     FieldSpec,
     Group,
+    InstantiationOutput,
     InteractiveResult,
     Leaf,
     Not,
     Or,
     Rule,
+    SchemaField,
     explore,
     field,
     instantiate,
@@ -22,6 +25,8 @@ from hypster import (
 )
 ```
 {% endcode %}
+
+`hypster.__version__` is the installed package version string.
 
 ## Config Function Contract
 
@@ -290,7 +295,7 @@ hp.bool(default, *, name, allow_none=False, description=None, metadata=None)
 
 Use `allow_none=True` when `None` is a real scalar value.
 Numeric coercion is consistent for top-level parameters and nested paths.
-Use `metadata={...}` for opaque JSON-compatible hints that should appear on schema nodes without affecting selected values or runtime return objects.
+Use `metadata={...}` for opaque JSON-compatible hints that should appear on schema nodes without affecting selected values or runtime return objects; see [Custom Metadata On A Basic Parameter](../in-depth/hp-call-types/README.md#custom-metadata-on-a-basic-parameter) for the worked example.
 Use `hp.text(..., multiline=True)` for prompt blocks and other long text; schemas record this as `metadata={"multiline": True}` so UIs can render a larger editor.
 
 ## HP Select Methods
@@ -421,6 +426,8 @@ def config(hp: HP) -> list[Rule[str]]:
 
 The config return value contains `Rule` objects. Selected params contain JSON-friendly dictionaries suitable for logging and replay. `explore(..., return_schema=True)` records rules as `kind="rules"` with `metadata["field_specs"]`, `metadata["then_specs"]`, and `metadata["combinators"]` for notebook and custom UI renderers.
 
+For the `FieldSpec` condition-builder methods (`.eq`, `.is_in`, `.gt`, …) and each field type's default operators, see [FieldSpec Methods And Default Operators](../in-depth/hp-call-types/rules.md#fieldspec-methods-and-default-operators).
+
 ## HP.schema
 
 {% code overflow="wrap" %}
@@ -474,3 +481,5 @@ def config(hp: HP):
     return hp.collect(locals(), exclude=["helper"])
 ```
 {% endcode %}
+
+For `include=`/`exclude=` usage in context, see [Select Return Values](../getting-started/selecting-output-variables.md).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -27,6 +27,8 @@ from hypster import (
 
 A config function must be callable and its first positional parameter must be named `hp`. A keyword-only `hp` parameter is rejected before the config executes because Hypster passes the `HP` object positionally.
 
+`ConfigFunc` is the `Protocol` type for this contract, exported from `hypster` for annotating functions, variables, or parameters that accept a config function.
+
 Config functions are pure Python, not a DSL. `instantiate()`, `explore()`, `interact()`, and the HPO adapter all execute the function to discover or select values, so public API calls inherit any side effects or expensive work in the function body.
 
 {% code overflow="wrap" %}
@@ -41,6 +43,30 @@ def config(hp: HP) -> int:
 The `hp: HP` annotation is recommended but not mandatory. If the first parameter has a type annotation, it must include `HP`. Callable objects are supported when `inspect.signature()` can read their `__call__` signature; signature validation errors use the class name.
 
 Reference examples use small return values for compactness. In application docs and production code, the usual pattern is to return the initialized object your application will use.
+
+### functools.partial-Wrapped Config Functions
+
+Config functions may be wrapped with `functools.partial` to pre-bind execution arguments. Hypster validates the signature with `inspect.signature()`, which reads through a `partial` object to the underlying function's signature, so `hp` is still recognized as the first parameter:
+
+{% code overflow="wrap" %}
+```python
+from functools import partial
+from hypster import HP, instantiate_with_params
+
+def training_config(hp: HP, *, dataset_size: int) -> dict:
+    batch_size = hp.int(32, name="batch_size", min=1)
+    epochs = hp.int(10, name="epochs", min=1)
+    return {"batch_size": batch_size, "epochs": epochs, "dataset_size": dataset_size}
+
+bound_config = partial(training_config, dataset_size=50_000)
+run = instantiate_with_params(bound_config, values={"batch_size": 64})
+
+assert run.value == {"batch_size": 64, "epochs": 10, "dataset_size": 50000}
+assert run.params == {"batch_size": 64, "epochs": 10}
+```
+{% endcode %}
+
+`dataset_size` is bound by `partial`, not selected through `hp.*`, so it is passed through to the return value but does not appear in `run.params`.
 
 Config functions may accept extra keyword-only execution arguments. Pass those directly; Hypster-owned names such as `values`, `on_unknown`, `return_schema`, `auto_apply`, `name`, and `description` are reserved at their API boundaries.
 


### PR DESCRIPTION
## Summary

Docs-only round closing six seeded gaps plus two self-found gaps. No src/tests/packages changes.

- **FieldSpec method/operator table** — `docs/in-depth/hp-call-types/rules.md`: every `FieldSpec` method (`.eq`, `.neq`, `.is_in`, `.not_in`, `.is_true`, `.is_false`, `.gt`, `.lt`, `.contains`) mapped to the `Leaf` operator string it builds, plus the full `DEFAULT_OPERATORS` table per type. Also documents an observed behavior: `FieldSpec` methods do not validate against the type's own `operators` tuple (e.g. `field.text(...).gt(...)` builds a `Leaf` with `">"` even though `text`'s default operators are only `=`/`contains`).
- **functools.partial-wrapped config functions** — `docs/reference/api.md`: verified `inspect.signature()` reads through `partial` to the wrapped function, so config functions can be partially applied with extra execution kwargs pre-bound. Worked example shows the bound kwarg does not appear in `run.params`.
- **Branch-conditional `on_unknown` behavior** — `docs/in-depth/values-and-overrides.md`: worked multi-branch example (`hp.select` picking between two child branches with disjoint parameter names) showing `"raise"`/`"warn"`/`"ignore"` behavior when overriding a parameter that only exists on the untaken branch.
- **Custom metadata on a basic param, round-tripped through schema** — `docs/in-depth/hp-call-types/README.md`: `hp.select(..., metadata={...})` read back via `explore(..., return_schema=True)`, linked to the existing `hp.nest(..., metadata=...)` group-level example in `docs/in-depth/nest.md`.
- **`ConfigFunc` Protocol** — one-line mention in `docs/reference/api.md`'s Config Function Contract section (it had zero doc mentions before this).
- **ADR nav gap** — `docs/SUMMARY.md`: ADR 0002 and ADR 0003 existed on disk but weren't linked from the table of contents; added alongside the existing ADR 0001 entry.
- **`hp.collect` findability** — investigated, found already nav-reachable (`docs/getting-started/selecting-output-variables.md`, `docs/in-depth/basic-best-practices.md`, `docs/in-depth/hp-call-types/README.md`, `docs/reference/api.md`); no fix needed, noted as a stale premise in the report.
- **Orphaned docs audit** — 6 confirmed redirect stubs, 1 intentionally-hidden GitBook cards page, 1 substantive-but-fully-superseded page (`docs/in-depth/performing-hyperparameter-optimization.md`) — flagged only, not touched (out of scope per brief).

## Test plan

- [x] Every new code snippet run standalone against this checkout before being copied into a doc (see ledger in the completion report)
- [x] `uv run pre-commit run --files <changed files>` — clean
- [x] `git diff --check` — clean
- [x] `git status` — docs-only changes, no stray files

Full gap dispositions, snippet ledger, and bug findings are in the session's completion report (not duplicated here to avoid drift between the two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)