### PR TITLE
Post-merge review fixes: warning attribution, name validation, release hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,10 @@ jobs:
     steps:
       - name: Require master
         if: github.ref != 'refs/heads/master'
+        env:
+          REF: ${{ github.ref }}
         run: |
-          echo "::error::Releases are dispatched from master only (got ${{ github.ref }})."
+          echo "::error::Releases are dispatched from master only (got $REF)."
           exit 1
 
       - uses: actions/checkout@v6.0.2
@@ -48,8 +50,10 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$ ]]; then
-            echo "::error::Invalid version format: $VERSION"
+          # Stable versions only: PEP 440 normalizes prerelease names (0.9.0-alpha.1
+          # -> 0.9.0a1) so raw prerelease input would break filename-based gating.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version: $VERSION. This workflow releases stable X.Y.Z versions only."
             exit 1
           fi
 
@@ -174,10 +178,14 @@ jobs:
 
       # pypa's action performs Trusted Publishing via OIDC and generates
       # PEP 740 attestations for the uploaded files by default.
+      # skip-existing lets a rerun recover when PyPI accepted the files but a
+      # later job failed; the github-release job re-verifies the published
+      # hashes, so a silent skip can never tag bytes PyPI does not have.
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          skip-existing: true
 
   github-release:
     # Tag + public release happen only after PyPI accepted the same bytes.
@@ -194,6 +202,43 @@ jobs:
         with:
           name: dist-${{ inputs.version }}
           path: dist
+
+      - name: Verify PyPI serves exactly the bytes we built
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          import time
+          import urllib.request
+
+          version = os.environ["VERSION"]
+          local = {}
+          with open("dist/SHA256SUMS") as fh:
+              for line in fh:
+                  digest, name = line.split()
+                  name = name.lstrip("./")
+                  if name != "SHA256SUMS":
+                      local[name] = digest
+
+          data = None
+          for _ in range(12):
+              try:
+                  with urllib.request.urlopen(f"https://pypi.org/pypi/hypster/{version}/json") as resp:
+                      data = json.load(resp)
+                  break
+              except Exception:
+                  time.sleep(10)
+          assert data is not None, f"PyPI never served metadata for {version}"
+
+          remote = {u["filename"]: u["digests"]["sha256"] for u in data["urls"]}
+          for name, digest in local.items():
+              assert name in remote, f"{name} missing from PyPI"
+              assert remote[name] == digest, f"{name}: PyPI has {remote[name]}, we built {digest}"
+          print(f"PyPI serves the exact bytes we built: {sorted(local)}")
+          PY
 
       - name: Extract changelog section
         env:

--- a/src/hypster/_execution.py
+++ b/src/hypster/_execution.py
@@ -39,8 +39,19 @@ def reject_reserved_execution_arguments(
     raise TypeError(f"{api_name} reserves {names} for Hypster execution controls. {guidance}")
 
 
-def handle_unknown_parameters(provided_values: Dict[str, Any], called_params: set[str], on_unknown: str) -> None:
-    """Handle unknown or unreachable parameters based on on_unknown setting."""
+def handle_unknown_parameters(
+    provided_values: Dict[str, Any],
+    called_params: set[str],
+    on_unknown: str,
+    *,
+    stacklevel: int = 3,
+) -> None:
+    """Handle unknown or unreachable parameters based on on_unknown setting.
+
+    ``stacklevel`` must make the warning point at USER code: pass the number of
+    frames between ``warnings.warn`` and the user's call site (this function
+    counts as 1).
+    """
     if on_unknown == "ignore":
         return
 
@@ -68,4 +79,4 @@ def handle_unknown_parameters(provided_values: Dict[str, Any], called_params: se
     if on_unknown == "raise":
         raise ValueError(error_message)
     elif on_unknown == "warn":
-        warnings.warn(error_message, UserWarning, stacklevel=3)
+        warnings.warn(error_message, UserWarning, stacklevel=stacklevel)

--- a/src/hypster/core.py
+++ b/src/hypster/core.py
@@ -116,7 +116,8 @@ def _run_config(
 
     result = func(hp, **kwargs)
     leaf_params = hp.called_params - hp.nested_scope_paths
-    handle_unknown_parameters(normalized_values, leaf_params, on_unknown)
+    # stacklevel 4: warn -> here -> public entry point (instantiate/explore/...) -> user code
+    handle_unknown_parameters(normalized_values, leaf_params, on_unknown, stacklevel=4)
     return result
 
 

--- a/src/hypster/hp.py
+++ b/src/hypster/hp.py
@@ -183,14 +183,20 @@ class HP:
             hpo_spec=hpo_spec,
         )
 
-    def _register_param(self, name: Optional[str], full_path: str) -> None:
-        """Validate a parameter name and register it as called."""
+    def _register_param(self, name: Optional[str]) -> str:
+        """Validate a parameter name, register it as called, and return its full path.
+
+        Name validation must run before path construction: joining the
+        namespace stack with a non-string name would raise a raw TypeError.
+        """
         if name is None:
-            raise HPCallError(full_path, "requires 'name' for overrides. How to fix: pass name='...'")
+            raise HPCallError("<unnamed>", "requires 'name' for overrides. How to fix: pass name='...'")
         validate_identifier_name(name, kind="parameter name")
+        full_path = self._get_full_param_path(name)
         if full_path in self.called_params:
             raise HPCallError(full_path, "has already been defined")
         self.called_params.add(full_path)
+        return full_path
 
     def _require_default(self, default: Any, full_path: str, param_type: str, name: str) -> None:
         if default is _NO_DEFAULT:
@@ -216,8 +222,7 @@ class HP:
         description: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        full_path = self._get_full_param_path(name)
-        self._register_param(name, full_path)
+        full_path = self._register_param(name)
         self._require_default(default, full_path, param_type, name)
 
         if default is None and not allow_none:
@@ -285,8 +290,7 @@ class HP:
         description: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> List[Any]:
-        full_path = self._get_full_param_path(name)
-        self._register_param(name, full_path)
+        full_path = self._register_param(name)
         self._require_default(default, full_path, param_type, name)
 
         if allow_none:
@@ -332,8 +336,7 @@ class HP:
         description: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        full_path = self._get_full_param_path(name)
-        self._register_param(name, full_path)
+        full_path = self._register_param(name)
 
         is_mapping = isinstance(options, Mapping)
         adapter = OptionsAdapter(options=options)
@@ -393,8 +396,7 @@ class HP:
         description: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> List[Any]:
-        full_path = self._get_full_param_path(name)
-        self._register_param(name, full_path)
+        full_path = self._register_param(name)
 
         is_mapping = isinstance(options, Mapping)
         adapter = OptionsAdapter(options=options)
@@ -441,12 +443,12 @@ class HP:
         **kwargs: Any,
     ) -> Any:
         """Nest another configuration function."""
-        full_path = self._get_full_param_path(name)
-
-        # Validate name
+        # Validate the name before building the path: joining the namespace
+        # stack with a non-string name would raise a raw TypeError.
         if name is None:
-            raise HPCallError(full_path, "requires 'name' for nesting")
+            raise HPCallError("<unnamed>", "requires 'name' for nesting")
         validate_identifier_name(name, kind="nest name")
+        full_path = self._get_full_param_path(name)
 
         # Disallow nesting under a prefix that already has parameters defined by the parent
         # but allow repeated nesting with the same name to surface duplicate param errors later
@@ -902,8 +904,7 @@ class HP:
         ``then`` is a FieldSpec (or type shorthand) for the payload widget.
         ``combinators`` controls the tier: ["and"] for simple, ["and","or","not"] for full.
         """
-        full_path = self._get_full_param_path(name)
-        self._register_param(name, full_path)
+        full_path = self._register_param(name)
 
         if combinators is None:
             combinators = ["and"]
@@ -954,8 +955,7 @@ class HP:
         metadata: Optional[Dict[str, Any]] = None,
     ) -> list:
         """Schema parameter — a list of SchemaField extraction field definitions."""
-        full_path = self._get_full_param_path(name)
-        self._register_param(name, full_path)
+        full_path = self._register_param(name)
 
         value, found = self._get_value_for_param(name)
         schema_value = coerce_schema_fields(value if found else (default or []))

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -145,3 +145,41 @@ def test_nested_values_unknown_keys_participate_in_on_unknown() -> None:
     assert "model.lerning_rate" in error
     assert "model.learning_rate" in error
     assert "Nested dict values are interpreted as parameter paths" in error
+
+
+def test_nest_with_none_name_raises_friendly_error() -> None:
+    """name=None must hit HPCallError validation, not a raw TypeError from path joining."""
+
+    def child(hp: HP) -> Dict[str, float]:
+        return {"lr": hp.float(0.1, name="lr")}
+
+    def config(hp: HP) -> Dict[str, float]:
+        return hp.nest(child, name=None)
+
+    with pytest.raises(ValueError, match="requires 'name' for nesting"):
+        instantiate(config)
+
+
+def test_nested_param_with_none_name_raises_friendly_error() -> None:
+    """Inside a nested scope, name=None used to crash joining the namespace stack."""
+
+    def child(hp: HP) -> float:
+        return hp.float(0.1, name=None)
+
+    def config(hp: HP) -> float:
+        return hp.nest(child, name="inner")
+
+    with pytest.raises(ValueError, match="requires 'name' for overrides"):
+        instantiate(config)
+
+
+def test_unknown_parameter_warning_points_at_user_code() -> None:
+    """The UserWarning must be attributed to the caller of instantiate(), not hypster internals."""
+
+    def config(hp: HP) -> Dict[str, float]:
+        return {"lr": hp.float(0.1, name="learning_rate")}
+
+    with pytest.warns(UserWarning) as records:
+        instantiate(config, values={"lerning_rate": 0.05}, on_unknown="warn")
+
+    assert records[0].filename == __file__


### PR DESCRIPTION
Addresses the three CodeRabbit findings left on #77 after it merged, plus two findings Greptile raised on the equivalent hypernote workflow (gilad-rubin/hypernote#22) that apply to ours verbatim.

## User-facing fixes
- `instantiate(..., on_unknown="warn")` warnings now point at **your** code, not `hypster/core.py` (new test asserts the attribution).
- `hp.nest(child, name=None)` and `hp.float(0.1, name=None)` inside a nested scope now raise the friendly `requires 'name'` error instead of `TypeError: sequence item 1: expected str instance, NoneType found`.

## Release workflow hardening
- `${{ github.ref }}` no longer interpolated into shell (injection vector → env var).
- Version input restricted to stable `X.Y.Z` — PEP 440 normalization (`0.9.0-alpha.1` → `0.9.0a1`) would otherwise break filename-based gating.
- `skip-existing: true` + a post-publish step that verifies PyPI serves byte-identical files to our `SHA256SUMS` before tagging: a rerun after a failed release job can now recover, and a silent skip can never tag bytes PyPI doesn't have.

190 tests green (3 new), ruff/mypy clean, workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)