### PR TITLE
Add the real VS Code Desktop host spike

### DIFF
--- a/.github/workflows/vscode-host.yml
+++ b/.github/workflows/vscode-host.yml
@@ -1,0 +1,161 @@
+name: VS Code host spike
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  kernel-selection-spike:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      HYPSTER_NOTEBOOK: ${{ github.workspace }}/tests/jupyterlab_host/branch_round_trip.ipynb
+      HYPSTER_VSCODE_ARTIFACT_DIR: ${{ github.workspace }}/host-evidence/vscode
+      HYPSTER_VSCODE_RUNTIME_DIR: ${{ runner.temp }}/hypster-vscode-runtime
+      HYPSTER_VSCODE_KERNEL_ENV: ${{ runner.temp }}/hypster-vscode-kernel
+      HYPSTER_VSCODE_KERNEL_PREFIX: ${{ runner.temp }}/hypster-vscode-kernels
+      JUPYTER_PATH: ${{ runner.temp }}/hypster-vscode-kernels/share/jupyter
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.8"
+          enable-cache: true
+          python-version: "3.13.13"
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24.18.0"
+          cache: npm
+          cache-dependency-path: tests/vscode_host/package-lock.json
+
+      - name: Select exact Node.js and npm runtime
+        run: |
+          test "$(node --version)" = "v24.18.0"
+          npm install --global npm@11.16.0
+          node tests/vscode_host/scripts/assert-runtime.cjs
+
+      - name: Install Electron host libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2t64 libgbm1 libgtk-3-0 libnss3 xvfb
+
+      - name: Install locked harness
+        working-directory: tests/vscode_host
+        run: |
+          node scripts/assert-runtime.cjs
+          npm ci --ignore-scripts
+          npm run check
+
+      - name: Build repository wheel
+        run: uv build --wheel --out-dir dist
+
+      - name: Create isolated installed-wheel kernel
+        run: |
+          set -euo pipefail
+          WHEEL=$(find "$GITHUB_WORKSPACE/dist" -maxdepth 1 -name '*.whl' -print -quit)
+          test -n "$WHEEL"
+          uv venv --python 3.13.13 "$HYPSTER_VSCODE_KERNEL_ENV"
+          uv pip install \
+            --python "$HYPSTER_VSCODE_KERNEL_ENV/bin/python" \
+            --requirement tests/jupyterlab_host/kernel-requirements.lock \
+            "${WHEEL}[viz]"
+          uv pip check --python "$HYPSTER_VSCODE_KERNEL_ENV/bin/python"
+          "$HYPSTER_VSCODE_KERNEL_ENV/bin/python" -m ipykernel install \
+            --prefix "$HYPSTER_VSCODE_KERNEL_PREFIX" \
+            --name hypster-host \
+            --display-name "Hypster host test"
+          mkdir -p host-evidence/vscode
+          WHEEL_SHA256=$(sha256sum "$WHEEL" | cut -d ' ' -f 1)
+          WHEEL_SHA256="$WHEEL_SHA256" "$HYPSTER_VSCODE_KERNEL_ENV/bin/python" - <<'PY'
+          import importlib.metadata
+          import json
+          import os
+          import platform
+          import sys
+          from pathlib import Path
+
+          import hypster
+
+          hypster_path = Path(hypster.__file__).resolve()
+          assert "site-packages" in hypster_path.parts, hypster_path
+          evidence = {
+              "python": sys.version,
+              "executable": sys.executable,
+              "platform": platform.platform(),
+              "hypster_import_path": str(hypster_path),
+              "wheel_sha256": os.environ["WHEEL_SHA256"],
+              "packages": {
+                  name: importlib.metadata.version(name)
+                  for name in [
+                      "hypster",
+                      "anywidget",
+                      "ipykernel",
+                      "ipywidgets",
+                      "jupyterlab-widgets",
+                  ]
+              },
+          }
+          Path("host-evidence/vscode/kernel-environment.json").write_text(
+              json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+          )
+          PY
+
+      - name: Capture setup versions
+        run: |
+          {
+            uname -a
+            cat /etc/os-release
+            node --version
+            npm --version
+            uv --version
+            dpkg-query -W xvfb
+          } > host-evidence/vscode/setup.txt
+
+      - name: Reproduce kernel-selection spike in real VS Code Desktop
+        working-directory: tests/vscode_host
+        run: |
+          unset PYTHONPATH
+          node scripts/assert-runtime.cjs
+          timeout --signal=TERM --kill-after=30s 8m xvfb-run -a npm test
+
+      - name: Capture VS Code and Jupyter logs
+        if: always()
+        run: |
+          mkdir -p host-evidence/vscode/vscode-logs
+          if [ -d "$HYPSTER_VSCODE_RUNTIME_DIR/user-data/logs" ]; then
+            cp -R "$HYPSTER_VSCODE_RUNTIME_DIR/user-data/logs/." host-evidence/vscode/vscode-logs/
+          fi
+
+      - name: Terminate and verify host processes
+        if: always()
+        run: |
+          set +e
+          pkill -TERM -f "$HYPSTER_VSCODE_RUNTIME_DIR"
+          pkill -TERM -f "$HYPSTER_VSCODE_KERNEL_ENV"
+          sleep 2
+          pkill -KILL -f "$HYPSTER_VSCODE_RUNTIME_DIR"
+          pkill -KILL -f "$HYPSTER_VSCODE_KERNEL_ENV"
+          set -e
+          if pgrep -af "$HYPSTER_VSCODE_RUNTIME_DIR|$HYPSTER_VSCODE_KERNEL_ENV" \
+            > host-evidence/vscode/process-cleanup.txt; then
+            cat host-evidence/vscode/process-cleanup.txt
+            exit 1
+          fi
+          echo "No VS Code, Electron, Chromium, or kernel process remains" \
+            > host-evidence/vscode/process-cleanup.txt
+
+      - name: Upload VS Code spike evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: vscode-host-spike-${{ github.run_id }}
+          path: host-evidence/vscode/
+          if-no-files-found: error

--- a/.github/workflows/vscode-host.yml
+++ b/.github/workflows/vscode-host.yml
@@ -15,14 +15,17 @@ jobs:
     env:
       HYPSTER_NOTEBOOK: ${{ github.workspace }}/tests/jupyterlab_host/branch_round_trip.ipynb
       HYPSTER_VSCODE_ARTIFACT_DIR: ${{ github.workspace }}/host-evidence/vscode
-      HYPSTER_VSCODE_RUNTIME_DIR: ${{ runner.temp }}/hypster-vscode-runtime
-      HYPSTER_VSCODE_KERNEL_ENV: ${{ runner.temp }}/hypster-vscode-kernel
-      HYPSTER_VSCODE_KERNEL_PREFIX: ${{ runner.temp }}/hypster-vscode-kernels
-      JUPYTER_PATH: ${{ runner.temp }}/hypster-vscode-kernels/share/jupyter
     steps:
       - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
+
+      - name: Configure isolated runtime paths
+        run: |
+          echo "HYPSTER_VSCODE_RUNTIME_DIR=$RUNNER_TEMP/hypster-vscode-runtime" >> "$GITHUB_ENV"
+          echo "HYPSTER_VSCODE_KERNEL_ENV=$RUNNER_TEMP/hypster-vscode-kernel" >> "$GITHUB_ENV"
+          echo "HYPSTER_VSCODE_KERNEL_PREFIX=$RUNNER_TEMP/hypster-vscode-kernels" >> "$GITHUB_ENV"
+          echo "JUPYTER_PATH=$RUNNER_TEMP/hypster-vscode-kernels/share/jupyter" >> "$GITHUB_ENV"
 
       - uses: astral-sh/setup-uv@v8.1.0
         with:

--- a/.github/workflows/vscode-host.yml
+++ b/.github/workflows/vscode-host.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           echo "HYPSTER_VSCODE_RUNTIME_DIR=$RUNNER_TEMP/hypster-vscode-runtime" >> "$GITHUB_ENV"
           echo "HYPSTER_VSCODE_KERNEL_ENV=$RUNNER_TEMP/hypster-vscode-kernel" >> "$GITHUB_ENV"
+          echo "HYPSTER_VSCODE_PYTHON=$RUNNER_TEMP/hypster-vscode-kernel/bin/python" >> "$GITHUB_ENV"
           echo "HYPSTER_VSCODE_KERNEL_PREFIX=$RUNNER_TEMP/hypster-vscode-kernels" >> "$GITHUB_ENV"
           echo "JUPYTER_PATH=$RUNNER_TEMP/hypster-vscode-kernels/share/jupyter" >> "$GITHUB_ENV"
 

--- a/tests/vscode_host/.gitignore
+++ b/tests/vscode_host/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.vscode-test/

--- a/tests/vscode_host/README.md
+++ b/tests/vscode_host/README.md
@@ -27,6 +27,9 @@ boundary:
 
 The Ubuntu witness determines the outcome rather than assuming it in advance:
 
+- if the pinned Jupyter extension activates but VS Code does not register the
+  documented `notebook.selectKernel` command, the artifact reports
+  `kernel_selection_gate_failure`;
 - if both supported commands fulfill but the creation marker is absent while
   the cell has no execution summary and zero outputs, the cell never executed;
   the artifact reports `kernel_selection_gate_failure` and the job may complete

--- a/tests/vscode_host/README.md
+++ b/tests/vscode_host/README.md
@@ -27,26 +27,43 @@ boundary:
 
 The harness determines the outcome rather than assuming it in advance:
 
-- if the pinned Jupyter extension activates but VS Code does not register the
-  documented `notebook.selectKernel` command, the artifact reports
-  `kernel_selection_gate_failure`;
-- once the command is registered, a rejected or timed-out selector/execution
-  command, any creation-marker timeout, any execution summary, or any
-  non-marker output is a red `runtime_failure`. An empty cell at the marker
-  deadline is inconclusive because uncancelled execution may still start;
+- if the pinned Jupyter extension exposes neither its public `openNotebook`
+  API nor the documented `notebook.selectKernel` command after activation, the
+  artifact reports `kernel_selection_gate_failure`;
+- once either supported selection route is available, a rejected or timed-out
+  selection/execution request, any creation-marker timeout, any execution
+  summary, or any non-marker output is a red `runtime_failure`. An empty cell at
+  the marker deadline is inconclusive because uncancelled execution may still
+  start;
 - if the creation marker appears, every later renderer, messaging, or Python
   oracle failure—including verification-command rejection or timeout—is a red
   `runtime_failure`;
 - only the complete renderer-to-Python round trip reports
   `basic_scenario_green`.
 
-The exact pinned witness completed in
+The first exact pinned witness completed in
 [workflow run 29192874852](https://github.com/gilad-rubin/hypster/actions/runs/29192874852).
 After explicit activation, Microsoft Jupyter `2025.9.1` did not register the
 documented `notebook.selectKernel` command in VS Code Desktop `1.128.0`. The
 uploaded evidence therefore records `kernel_selection_gate_failure`, with no
 round-trip attempt and complete process cleanup. [`SPIKE_FAILURE.md`](SPIKE_FAILURE.md)
-is the verified root-owned follow-up payload for the missing supported seam.
+captures that verified historical observation.
+
+## Supported exported seam
+
+Follow-up source review found a supported route that does not require the
+missing built-in command or copying Jupyter's private controller IDs. In pinned
+Jupyter `2025.9.1`, the extension's public, non-breaking API exports
+`openNotebook(uri, pythonEnvironment)`. Jupyter's own smoke test resolves an
+exact executable with `PythonExtension.api().environments.resolveEnvironment()`
+and passes the resolved environment to that export.
+
+The harness now follows that same path first. It pins
+`@vscode/python-extension==1.0.6`, records both facade/export keys, requires the
+resolved executable to equal the isolated installed-wheel Python, and calls
+`jupyterApi.openNotebook()` before cell execution. The command-based route is
+only a fallback when the public export is absent. A new Ubuntu witness is still
+required to prove the full renderer-to-Python round trip.
 
 ## Before / after
 
@@ -71,6 +88,7 @@ real VS Code 1.128.0 Electron on Ubuntu/Xvfb
 
 - Node.js `24.18.0`
 - npm `11.16.0`
+- `@vscode/python-extension==1.0.6`
 - `@vscode/test-electron==3.0.0`
 - VS Code Desktop `1.128.0`
 - Microsoft Python `2026.4.0` (stable)
@@ -106,6 +124,11 @@ outputs.
 - [VS Code API](https://code.visualstudio.com/api/references/vscode-api)
   documents that an extension may create messaging only for a renderer it
   contributes; it exposes no foreign-controller discovery API.
+- [Jupyter 2025.9.1 public API](https://github.com/microsoft/vscode-jupyter/blob/v2025.9.1/src/standalone/api/index.ts)
+  exports `openNotebook` and forbids breaking changes to the extension API.
+- [Jupyter 2025.9.1 smoke test](https://github.com/microsoft/vscode-jupyter/blob/v2025.9.1/src/test/smoke/datascience.smoke.test.ts)
+  resolves an exact Python environment through the official Python-extension
+  facade before calling `jupyterExt.exports.openNotebook`.
 
 ## Local structural proof
 
@@ -128,5 +151,6 @@ timeout --signal=TERM --kill-after=30s 8m xvfb-run -a npm test
 ```
 
 Required absolute environment variables are `HYPSTER_NOTEBOOK`,
-`HYPSTER_VSCODE_ARTIFACT_DIR`, and `HYPSTER_VSCODE_RUNTIME_DIR`. The workflow
-also supplies `JUPYTER_PATH` pointing at the isolated clean-kernel prefix.
+`HYPSTER_VSCODE_ARTIFACT_DIR`, `HYPSTER_VSCODE_RUNTIME_DIR`, and
+`HYPSTER_VSCODE_PYTHON`. The workflow also supplies `JUPYTER_PATH` pointing at
+the isolated clean-kernel prefix.

--- a/tests/vscode_host/README.md
+++ b/tests/vscode_host/README.md
@@ -58,12 +58,25 @@ Jupyter `2025.9.1`, the extension's public, non-breaking API exports
 exact executable with `PythonExtension.api().environments.resolveEnvironment()`
 and passes the resolved environment to that export.
 
-The harness now follows that same path first. It pins
+The harness follows that same path first. It pins
 `@vscode/python-extension==1.0.6`, records both facade/export keys, requires the
 resolved executable to equal the isolated installed-wheel Python, and calls
 `jupyterApi.openNotebook()` before cell execution. The command-based route is
-only a fallback when the public export is absent. A new Ubuntu witness is still
-required to prove the full renderer-to-Python round trip.
+only a fallback when the public export is absent.
+
+The second exact witness in
+[workflow run 29193331802](https://github.com/gilad-rubin/hypster/actions/runs/29193331802)
+proved that path through the clean kernel: the Python facade resolved the exact
+isolated executable, `openNotebook` fulfilled, and the creation cell imported
+Hypster from `site-packages`. The run then stayed correctly red because Jupyter
+refused an interactive widget-CDN prompt in its test host.
+
+Jupyter's own standard and widget tests avoid that prompt by globally setting
+`jupyter.widgetScriptSources` to exactly `['jsdelivr.com', 'unpkg.com']`. The
+harness now writes that supported setting before activating Jupyter or creating
+the widget, records its global and effective values, and fails if either value
+differs. A new Ubuntu witness is still required to prove the full
+renderer-to-Python round trip.
 
 ## Before / after
 
@@ -129,6 +142,9 @@ outputs.
 - [Jupyter 2025.9.1 smoke test](https://github.com/microsoft/vscode-jupyter/blob/v2025.9.1/src/test/smoke/datascience.smoke.test.ts)
   resolves an exact Python environment through the official Python-extension
   facade before calling `jupyterExt.exports.openNotebook`.
+- [Jupyter 2025.9.1 standard widget test](https://github.com/microsoft/vscode-jupyter/blob/v2025.9.1/src/test/datascience/widgets/standardWidgets.vscode.common.test.ts)
+  sets `widgetScriptSources` globally to `jsdelivr.com` and `unpkg.com` before
+  initializing widgets in CI.
 
 ## Local structural proof
 

--- a/tests/vscode_host/README.md
+++ b/tests/vscode_host/README.md
@@ -1,0 +1,125 @@
+# VS Code Desktop host spike
+
+This harness exercises issue #98's two explicit spike gates against a real,
+exactly pinned VS Code Desktop Electron process on Ubuntu/Xvfb.
+
+## Runtime outcomes
+
+The renderer gate has a supported implementation. The probe contributes a
+renderer whose entrypoint extends `jupyter-ipywidget-renderer`, so it runs in
+the shared notebook output webview. Its extension-host half communicates only
+through the probe's own `NotebookRendererMessaging` channel. If execution
+reaches the widget, it emits real branch and numeric DOM events and requires a
+replacement numeric node containing `1.25` before the notebook's Python oracle
+runs.
+
+Static analysis identifies a possible kernel-selection gate at the public API
+boundary:
+
+- `notebook.selectKernel` is a documented built-in command and accepts
+  `{ notebookEditor, id, extension }`.
+- `id` is an opaque notebook-controller ID, not a kernelspec name.
+- the public `vscode.notebooks` namespace can create controllers owned by the
+  calling extension, but cannot enumerate another extension's controllers or
+  observe the selected controller identity;
+- Microsoft Jupyter 2025.9.1 computes its controller IDs with private kernel
+  metadata/path logic. This harness deliberately does not copy that algorithm.
+
+The Ubuntu witness determines the outcome rather than assuming it in advance:
+
+- if both supported commands fulfill but the creation marker is absent while
+  the cell has no execution summary and zero outputs, the cell never executed;
+  the artifact reports `kernel_selection_gate_failure` and the job may complete
+  successfully;
+- a rejected or timed-out selector/execution command, any execution summary,
+  or any non-marker output is a red `runtime_failure` rather than a gate;
+- if the creation marker appears, every later renderer, messaging, or Python
+  oracle failure is a red `runtime_failure`;
+- only the complete renderer-to-Python round trip reports
+  `basic_scenario_green`.
+
+[`SPIKE_FAILURE.md`](SPIKE_FAILURE.md) is a draft root-owned follow-up payload.
+It must not be filed or described as observed until corrected Ubuntu CI
+produces a `kernel_selection_gate_failure` artifact.
+
+## Before / after
+
+Before:
+
+```text
+The repo had no VS Code Desktop process, no isolated extension installation,
+and no supported renderer bridge.
+```
+
+After:
+
+```text
+real VS Code 1.128.0 Electron on Ubuntu/Xvfb
+  -> exact stable Python/Jupyter/Jupyter-renderers extensions
+  -> clean installed-wheel kernelspec
+  -> documented notebook.selectKernel attempt
+  -> raw gate evidence (and full renderer/Python oracle if execution proceeds)
+```
+
+## Exact pins
+
+- Node.js `24.18.0`
+- npm `11.16.0`
+- `@vscode/test-electron==3.0.0`
+- VS Code Desktop `1.128.0`
+- Microsoft Python `2026.4.0` (stable)
+- Microsoft Jupyter `2025.9.1` (stable)
+- Microsoft Jupyter Notebook Renderers `1.3.0` (stable)
+- Python `3.13.13`
+- `uv==0.11.8`
+- kernel packages: the checked-in
+  `tests/jupyterlab_host/kernel-requirements.lock`
+
+The job records VS Code, Electron, Chromium, Node, npm, OS, kernel Python,
+every extension/package version, the wheel SHA-256, the explicit Electron
+environment-key allowlist, runtime public notebook API keys, command
+result/timeout, cell outputs, and VS Code/Jupyter logs.
+
+The local structural check includes pure classifier falsifiers for rejected and
+timed-out commands, missing kernelspec errors, completed/failed execution
+summaries, text errors, and non-text outputs.
+
+## Supported upstream seams read before implementation
+
+- [Testing Extensions](https://code.visualstudio.com/api/working-with-extensions/testing-extension)
+  documents real Desktop tests through `@vscode/test-electron` and exact-version
+  downloads.
+- [Continuous Integration](https://code.visualstudio.com/api/working-with-extensions/continuous-integration)
+  documents Xvfb for Linux Electron tests.
+- [Built-in Commands](https://code.visualstudio.com/api/references/commands)
+  documents `notebook.selectKernel`, `notebook.cell.execute`, and the selector's
+  void return.
+- [Notebook API](https://code.visualstudio.com/api/extension-guides/notebook)
+  documents renderer extension points and `NotebookRendererMessaging`.
+- [VS Code API](https://code.visualstudio.com/api/references/vscode-api)
+  documents that an extension may create messaging only for a renderer it
+  contributes; it exposes no foreign-controller discovery API.
+
+## Local structural proof
+
+macOS cannot satisfy the required Ubuntu/Xvfb witness. It can validate the
+locked JavaScript installation and harness structure:
+
+```bash
+cd tests/vscode_host
+npx --yes --package=node@24.18.0 --package=npm@11.16.0 --call \
+  'node scripts/assert-runtime.cjs && npm ci --ignore-scripts && npm run check'
+```
+
+## Bounded Ubuntu reproduction
+
+The workflow performs setup first, then runs this exact physical command:
+
+```bash
+cd tests/vscode_host
+timeout --signal=TERM --kill-after=30s 8m xvfb-run -a npm test
+```
+
+Required absolute environment variables are `HYPSTER_NOTEBOOK`,
+`HYPSTER_VSCODE_ARTIFACT_DIR`, and `HYPSTER_VSCODE_RUNTIME_DIR`. The workflow
+also supplies `JUPYTER_PATH` pointing at the isolated clean-kernel prefix.

--- a/tests/vscode_host/README.md
+++ b/tests/vscode_host/README.md
@@ -73,10 +73,9 @@ refused an interactive widget-CDN prompt in its test host.
 
 Jupyter's own standard and widget tests avoid that prompt by globally setting
 `jupyter.widgetScriptSources` to exactly `['jsdelivr.com', 'unpkg.com']`. The
-harness now writes that supported setting before activating Jupyter or creating
-the widget, records its global and effective values, and fails if either value
-differs. A new Ubuntu witness is still required to prove the full
-renderer-to-Python round trip.
+harness first wrote that supported setting before activating Jupyter or
+creating the widget, recorded its global and effective values, and failed if
+either value differed.
 
 [Workflow run 29193526092](https://github.com/gilad-rubin/hypster/actions/runs/29193526092)
 confirmed that both inspected global values persisted exactly, but exposed a
@@ -86,23 +85,44 @@ now reacquires configuration after writing the setting and verifies the
 effective value again after Jupyter activation, at the point the widget
 consumer reads it.
 
+[Workflow run 29193666883](https://github.com/gilad-rubin/hypster/actions/runs/29193666883)
+then proved the exact setting before and after activation, the exact clean
+interpreter, and successful kernel startup. It also exposed the next concrete
+boundary: pinned Jupyter tries configured CDN providers before its installed
+local nbextension provider, and the Electron webview could not fetch
+`https://unpkg.com/`. The unchanged 30-second creation timeout therefore stayed
+correctly red.
+
+The harness now uses Jupyter's public custom-source setting without depending
+on an external network. Before Jupyter activation it derives the selected
+kernel prefix from `HYPSTER_VSCODE_PYTHON`, requires parser-compatible
+`share/jupyter/nbextensions/anywidget/extension.js`, and serves that same
+installation's `index.js` from a loopback-only HTTP endpoint. It configures the
+exact dynamic template
+`http://127.0.0.1:<port>/${packageName}/${fileNameWithExt}` globally and verifies
+the effective value again after activation. The artifact records both asset
+paths, byte counts, SHA-256 hashes, and every request. Even if the renderer
+probe otherwise succeeds, the run remains red unless the exact
+`/anywidget/index.js` route received a successful GET.
+
 ## Before / after
 
 Before:
 
 ```text
-The repo had no VS Code Desktop process, no isolated extension installation,
-and no supported renderer bridge.
+configured CDN source
+  -> Jupyter tries unpkg before its installed local provider
+  -> Electron webview cannot fetch unpkg
+  -> widget never renders and the strict execution deadline stays red
 ```
 
 After:
 
 ```text
-real VS Code 1.128.0 Electron on Ubuntu/Xvfb
-  -> exact stable Python/Jupyter/Jupyter-renderers extensions
-  -> clean installed-wheel kernelspec
-  -> documented notebook.selectKernel attempt
-  -> raw gate evidence (and full renderer/Python oracle if execution proceeds)
+exact selected kernel prefix
+  -> validate anywidget extension.js mapping and hash installed index.js
+  -> loopback-only custom Jupyter source serves that exact index.js
+  -> artifact proves path + hash + successful GET before green is possible
 ```
 
 ## Exact pins
@@ -117,6 +137,7 @@ real VS Code 1.128.0 Electron on Ubuntu/Xvfb
 - Microsoft Jupyter Notebook Renderers `1.3.0` (stable)
 - Python `3.13.13`
 - `uv==0.11.8`
+- `anywidget==0.11.0`
 - kernel packages: the checked-in
   `tests/jupyterlab_host/kernel-requirements.lock`
 
@@ -128,7 +149,9 @@ result/timeout, cell outputs, and VS Code/Jupyter logs.
 The local structural check includes pure classifier falsifiers for transient
 empty creation state, rejected and timed-out commands, missing kernelspec
 errors, completed/failed execution summaries, text errors, and non-text
-outputs.
+outputs. It also builds a temporary exact-prefix nbextension, proves the custom
+template's HEAD/GET behavior and SHA-256 evidence, rejects other routes, and
+proves an incompatible `extension.js` fails before server startup.
 
 ## Supported upstream seams read before implementation
 
@@ -153,6 +176,11 @@ outputs.
 - [Jupyter 2025.9.1 standard widget test](https://github.com/microsoft/vscode-jupyter/blob/v2025.9.1/src/test/datascience/widgets/standardWidgets.vscode.common.test.ts)
   sets `widgetScriptSources` globally to `jsdelivr.com` and `unpkg.com` before
   initializing widgets in CI.
+- [Jupyter 2025.9.1 script-source factory](https://github.com/microsoft/vscode-jupyter/blob/v2025.9.1/src/notebooks/controllers/ipywidgets/scriptSourceProvider/scriptSourceProviderFactory.node.ts)
+  orders configured CDN/custom sources before the installed local provider.
+- [Jupyter 2025.9.1 local widget manager](https://github.com/microsoft/vscode-jupyter/blob/v2025.9.1/src/notebooks/controllers/ipywidgets/scriptSourceProvider/localIPyWidgetScriptManager.node.ts)
+  discovers `extension.js` below the interpreter's Jupyter data directories and
+  parses its RequireJS mapping.
 
 ## Local structural proof
 

--- a/tests/vscode_host/README.md
+++ b/tests/vscode_host/README.md
@@ -125,22 +125,43 @@ RequireJS `anywidget` registration state, a bounded blob-module import probe,
 the inherited Jupyter renderer/kernel globals, CSP, and browser errors or
 unhandled rejections captured from renderer module load.
 
+[Workflow run 29194503005](https://github.com/gilad-rubin/hypster/actions/runs/29194503005)
+proved the creation cell was inside VS Code's reported visible range and
+executed the clean installed wheel, but only Jupyter's Node-side source check
+fetched `anywidget`. The renderer probe again hit the host's generic 30-second
+timeout without returning its 20-second diagnostic. Pinned VS Code source
+explains why: `NotebookRendererMessaging.postMessage()` returns `true` when the
+notebook webview accepts the envelope, even when the target extending renderer
+has not loaded. Its message event then has no listener and the message is lost.
+
+The probe now follows the documented renderer-originated messaging pattern.
+Its extending renderer first resolves `jupyter-ipywidget-renderer` through
+`RendererContext.getRenderer()`, then posts a ready handshake containing base
+API and activation diagnostics. The extension host waits at most five seconds
+for that ready message before sending the exercise request. The renderer has a
+20-second exercise deadline and the host has a 22-second response deadline, so
+both stages fail before the unchanged 30-second outer budget. A missing base
+renderer now reports an activation-handshake failure instead of a misleading
+response timeout.
+
 ## Before / after
 
 Before:
 
 ```text
 exact local anywidget source reaches the webview
-  -> notebook output may remain virtualized outside the viewport
-  -> renderer-side 30s wait loses to outer 30s deadline
-  -> useful DOM/module failure evidence is lost
+  -> host sends before extending renderer installs its listener
+  -> VS Code accepts then drops the message
+  -> generic outer timeout hides the activation boundary
 ```
 
 After:
 
 ```text
 close panel + maximize editor + collapse inputs + reveal creation cell
-  -> one 25s renderer envelope inside unchanged 30s host deadline
+  -> extending renderer resolves the real Jupyter base and posts ready
+  -> host sends only after ready: 5s activation + 22s response < 30s outer
+  -> renderer returns its own diagnostic by 20s
   -> success proves the real branch/numeric flow
   -> failure returns DOM + AMD + blob import + inheritance + early errors
 
@@ -190,7 +211,14 @@ incompatible `extension.js` fails before server startup.
   documents `notebook.selectKernel`, `notebook.cell.execute`, and the selector's
   void return.
 - [Notebook API](https://code.visualstudio.com/api/extension-guides/notebook)
-  documents renderer extension points and `NotebookRendererMessaging`.
+  documents renderer extension points, renderer-originated messaging, and the
+  `onRenderer:<id>` activation event needed before messages are delivered.
+- [VS Code 1.128 renderer implementation](https://github.com/microsoft/vscode/blob/1.128.0/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts)
+  loads dependent renderers after their base and exposes that base through
+  `RendererContext.getRenderer()`.
+- [VS Code 1.128 notebook webview implementation](https://github.com/microsoft/vscode/blob/1.128.0/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts)
+  reports successful host delivery when the webview accepts a message; that
+  result does not prove the target renderer installed a listener.
 - [VS Code API](https://code.visualstudio.com/api/references/vscode-api)
   documents that an extension may create messaging only for a renderer it
   contributes; it exposes no foreign-controller discovery API.

--- a/tests/vscode_host/README.md
+++ b/tests/vscode_host/README.md
@@ -10,8 +10,9 @@ renderer whose entrypoint extends `jupyter-ipywidget-renderer`, so it runs in
 the shared notebook output webview. Its extension-host half communicates only
 through the probe's own `NotebookRendererMessaging` channel. If execution
 reaches the widget, it emits real branch and numeric DOM events and requires a
-replacement numeric node containing `1.25` before the notebook's Python oracle
-runs.
+connected widget root that either replaced and detached the prior root or
+changed in place. It then requires a replacement numeric node containing
+`1.25` before the notebook's Python oracle runs.
 
 The pinned Ubuntu witness identifies a kernel-selection gate at the public API
 boundary:
@@ -102,9 +103,12 @@ exact dynamic template
 `http://127.0.0.1:<port>/${packageName}/${fileNameWithExt}` globally and verifies
 the effective value again after activation. The artifact records both asset
 paths, byte counts, SHA-256 hashes, and every request. Even if the renderer
-probe otherwise succeeds, the run remains red unless the exact
-`/anywidget/index.js` route received a successful Electron-webview GET; an
-extension-host source check alone cannot satisfy the gate.
+probe otherwise succeeds, the run remains red unless VS Code consumed exact
+bytes: either the Electron webview fetched `/anywidget/index.js` directly, or
+RequireJS defined `anywidget` from VS Code's supported copied file-resource and
+the extension host hashes that actual copied file byte-for-byte against the
+selected kernel bundle. An extension-host availability GET alone cannot
+satisfy the gate.
 
 [Workflow run 29194056537](https://github.com/gilad-rubin/hypster/actions/runs/29194056537)
 proved both sides of that boundary: one GET came from Jupyter's extension-host
@@ -144,6 +148,19 @@ both stages fail before the unchanged 30-second outer budget. A missing base
 renderer now reports an activation-handshake failure instead of a misleading
 response timeout.
 
+[Workflow run 29194823654](https://github.com/gilad-rubin/hypster/actions/runs/29194823654)
+crossed that boundary: the extending renderer activated, RequireJS defined
+`anywidget`, the widget rendered, and the real branch action produced the
+remote numeric control. It exposed two false-negative witnesses. First, the
+probe retained the detached pre-action `.hypster-widget` and compared its stale
+HTML while the global document already contained the replacement root. Second,
+the source gate required an Electron loopback GET even though pinned Jupyter
+had copied the exact bundle to its supported
+`temp/scripts/.../jupyter/nbextensions/anywidget/index.js` file-resource. The
+probe now observes the current connected root and the source gate hashes that
+copied file. The numeric node replacement and Python verification oracle remain
+unchanged.
+
 ## Before / after
 
 Before:
@@ -168,7 +185,14 @@ close panel + maximize editor + collapse inputs + reveal creation cell
 exact selected kernel prefix
   -> validate anywidget extension.js mapping and hash installed index.js
   -> loopback-only custom Jupyter source serves that exact index.js
-  -> artifact proves path + hash + successful GET before green is possible
+  -> artifact proves either direct Electron GET or AMD-defined copied URL
+  -> hash actual copied file against selected-kernel bytes before green
+
+branch action
+  -> capture connected root immediately before click
+  -> accept distinct connected root only after prior root detaches
+  -> otherwise require that same connected root's HTML to change
+  -> require numeric node replacement, value 1.25, then Python oracle
 ```
 
 ## Exact pins
@@ -190,15 +214,20 @@ exact selected kernel prefix
 The job records VS Code, Electron, Chromium, Node, npm, OS, kernel Python,
 every extension/package version, the wheel SHA-256, the explicit Electron
 environment-key allowlist, runtime public notebook API keys, command
-result/timeout, cell outputs, and VS Code/Jupyter logs.
+result/timeout, cell outputs, and VS Code/Jupyter logs. Marketplace CLI calls
+also have a two-minute per-process timeout while retaining status, stdout,
+stderr, and spawn errors.
 
 The local structural check includes pure classifier falsifiers for transient
 empty creation state, rejected and timed-out commands, missing kernelspec
 errors, completed/failed execution summaries, text errors, and non-text
 outputs. It also builds a temporary exact-prefix nbextension, proves the custom
 template's HEAD/GET behavior and SHA-256 evidence, rejects other routes, and
-proves an extension-host GET cannot satisfy the Electron gate or that an
-incompatible `extension.js` fails before server startup.
+proves an extension-host GET alone cannot satisfy the gate. It accepts a VS
+Code copied resource reported by AMD only when the actual file matches the
+selected kernel bytes, rejects a mismatched copy, rejects an incompatible
+`extension.js` before server startup, and verifies root-transition and CLI
+timeout behavior independently.
 
 ## Supported upstream seams read before implementation
 

--- a/tests/vscode_host/README.md
+++ b/tests/vscode_host/README.md
@@ -161,6 +161,17 @@ probe now observes the current connected root and the source gate hashes that
 copied file. The numeric node replacement and Python verification oracle remain
 unchanged.
 
+[Workflow run 29195169905](https://github.com/gilad-rubin/hypster/actions/runs/29195169905)
+physically proved the copied-file gate: the RequireJS-reported file was 33,501
+bytes and its SHA-256 exactly matched the selected kernel's `anywidget` bundle.
+It also exposed a narrower renderer race. Clicking the remote option first
+closed the menu in place, which changed HTML before Python published the new
+Interactive Snapshot; the HTML-only transition therefore captured that stale
+root. The probe now waits for semantic publication—one connected widget root
+containing both `mode=remote` and `remote.temperature`—derives the root from
+that numeric control, and only then classifies replacement or a valid in-place
+update.
+
 ## Before / after
 
 Before:
@@ -190,6 +201,9 @@ exact selected kernel prefix
 
 branch action
   -> capture connected root immediately before click
+  -> ignore menu-close-only HTML change
+  -> wait for connected mode=remote + remote.temperature
+  -> derive current root from the dependent numeric control
   -> accept distinct connected root only after prior root detaches
   -> otherwise require that same connected root's HTML to change
   -> require numeric node replacement, value 1.25, then Python oracle

--- a/tests/vscode_host/README.md
+++ b/tests/vscode_host/README.md
@@ -103,22 +103,47 @@ exact dynamic template
 the effective value again after activation. The artifact records both asset
 paths, byte counts, SHA-256 hashes, and every request. Even if the renderer
 probe otherwise succeeds, the run remains red unless the exact
-`/anywidget/index.js` route received a successful GET.
+`/anywidget/index.js` route received a successful Electron-webview GET; an
+extension-host source check alone cannot satisfy the gate.
+
+[Workflow run 29194056537](https://github.com/gilad-rubin/hypster/actions/runs/29194056537)
+proved both sides of that boundary: one GET came from Jupyter's extension-host
+source check and a second came from the exact Electron/Chromium webview. The
+creation cell completed successfully, but `.hypster-widget` never appeared and
+the outer 30-second renderer deadline won the race against an identical
+renderer-side wait. The older generic `unpkg.com` reachability log remained,
+but the request evidence proves it was not the source used for `anywidget`.
+
+Pinned Jupyter's own third-party widget tests document another necessary host
+condition: VS Code does not render a virtualized notebook output that is
+outside the visible viewport. Before exercising the renderer, this harness now
+uses the same supported workbench commands to close the panel, maximize the
+editor, collapse cell inputs, and explicitly reveal the creation cell in the
+center. A 25-second renderer-side envelope returns before the unchanged
+30-second extension-host deadline. Failure evidence includes body/output DOM,
+RequireJS `anywidget` registration state, a bounded blob-module import probe,
+the inherited Jupyter renderer/kernel globals, CSP, and browser errors or
+unhandled rejections captured from renderer module load.
 
 ## Before / after
 
 Before:
 
 ```text
-configured CDN source
-  -> Jupyter tries unpkg before its installed local provider
-  -> Electron webview cannot fetch unpkg
-  -> widget never renders and the strict execution deadline stays red
+exact local anywidget source reaches the webview
+  -> notebook output may remain virtualized outside the viewport
+  -> renderer-side 30s wait loses to outer 30s deadline
+  -> useful DOM/module failure evidence is lost
 ```
 
 After:
 
 ```text
+close panel + maximize editor + collapse inputs + reveal creation cell
+  -> one 25s renderer envelope inside unchanged 30s host deadline
+  -> success proves the real branch/numeric flow
+  -> failure returns DOM + AMD + blob import + inheritance + early errors
+
 exact selected kernel prefix
   -> validate anywidget extension.js mapping and hash installed index.js
   -> loopback-only custom Jupyter source serves that exact index.js
@@ -151,7 +176,8 @@ empty creation state, rejected and timed-out commands, missing kernelspec
 errors, completed/failed execution summaries, text errors, and non-text
 outputs. It also builds a temporary exact-prefix nbextension, proves the custom
 template's HEAD/GET behavior and SHA-256 evidence, rejects other routes, and
-proves an incompatible `extension.js` fails before server startup.
+proves an extension-host GET cannot satisfy the Electron gate or that an
+incompatible `extension.js` fails before server startup.
 
 ## Supported upstream seams read before implementation
 
@@ -181,6 +207,9 @@ proves an incompatible `extension.js` fails before server startup.
 - [Jupyter 2025.9.1 local widget manager](https://github.com/microsoft/vscode-jupyter/blob/v2025.9.1/src/notebooks/controllers/ipywidgets/scriptSourceProvider/localIPyWidgetScriptManager.node.ts)
   discovers `extension.js` below the interpreter's Jupyter data directories and
   parses its RequireJS mapping.
+- [Jupyter 2025.9.1 third-party widget tests](https://github.com/microsoft/vscode-jupyter/blob/v2025.9.1/src/test/datascience/widgets/thirdpartyWidgets.vscode.common.test.ts)
+  state that outputs outside the viewport are not rendered and prepare the
+  workbench by hiding the panel and maximizing the editor.
 
 ## Local structural proof
 

--- a/tests/vscode_host/README.md
+++ b/tests/vscode_host/README.md
@@ -13,7 +13,7 @@ reaches the widget, it emits real branch and numeric DOM events and requires a
 replacement numeric node containing `1.25` before the notebook's Python oracle
 runs.
 
-Static analysis identifies a possible kernel-selection gate at the public API
+The pinned Ubuntu witness identifies a kernel-selection gate at the public API
 boundary:
 
 - `notebook.selectKernel` is a documented built-in command and accepts
@@ -25,25 +25,28 @@ boundary:
 - Microsoft Jupyter 2025.9.1 computes its controller IDs with private kernel
   metadata/path logic. This harness deliberately does not copy that algorithm.
 
-The Ubuntu witness determines the outcome rather than assuming it in advance:
+The harness determines the outcome rather than assuming it in advance:
 
 - if the pinned Jupyter extension activates but VS Code does not register the
   documented `notebook.selectKernel` command, the artifact reports
   `kernel_selection_gate_failure`;
-- if both supported commands fulfill but the creation marker is absent while
-  the cell has no execution summary and zero outputs, the cell never executed;
-  the artifact reports `kernel_selection_gate_failure` and the job may complete
-  successfully;
-- a rejected or timed-out selector/execution command, any execution summary,
-  or any non-marker output is a red `runtime_failure` rather than a gate;
+- once the command is registered, a rejected or timed-out selector/execution
+  command, any creation-marker timeout, any execution summary, or any
+  non-marker output is a red `runtime_failure`. An empty cell at the marker
+  deadline is inconclusive because uncancelled execution may still start;
 - if the creation marker appears, every later renderer, messaging, or Python
-  oracle failure is a red `runtime_failure`;
+  oracle failure—including verification-command rejection or timeout—is a red
+  `runtime_failure`;
 - only the complete renderer-to-Python round trip reports
   `basic_scenario_green`.
 
-[`SPIKE_FAILURE.md`](SPIKE_FAILURE.md) is a draft root-owned follow-up payload.
-It must not be filed or described as observed until corrected Ubuntu CI
-produces a `kernel_selection_gate_failure` artifact.
+The exact pinned witness completed in
+[workflow run 29192874852](https://github.com/gilad-rubin/hypster/actions/runs/29192874852).
+After explicit activation, Microsoft Jupyter `2025.9.1` did not register the
+documented `notebook.selectKernel` command in VS Code Desktop `1.128.0`. The
+uploaded evidence therefore records `kernel_selection_gate_failure`, with no
+round-trip attempt and complete process cleanup. [`SPIKE_FAILURE.md`](SPIKE_FAILURE.md)
+is the verified root-owned follow-up payload for the missing supported seam.
 
 ## Before / after
 
@@ -83,9 +86,10 @@ every extension/package version, the wheel SHA-256, the explicit Electron
 environment-key allowlist, runtime public notebook API keys, command
 result/timeout, cell outputs, and VS Code/Jupyter logs.
 
-The local structural check includes pure classifier falsifiers for rejected and
-timed-out commands, missing kernelspec errors, completed/failed execution
-summaries, text errors, and non-text outputs.
+The local structural check includes pure classifier falsifiers for transient
+empty creation state, rejected and timed-out commands, missing kernelspec
+errors, completed/failed execution summaries, text errors, and non-text
+outputs.
 
 ## Supported upstream seams read before implementation
 

--- a/tests/vscode_host/README.md
+++ b/tests/vscode_host/README.md
@@ -78,6 +78,14 @@ the widget, records its global and effective values, and fails if either value
 differs. A new Ubuntu witness is still required to prove the full
 renderer-to-Python round trip.
 
+[Workflow run 29193526092](https://github.com/gilad-rubin/hypster/actions/runs/29193526092)
+confirmed that both inspected global values persisted exactly, but exposed a
+harness-verifier bug: `configuration.get()` was called on the configuration
+object created before the update and returned its cached default. The harness
+now reacquires configuration after writing the setting and verifies the
+effective value again after Jupyter activation, at the point the widget
+consumer reads it.
+
 ## Before / after
 
 Before:

--- a/tests/vscode_host/SPIKE_FAILURE.md
+++ b/tests/vscode_host/SPIKE_FAILURE.md
@@ -1,6 +1,9 @@
 # Follow-up issue payload: supported VS Code kernel selection seam
 
-> Verified by the pinned Ubuntu witness in [workflow run 29192874852](https://github.com/gilad-rubin/hypster/actions/runs/29192874852).
+> Historical observation verified by the pinned Ubuntu witness in
+> [workflow run 29192874852](https://github.com/gilad-rubin/hypster/actions/runs/29192874852).
+> Do not file this as an unavoidable gate while the supported exported
+> `openNotebook` seam is under physical verification.
 
 The uploaded `spike-result.json` records VS Code Desktop `1.128.0`, Microsoft
 Jupyter `2025.9.1`, and `selector.commandRegistered: false` after explicit
@@ -8,6 +11,14 @@ Jupyter activation. It classifies the exact observation as
 `kernel_selection_gate_failure`; no notebook cell or substitute renderer path
 was attempted. The cleanup artifact confirms that no VS Code, Electron,
 Chromium, or kernel process remained.
+
+Pinned Jupyter `2025.9.1` also publicly exports
+`openNotebook(uri, pythonEnvironment)`, which selects its internal controller
+without exposing or copying the private ID. The harness now exercises the same
+Python-environment resolution and `openNotebook` sequence as Jupyter's own
+smoke test. This payload is relevant only if the corrected physical witness
+shows that supported export is unavailable; an export invocation or round-trip
+failure is a red runtime failure, not this accepted gate.
 
 ## Title
 

--- a/tests/vscode_host/SPIKE_FAILURE.md
+++ b/tests/vscode_host/SPIKE_FAILURE.md
@@ -1,13 +1,13 @@
 # Follow-up issue payload: supported VS Code kernel selection seam
 
-> Draft only. Do not file this payload or claim the failure was observed until
-> a corrected Ubuntu run records `kernel_selection_gate_failure` in
-> `host-evidence/vscode/spike-result.json`.
+> Verified by the pinned Ubuntu witness in [workflow run 29192874852](https://github.com/gilad-rubin/hypster/actions/runs/29192874852).
 
-The qualifying artifact must show fulfilled selector and creation commands,
-`creationExecutionSummary: null`, `creationOutputCount: 0`, and an empty
-`creationRawOutput`. Command rejection/timeout, any execution summary, or any
-output is a runtime failure and does not qualify this payload for filing.
+The uploaded `spike-result.json` records VS Code Desktop `1.128.0`, Microsoft
+Jupyter `2025.9.1`, and `selector.commandRegistered: false` after explicit
+Jupyter activation. It classifies the exact observation as
+`kernel_selection_gate_failure`; no notebook cell or substitute renderer path
+was attempted. The cleanup artifact confirms that no VS Code, Electron,
+Chromium, or kernel process remained.
 
 ## Title
 
@@ -42,7 +42,7 @@ kernelspec name `hypster-host` is not that ID. The exact pinned Jupyter
 extension derives controller IDs with private kernel metadata/path logic; the
 host harness is forbidden from copying or importing that algorithm.
 
-A qualifying run must preserve `host-evidence/vscode/spike-result.json` with
+A reproduction run must preserve `host-evidence/vscode/spike-result.json` with
 the public `vscode.notebooks` runtime keys, command result/timeout, exact
 process/extension versions, and cell/renderer progress. Its uploaded VS Code
 logs must preserve the controller-discovery evidence.

--- a/tests/vscode_host/SPIKE_FAILURE.md
+++ b/tests/vscode_host/SPIKE_FAILURE.md
@@ -57,6 +57,12 @@ current connected root, and hashes the RequireJS-reported copied file against
 the selected kernel bundle. Numeric replacement and the Python oracle remain
 required. This is also downstream of the historical selection gate.
 
+Workflow run 29195169905 physically proved that copied-source hash gate, then
+found a narrower renderer-witness race: closing the choice menu changed the old
+root in place before Python published the remote snapshot. The probe now waits
+for `mode=remote` and `remote.temperature` on one connected root before
+classifying its transition. This remains downstream of kernel selection.
+
 ## Title
 
 Expose or adopt a supported VS Code kernel-controller discovery seam for the

--- a/tests/vscode_host/SPIKE_FAILURE.md
+++ b/tests/vscode_host/SPIKE_FAILURE.md
@@ -20,6 +20,16 @@ smoke test. Workflow run 29193331802 proved that export against the exact clean
 Python environment and reached the widget. Its later widget-CDN prompt failure
 is a red harness-configuration failure, not this accepted gate.
 
+Workflow run 29193666883 subsequently proved the exact global widget setting
+before and after activation, plus successful startup of that exact clean
+kernel. The remaining failure was a concrete renderer source error:
+`Failed to access CDN https://unpkg.com/ ... TypeError: Failed to fetch`.
+Pinned Jupyter orders configured network/custom providers before its installed
+local provider. The harness now uses the public custom-source setting to serve
+the exact selected kernel prefix's installed `anywidget/index.js` on loopback,
+and requires path/hash/request evidence before green. This does not change the
+historical kernel-selection gate recorded by this payload.
+
 ## Title
 
 Expose or adopt a supported VS Code kernel-controller discovery seam for the

--- a/tests/vscode_host/SPIKE_FAILURE.md
+++ b/tests/vscode_host/SPIKE_FAILURE.md
@@ -1,9 +1,9 @@
 # Follow-up issue payload: supported VS Code kernel selection seam
 
-> Historical observation verified by the pinned Ubuntu witness in
+> Superseded historical observation verified by the pinned Ubuntu witness in
 > [workflow run 29192874852](https://github.com/gilad-rubin/hypster/actions/runs/29192874852).
-> Do not file this as an unavoidable gate while the supported exported
-> `openNotebook` seam is under physical verification.
+> Do not file this as an unavoidable gate: the supported exported
+> `openNotebook` seam was physically proven in workflow run 29193331802.
 
 The uploaded `spike-result.json` records VS Code Desktop `1.128.0`, Microsoft
 Jupyter `2025.9.1`, and `selector.commandRegistered: false` after explicit
@@ -16,9 +16,9 @@ Pinned Jupyter `2025.9.1` also publicly exports
 `openNotebook(uri, pythonEnvironment)`, which selects its internal controller
 without exposing or copying the private ID. The harness now exercises the same
 Python-environment resolution and `openNotebook` sequence as Jupyter's own
-smoke test. This payload is relevant only if the corrected physical witness
-shows that supported export is unavailable; an export invocation or round-trip
-failure is a red runtime failure, not this accepted gate.
+smoke test. Workflow run 29193331802 proved that export against the exact clean
+Python environment and reached the widget. Its later widget-CDN prompt failure
+is a red harness-configuration failure, not this accepted gate.
 
 ## Title
 

--- a/tests/vscode_host/SPIKE_FAILURE.md
+++ b/tests/vscode_host/SPIKE_FAILURE.md
@@ -39,6 +39,15 @@ reveals the creation-cell viewport and returns renderer diagnostics inside the
 unchanged outer deadline. This remains unrelated to the superseded selection
 gate described here.
 
+Workflow run 29194503005 proved viewport visibility but exposed a separate
+renderer-messaging race: VS Code reported host-to-webview delivery even though
+the extending renderer had not installed its listener, so its inner diagnostic
+never started. The probe now waits for a renderer-originated ready handshake
+after resolving the real Jupyter base renderer through the supported
+`RendererContext.getRenderer()` API. Its bounded activation and response stages
+both finish before the unchanged outer deadline. This is downstream of the
+historical selection gate.
+
 ## Title
 
 Expose or adopt a supported VS Code kernel-controller discovery seam for the

--- a/tests/vscode_host/SPIKE_FAILURE.md
+++ b/tests/vscode_host/SPIKE_FAILURE.md
@@ -30,6 +30,15 @@ the exact selected kernel prefix's installed `anywidget/index.js` on loopback,
 and requires path/hash/request evidence before green. This does not change the
 historical kernel-selection gate recorded by this payload.
 
+Workflow run 29194056537 then proved that both Jupyter's extension host and the
+Electron webview fetched the exact installed anywidget bundle. The remaining
+renderer timeout is downstream of kernel selection and widget-source delivery.
+Pinned Jupyter's own third-party tests warn that offscreen notebook outputs are
+virtualized and not rendered, so the harness now explicitly prepares and
+reveals the creation-cell viewport and returns renderer diagnostics inside the
+unchanged outer deadline. This remains unrelated to the superseded selection
+gate described here.
+
 ## Title
 
 Expose or adopt a supported VS Code kernel-controller discovery seam for the

--- a/tests/vscode_host/SPIKE_FAILURE.md
+++ b/tests/vscode_host/SPIKE_FAILURE.md
@@ -48,6 +48,15 @@ after resolving the real Jupyter base renderer through the supported
 both finish before the unchanged outer deadline. This is downstream of the
 historical selection gate.
 
+Workflow run 29194823654 then crossed the renderer boundary, rendered the real
+widget, and applied the remote branch. Its red result came from two harness
+witness errors, not kernel selection: the probe compared HTML on a detached old
+widget root, and the source gate rejected Jupyter's supported exact-byte copy
+because it expected a direct Electron loopback GET. The probe now verifies the
+current connected root, and hashes the RequireJS-reported copied file against
+the selected kernel bundle. Numeric replacement and the Python oracle remain
+required. This is also downstream of the historical selection gate.
+
 ## Title
 
 Expose or adopt a supported VS Code kernel-controller discovery seam for the

--- a/tests/vscode_host/SPIKE_FAILURE.md
+++ b/tests/vscode_host/SPIKE_FAILURE.md
@@ -1,0 +1,66 @@
+# Follow-up issue payload: supported VS Code kernel selection seam
+
+> Draft only. Do not file this payload or claim the failure was observed until
+> a corrected Ubuntu run records `kernel_selection_gate_failure` in
+> `host-evidence/vscode/spike-result.json`.
+
+The qualifying artifact must show fulfilled selector and creation commands,
+`creationExecutionSummary: null`, `creationOutputCount: 0`, and an empty
+`creationRawOutput`. Command rejection/timeout, any execution summary, or any
+output is a runtime failure and does not qualify this payload for filing.
+
+## Title
+
+Expose or adopt a supported VS Code kernel-controller discovery seam for the
+real-host harness
+
+## Parent
+
+#86; discovered by #98; spec #93; decision #82.
+
+## Reproduction
+
+Run the dedicated `VS Code host spike` workflow, or on Ubuntu with its setup
+environment:
+
+```bash
+cd tests/vscode_host
+timeout --signal=TERM --kill-after=30s 8m xvfb-run -a npm test
+```
+
+The reproduction workflow is designed to launch VS Code Desktop 1.128.0
+through `@vscode/test-electron`, use isolated user-data/extensions directories,
+install stable
+`ms-python.python@2026.4.0`, `ms-toolsai.jupyter@2025.9.1`, and
+`ms-toolsai.jupyter-renderers@1.3.0`, and register the clean `hypster-host`
+kernelspec from the installed repository wheel.
+
+`notebook.selectKernel` accepts `{ notebookEditor, id, extension }`, but `id`
+is the owning extension's opaque controller ID. The public VS Code API exposes
+neither foreign-controller enumeration nor selected-controller identity. The
+kernelspec name `hypster-host` is not that ID. The exact pinned Jupyter
+extension derives controller IDs with private kernel metadata/path logic; the
+host harness is forbidden from copying or importing that algorithm.
+
+A qualifying run must preserve `host-evidence/vscode/spike-result.json` with
+the public `vscode.notebooks` runtime keys, command result/timeout, exact
+process/extension versions, and cell/renderer progress. Its uploaded VS Code
+logs must preserve the controller-discovery evidence.
+
+## Acceptance criteria
+
+- [ ] A supported, versioned API lets the external test extension select the
+      controller for the exact clean `hypster-host` kernelspec without copying
+      Microsoft Jupyter internals or driving private workbench UI.
+- [ ] The harness can prove which controller was selected before executing the
+      shared notebook.
+- [ ] #98 is rerun unchanged through the real renderer-messaging bridge and the
+      Python oracle proves `{'mode': 'remote', 'remote.temperature': 1.25}`.
+- [ ] Exact versions, logs, timeouts, and process cleanup remain release
+      artifacts.
+
+## Forbidden workaround
+
+Do not derive Jupyter's controller ID from its private `getKernelId` algorithm,
+reach into extension internals, use private commands/UI selectors, or replace
+the real kernel/widget/renderer.

--- a/tests/vscode_host/cli-runner.cjs
+++ b/tests/vscode_host/cli-runner.cjs
@@ -1,0 +1,23 @@
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+
+const CLI_TIMEOUT_MS = 120_000;
+
+function runCLI(cliPath, baseArgs, args, environment, spawn = spawnSync) {
+  const completed = spawn(cliPath, [...baseArgs, ...args], {
+    encoding: "utf8",
+    env: environment,
+    shell: process.platform === "win32",
+    timeout: CLI_TIMEOUT_MS,
+  });
+  if (completed.error || completed.status !== 0) {
+    throw new Error(
+      `VS Code CLI failed (${completed.status}): ${JSON.stringify(args)}\n` +
+        `stdout:\n${completed.stdout}\nstderr:\n${completed.stderr}\n${completed.error ?? ""}`,
+    );
+  }
+  return `${completed.stdout}${completed.stderr}`.trim();
+}
+
+module.exports = { CLI_TIMEOUT_MS, runCLI };

--- a/tests/vscode_host/creation-gate.cjs
+++ b/tests/vscode_host/creation-gate.cjs
@@ -43,4 +43,18 @@ function classifyCommandResult(label, commandResult) {
   };
 }
 
-module.exports = { classifyCommandResult, classifyMissingCreationMarker };
+function selectKernelStrategy({ openNotebookExported, commandRegistered }) {
+  if (openNotebookExported) {
+    return "ms-toolsai.jupyter.exports.openNotebook";
+  }
+  if (commandRegistered) {
+    return "notebook.selectKernel";
+  }
+  return "kernel_selection_gate_failure";
+}
+
+module.exports = {
+  classifyCommandResult,
+  classifyMissingCreationMarker,
+  selectKernelStrategy,
+};

--- a/tests/vscode_host/creation-gate.cjs
+++ b/tests/vscode_host/creation-gate.cjs
@@ -20,14 +20,10 @@ function classifyMissingCreationMarker({
   if (outputCount !== 0 || rawOutput.length !== 0) {
     runtimeEvidence.push(`creation cell has ${outputCount} output(s)`);
   }
-
   if (runtimeEvidence.length === 0) {
-    return {
-      accepted: true,
-      outcome: "kernel_selection_gate_failure",
-      reason:
-        "Kernel selection and execution commands fulfilled, but the creation cell never executed.",
-    };
+    runtimeEvidence.push(
+      "creation state was still empty at the marker deadline; uncancelled execution may start later",
+    );
   }
   return {
     accepted: false,
@@ -36,4 +32,15 @@ function classifyMissingCreationMarker({
   };
 }
 
-module.exports = { classifyMissingCreationMarker };
+function classifyCommandResult(label, commandResult) {
+  if (commandResult.status === "fulfilled") {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    outcome: "runtime_failure",
+    reason: `${label} command ${commandResult.status}`,
+  };
+}
+
+module.exports = { classifyCommandResult, classifyMissingCreationMarker };

--- a/tests/vscode_host/creation-gate.cjs
+++ b/tests/vscode_host/creation-gate.cjs
@@ -1,0 +1,39 @@
+"use strict";
+
+function classifyMissingCreationMarker({
+  selectorCommand,
+  creationCommand,
+  executionSummary,
+  outputCount,
+  rawOutput,
+}) {
+  const runtimeEvidence = [];
+  if (selectorCommand.status !== "fulfilled") {
+    runtimeEvidence.push(`selector command ${selectorCommand.status}`);
+  }
+  if (creationCommand.status !== "fulfilled") {
+    runtimeEvidence.push(`creation command ${creationCommand.status}`);
+  }
+  if (executionSummary !== null) {
+    runtimeEvidence.push("creation cell has an execution summary");
+  }
+  if (outputCount !== 0 || rawOutput.length !== 0) {
+    runtimeEvidence.push(`creation cell has ${outputCount} output(s)`);
+  }
+
+  if (runtimeEvidence.length === 0) {
+    return {
+      accepted: true,
+      outcome: "kernel_selection_gate_failure",
+      reason:
+        "Kernel selection and execution commands fulfilled, but the creation cell never executed.",
+    };
+  }
+  return {
+    accepted: false,
+    outcome: "runtime_failure",
+    reason: `Creation marker missing after runtime activity: ${runtimeEvidence.join("; ")}.`,
+  };
+}
+
+module.exports = { classifyMissingCreationMarker };

--- a/tests/vscode_host/extension.cjs
+++ b/tests/vscode_host/extension.cjs
@@ -24,13 +24,17 @@ function activate(context) {
       if (message.ok) {
         request.resolve(message.evidence);
       } else {
-        request.reject(new Error(message.error));
+        request.reject(
+          new Error(
+            `${message.error}\nRENDERER_DIAGNOSTICS=${JSON.stringify(message.diagnostics ?? null)}`,
+          ),
+        );
       }
     }),
   );
 
   return Object.freeze({
-    async exercise(editor, timeoutMilliseconds = 30_000) {
+    async exercise(editor, options = {}, timeoutMilliseconds = 30_000) {
       const requestId = crypto.randomUUID();
       const deadline = Date.now() + timeoutMilliseconds;
       let phase = "delivery";
@@ -48,7 +52,15 @@ function activate(context) {
         while (!delivered && Date.now() < deadline) {
           const attempt = await Promise.race([
             channel
-              .postMessage({ kind: "hypster-probe-exercise", requestId }, editor)
+              .postMessage(
+                {
+                  kind: "hypster-probe-exercise",
+                  requestId,
+                  creationCellIndex: options.creationCellIndex ?? null,
+                  creationCellVisible: options.creationCellVisible ?? null,
+                },
+                editor,
+              )
               .then((value) => ({ kind: "delivery", delivered: value })),
             response.then((evidence) => ({ kind: "response", evidence })),
           ]);

--- a/tests/vscode_host/extension.cjs
+++ b/tests/vscode_host/extension.cjs
@@ -37,11 +37,11 @@ function activate(context) {
       if (message.ok) {
         request.resolve(message.evidence);
       } else {
-        request.reject(
-          new Error(
-            `${message.error}\nRENDERER_DIAGNOSTICS=${JSON.stringify(message.diagnostics ?? null)}`,
-          ),
+        const error = new Error(
+          `${message.error}\nRENDERER_DIAGNOSTICS=${JSON.stringify(message.diagnostics ?? null)}`,
         );
+        error.rendererDiagnostics = message.diagnostics ?? null;
+        request.reject(error);
       }
     }),
     { dispose: () => activationGate.dispose() },

--- a/tests/vscode_host/extension.cjs
+++ b/tests/vscode_host/extension.cjs
@@ -2,19 +2,32 @@
 
 const crypto = require("node:crypto");
 const vscode = require("vscode");
+const {
+  ACTIVATION_TIMEOUT_MS,
+  RESPONSE_TIMEOUT_MS,
+  RendererActivationGate,
+} = require("./renderer-gate.cjs");
 
 const RENDERER_ID = "hypster-vscode-host-probe";
 const pending = new Map();
+const activationGate = new RendererActivationGate();
 
-function delay(milliseconds) {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+function editorKey(editor) {
+  return editor.notebook.uri.toString();
 }
 
 function activate(context) {
   const channel = vscode.notebooks.createRendererMessaging(RENDERER_ID);
   context.subscriptions.push(
-    channel.onDidReceiveMessage(({ message }) => {
-      if (!message || message.kind !== "hypster-probe-result") {
+    channel.onDidReceiveMessage(({ editor, message }) => {
+      if (!message) {
+        return;
+      }
+      if (message.kind === "hypster-probe-ready") {
+        activationGate.markReady(editorKey(editor), message.evidence ?? null);
+        return;
+      }
+      if (message.kind !== "hypster-probe-result") {
         return;
       }
       const request = pending.get(message.requestId);
@@ -31,52 +44,44 @@ function activate(context) {
         );
       }
     }),
+    { dispose: () => activationGate.dispose() },
   );
 
   return Object.freeze({
-    async exercise(editor, options = {}, timeoutMilliseconds = 30_000) {
+    async exercise(editor, options = {}) {
+      const activationEvidence = await activationGate.wait(
+        editorKey(editor),
+        ACTIVATION_TIMEOUT_MS,
+      );
       const requestId = crypto.randomUUID();
-      const deadline = Date.now() + timeoutMilliseconds;
-      let phase = "delivery";
       let timer;
       const response = new Promise((resolve, reject) => {
         timer = setTimeout(() => {
-          reject(new Error(`renderer ${phase} timed out after ${timeoutMilliseconds}ms`));
-        }, timeoutMilliseconds);
+          reject(
+            new Error(
+              `renderer response timed out after ${RESPONSE_TIMEOUT_MS}ms following ready handshake`,
+            ),
+          );
+        }, RESPONSE_TIMEOUT_MS);
         pending.set(requestId, { resolve, reject });
       });
       response.catch(() => {});
 
       try {
-        let delivered = false;
-        while (!delivered && Date.now() < deadline) {
-          const attempt = await Promise.race([
-            channel
-              .postMessage(
-                {
-                  kind: "hypster-probe-exercise",
-                  requestId,
-                  creationCellIndex: options.creationCellIndex ?? null,
-                  creationCellVisible: options.creationCellVisible ?? null,
-                },
-                editor,
-              )
-              .then((value) => ({ kind: "delivery", delivered: value })),
-            response.then((evidence) => ({ kind: "response", evidence })),
-          ]);
-          if (attempt.kind === "response") {
-            return attempt.evidence;
-          }
-          delivered = attempt.delivered;
-          if (!delivered) {
-            await delay(Math.min(250, Math.max(0, deadline - Date.now())));
-          }
-        }
+        const delivered = await channel.postMessage(
+          {
+            kind: "hypster-probe-exercise",
+            requestId,
+            creationCellIndex: options.creationCellIndex ?? null,
+            creationCellVisible: options.creationCellVisible ?? null,
+          },
+          editor,
+        );
         if (!delivered) {
-          return await response;
+          throw new Error("renderer exercise was not delivered after ready handshake");
         }
-        phase = "response";
-        return await response;
+        const evidence = await response;
+        return { ...evidence, activation: activationEvidence };
       } finally {
         pending.delete(requestId);
         clearTimeout(timer);

--- a/tests/vscode_host/extension.cjs
+++ b/tests/vscode_host/extension.cjs
@@ -1,0 +1,83 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const vscode = require("vscode");
+
+const RENDERER_ID = "hypster-vscode-host-probe";
+const pending = new Map();
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function activate(context) {
+  const channel = vscode.notebooks.createRendererMessaging(RENDERER_ID);
+  context.subscriptions.push(
+    channel.onDidReceiveMessage(({ message }) => {
+      if (!message || message.kind !== "hypster-probe-result") {
+        return;
+      }
+      const request = pending.get(message.requestId);
+      if (!request) {
+        return;
+      }
+      if (message.ok) {
+        request.resolve(message.evidence);
+      } else {
+        request.reject(new Error(message.error));
+      }
+    }),
+  );
+
+  return Object.freeze({
+    async exercise(editor, timeoutMilliseconds = 30_000) {
+      const requestId = crypto.randomUUID();
+      const deadline = Date.now() + timeoutMilliseconds;
+      let phase = "delivery";
+      let timer;
+      const response = new Promise((resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`renderer ${phase} timed out after ${timeoutMilliseconds}ms`));
+        }, timeoutMilliseconds);
+        pending.set(requestId, { resolve, reject });
+      });
+      response.catch(() => {});
+
+      try {
+        let delivered = false;
+        while (!delivered && Date.now() < deadline) {
+          const attempt = await Promise.race([
+            channel
+              .postMessage({ kind: "hypster-probe-exercise", requestId }, editor)
+              .then((value) => ({ kind: "delivery", delivered: value })),
+            response.then((evidence) => ({ kind: "response", evidence })),
+          ]);
+          if (attempt.kind === "response") {
+            return attempt.evidence;
+          }
+          delivered = attempt.delivered;
+          if (!delivered) {
+            await delay(Math.min(250, Math.max(0, deadline - Date.now())));
+          }
+        }
+        if (!delivered) {
+          return await response;
+        }
+        phase = "response";
+        return await response;
+      } finally {
+        pending.delete(requestId);
+        clearTimeout(timer);
+      }
+    },
+  });
+}
+
+function deactivate() {
+  for (const [requestId, request] of pending) {
+    request.reject(new Error("Hypster host probe deactivated"));
+    pending.delete(requestId);
+  }
+}
+
+module.exports = { activate, deactivate };

--- a/tests/vscode_host/package-lock.json
+++ b/tests/vscode_host/package-lock.json
@@ -8,11 +8,23 @@
       "name": "hypster-vscode-host-spike",
       "version": "0.0.0",
       "devDependencies": {
+        "@vscode/python-extension": "1.0.6",
         "@vscode/test-electron": "3.0.0"
       },
       "engines": {
         "node": "24.18.0",
         "vscode": "^1.128.0"
+      }
+    },
+    "node_modules/@vscode/python-extension": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/python-extension/-/python-extension-1.0.6.tgz",
+      "integrity": "sha512-q7KYf+mymM67G0yS6xfhczFwu2teBi5oXHVdNgtCsYhErdSOkwMPtE291SqQahrjTcgKxn7O56i1qb1EQR6o4w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.17.0",
+        "vscode": "^1.93.0"
       }
     },
     "node_modules/@vscode/test-electron": {

--- a/tests/vscode_host/package-lock.json
+++ b/tests/vscode_host/package-lock.json
@@ -1,0 +1,485 @@
+{
+  "name": "hypster-vscode-host-spike",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hypster-vscode-host-spike",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@vscode/test-electron": "3.0.0"
+      },
+      "engines": {
+        "node": "24.18.0",
+        "vscode": "^1.128.0"
+      }
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
+      "integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tests/vscode_host/package.json
+++ b/tests/vscode_host/package.json
@@ -14,6 +14,7 @@
     "onRenderer:hypster-vscode-host-probe"
   ],
   "extensionDependencies": [
+    "ms-python.python",
     "ms-toolsai.jupyter"
   ],
   "contributes": {
@@ -35,6 +36,7 @@
     "test": "node run.cjs"
   },
   "devDependencies": {
+    "@vscode/python-extension": "1.0.6",
     "@vscode/test-electron": "3.0.0"
   }
 }

--- a/tests/vscode_host/package.json
+++ b/tests/vscode_host/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "assert-runtime": "node scripts/assert-runtime.cjs",
-    "check": "node scripts/check.cjs && node scripts/test-creation-gate.cjs",
+    "check": "node scripts/check.cjs && node scripts/test-creation-gate.cjs && node scripts/test-widget-source.cjs",
     "test": "node run.cjs"
   },
   "devDependencies": {

--- a/tests/vscode_host/package.json
+++ b/tests/vscode_host/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "assert-runtime": "node scripts/assert-runtime.cjs",
-    "check": "node scripts/check.cjs && node scripts/test-creation-gate.cjs && node scripts/test-widget-source.cjs",
+    "check": "node scripts/check.cjs && node scripts/test-creation-gate.cjs && node scripts/test-widget-source.cjs && node scripts/test-renderer-gate.cjs",
     "test": "node run.cjs"
   },
   "devDependencies": {

--- a/tests/vscode_host/package.json
+++ b/tests/vscode_host/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "hypster-vscode-host-spike",
+  "version": "0.0.0",
+  "private": true,
+  "packageManager": "npm@11.16.0",
+  "displayName": "Hypster VS Code host spike",
+  "publisher": "hypster",
+  "engines": {
+    "node": "24.18.0",
+    "vscode": "^1.128.0"
+  },
+  "main": "./extension.cjs",
+  "activationEvents": [
+    "onRenderer:hypster-vscode-host-probe"
+  ],
+  "extensionDependencies": [
+    "ms-toolsai.jupyter"
+  ],
+  "contributes": {
+    "notebookRenderer": [
+      {
+        "id": "hypster-vscode-host-probe",
+        "displayName": "Hypster host-test probe",
+        "entrypoint": {
+          "extends": "jupyter-ipywidget-renderer",
+          "path": "./renderer.mjs"
+        },
+        "requiresMessaging": "always"
+      }
+    ]
+  },
+  "scripts": {
+    "assert-runtime": "node scripts/assert-runtime.cjs",
+    "check": "node scripts/check.cjs && node scripts/test-creation-gate.cjs",
+    "test": "node run.cjs"
+  },
+  "devDependencies": {
+    "@vscode/test-electron": "3.0.0"
+  }
+}

--- a/tests/vscode_host/package.json
+++ b/tests/vscode_host/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "assert-runtime": "node scripts/assert-runtime.cjs",
-    "check": "node scripts/check.cjs && node scripts/test-creation-gate.cjs && node scripts/test-widget-source.cjs && node scripts/test-renderer-gate.cjs",
+    "check": "node scripts/check.cjs && node scripts/test-creation-gate.cjs && node scripts/test-widget-source.cjs && node scripts/test-renderer-gate.cjs && node scripts/test-renderer-witness.mjs && node scripts/test-cli-runner.cjs",
     "test": "node run.cjs"
   },
   "devDependencies": {

--- a/tests/vscode_host/pins.cjs
+++ b/tests/vscode_host/pins.cjs
@@ -4,6 +4,7 @@ module.exports = Object.freeze({
   node: "24.18.0",
   npm: "11.16.0",
   vscode: "1.128.0",
+  widgetScriptSources: Object.freeze(["jsdelivr.com", "unpkg.com"]),
   extensions: Object.freeze({
     "ms-python.python": "2026.4.0",
     "ms-toolsai.jupyter": "2025.9.1",

--- a/tests/vscode_host/pins.cjs
+++ b/tests/vscode_host/pins.cjs
@@ -1,0 +1,12 @@
+"use strict";
+
+module.exports = Object.freeze({
+  node: "24.18.0",
+  npm: "11.16.0",
+  vscode: "1.128.0",
+  extensions: Object.freeze({
+    "ms-python.python": "2026.4.0",
+    "ms-toolsai.jupyter": "2025.9.1",
+    "ms-toolsai.jupyter-renderers": "1.3.0",
+  }),
+});

--- a/tests/vscode_host/pins.cjs
+++ b/tests/vscode_host/pins.cjs
@@ -4,7 +4,7 @@ module.exports = Object.freeze({
   node: "24.18.0",
   npm: "11.16.0",
   vscode: "1.128.0",
-  widgetScriptSources: Object.freeze(["jsdelivr.com", "unpkg.com"]),
+  widgetScriptSourcePathTemplate: "/${packageName}/${fileNameWithExt}",
   extensions: Object.freeze({
     "ms-python.python": "2026.4.0",
     "ms-toolsai.jupyter": "2025.9.1",

--- a/tests/vscode_host/renderer-gate.cjs
+++ b/tests/vscode_host/renderer-gate.cjs
@@ -1,0 +1,81 @@
+"use strict";
+
+const OUTER_TIMEOUT_MS = 30_000;
+const ACTIVATION_TIMEOUT_MS = 5_000;
+const RENDERER_EXERCISE_TIMEOUT_MS = 20_000;
+const RESPONSE_TIMEOUT_MS = RENDERER_EXERCISE_TIMEOUT_MS + 2_000;
+
+if (ACTIVATION_TIMEOUT_MS + RESPONSE_TIMEOUT_MS >= OUTER_TIMEOUT_MS) {
+  throw new Error("renderer gate stages must finish before the outer timeout");
+}
+
+class RendererActivationGate {
+  #ready = new Map();
+  #waiters = new Map();
+  #disposed = false;
+
+  markReady(key, evidence) {
+    if (this.#disposed) {
+      return;
+    }
+    this.#ready.set(key, evidence);
+    const waiters = this.#waiters.get(key) ?? [];
+    this.#waiters.delete(key);
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timer);
+      waiter.resolve(evidence);
+    }
+  }
+
+  wait(key, timeoutMilliseconds = ACTIVATION_TIMEOUT_MS) {
+    if (this.#disposed) {
+      return Promise.reject(new Error("renderer activation gate is disposed"));
+    }
+    if (this.#ready.has(key)) {
+      return Promise.resolve(this.#ready.get(key));
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          const waiters = this.#waiters.get(key) ?? [];
+          const remaining = waiters.filter((candidate) => candidate !== waiter);
+          if (remaining.length) {
+            this.#waiters.set(key, remaining);
+          } else {
+            this.#waiters.delete(key);
+          }
+          reject(
+            new Error(
+              `renderer activation handshake timed out after ${timeoutMilliseconds}ms for ${key}`,
+            ),
+          );
+        }, timeoutMilliseconds),
+      };
+      const waiters = this.#waiters.get(key) ?? [];
+      waiters.push(waiter);
+      this.#waiters.set(key, waiters);
+    });
+  }
+
+  dispose() {
+    this.#disposed = true;
+    for (const waiters of this.#waiters.values()) {
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timer);
+        waiter.reject(new Error("renderer activation gate disposed before ready"));
+      }
+    }
+    this.#waiters.clear();
+    this.#ready.clear();
+  }
+}
+
+module.exports = {
+  ACTIVATION_TIMEOUT_MS,
+  OUTER_TIMEOUT_MS,
+  RENDERER_EXERCISE_TIMEOUT_MS,
+  RESPONSE_TIMEOUT_MS,
+  RendererActivationGate,
+};

--- a/tests/vscode_host/renderer-witness.mjs
+++ b/tests/vscode_host/renderer-witness.mjs
@@ -1,0 +1,15 @@
+export function detectWidgetRootTransition(previousRoot, previousHtml, currentRoot) {
+  if (!currentRoot?.isConnected) {
+    return undefined;
+  }
+  if (currentRoot !== previousRoot) {
+    if (previousRoot.isConnected) {
+      return undefined;
+    }
+    return { kind: "replaced", currentRoot };
+  }
+  if (currentRoot.innerHTML !== previousHtml) {
+    return { kind: "updated-in-place", currentRoot };
+  }
+  return undefined;
+}

--- a/tests/vscode_host/renderer-witness.mjs
+++ b/tests/vscode_host/renderer-witness.mjs
@@ -1,3 +1,19 @@
+const NUMERIC_SELECTOR = "input[data-path='remote.temperature'][data-kind='float']";
+const MODE_VALUE_SELECTOR = ".hypster-choice[data-path='mode'] .hypster-choice-value";
+
+export function findPublishedRemoteState(documentRoot) {
+  const numeric = documentRoot.querySelector(NUMERIC_SELECTOR);
+  if (!numeric?.isConnected) {
+    return undefined;
+  }
+  const currentRoot = numeric.closest(".hypster-widget");
+  if (!currentRoot?.isConnected) {
+    return undefined;
+  }
+  const mode = currentRoot.querySelector(MODE_VALUE_SELECTOR)?.textContent?.trim();
+  return mode === "remote" ? { currentRoot, numeric } : undefined;
+}
+
 export function detectWidgetRootTransition(previousRoot, previousHtml, currentRoot) {
   if (!currentRoot?.isConnected) {
     return undefined;

--- a/tests/vscode_host/renderer.mjs
+++ b/tests/vscode_host/renderer.mjs
@@ -1,0 +1,108 @@
+const COMM_TIMEOUT_MS = 30_000;
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitFor(description, predicate) {
+  const deadline = Date.now() + COMM_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const value = predicate();
+    if (value) {
+      return value;
+    }
+    await delay(50);
+  }
+  throw new Error(`${description} did not appear within ${COMM_TIMEOUT_MS}ms`);
+}
+
+async function exerciseWidget() {
+  const root = await waitFor(".hypster-widget", () => document.querySelector(".hypster-widget"));
+  const prematureNumeric = document.querySelector(
+    "input[data-path='remote.temperature'][data-kind='float']",
+  );
+  if (prematureNumeric) {
+    throw new Error("dependent numeric control existed before the branch action");
+  }
+
+  const beforeBranch = root.innerHTML;
+  const trigger = root.querySelector(
+    ".hypster-choice[data-path='mode'] .hypster-choice-trigger",
+  );
+  if (!trigger) {
+    throw new Error("mode branch trigger was not rendered");
+  }
+  trigger.click();
+
+  const remoteOption = await waitFor("remote branch option", () =>
+    [...document.querySelectorAll("[data-hypster-choice-option][data-path='mode']")].find(
+      (element) => element.textContent?.trim() === "remote",
+    ),
+  );
+  remoteOption.click();
+
+  const numeric = await waitFor("dependent numeric control", () =>
+    document.querySelector("input[data-path='remote.temperature'][data-kind='float']"),
+  );
+  if (numeric.value !== "0.25") {
+    throw new Error(`dependent numeric default was ${numeric.value}, expected 0.25`);
+  }
+  if (root.innerHTML === beforeBranch) {
+    throw new Error("branch action did not publish replacement renderer state");
+  }
+
+  numeric.value = "1.25";
+  numeric.dispatchEvent(new Event("change", { bubbles: true }));
+  await waitFor("detached prior numeric control", () => !numeric.isConnected);
+  const replacement = await waitFor("replacement numeric control", () => {
+    const candidate = document.querySelector(
+      "input[data-path='remote.temperature'][data-kind='float']",
+    );
+    return candidate && candidate !== numeric ? candidate : undefined;
+  });
+  if (replacement.value !== "1.25") {
+    throw new Error(`replacement numeric value was ${replacement.value}, expected 1.25`);
+  }
+
+  const widgetErrors = [...document.querySelectorAll(
+    ".hypster-status-error, .hypster-status-draft_error",
+  )].map((element) => element.textContent);
+  if (widgetErrors.length) {
+    throw new Error(`widget surfaced errors: ${JSON.stringify(widgetErrors)}`);
+  }
+
+  return {
+    branch: "remote",
+    numericBefore: "0.25",
+    numericAfter: replacement.value,
+    numericNodeReplaced: !numeric.isConnected,
+  };
+}
+
+export function activate(context) {
+  if (!context.onDidReceiveMessage || !context.postMessage) {
+    throw new Error("NotebookRendererMessaging is unavailable");
+  }
+  context.onDidReceiveMessage(async (message) => {
+    if (!message || message.kind !== "hypster-probe-exercise") {
+      return;
+    }
+    try {
+      const evidence = await exerciseWidget();
+      context.postMessage({
+        kind: "hypster-probe-result",
+        requestId: message.requestId,
+        ok: true,
+        evidence,
+      });
+    } catch (error) {
+      context.postMessage({
+        kind: "hypster-probe-result",
+        requestId: message.requestId,
+        ok: false,
+        error: error instanceof Error ? `${error.message}\n${error.stack}` : String(error),
+      });
+    }
+  });
+  return {};
+}

--- a/tests/vscode_host/renderer.mjs
+++ b/tests/vscode_host/renderer.mjs
@@ -1,4 +1,7 @@
-import { detectWidgetRootTransition } from "./renderer-witness.mjs";
+import {
+  detectWidgetRootTransition,
+  findPublishedRemoteState,
+} from "./renderer-witness.mjs";
 
 const EXERCISE_TIMEOUT_MS = 20_000;
 const DIAGNOSTIC_TEXT_LIMIT = 20_000;
@@ -276,20 +279,15 @@ async function exerciseWidget(deadline) {
   const beforeBranch = branchRoot.innerHTML;
   remoteOption.click();
 
-  const rootTransition = await waitFor(
-    "replacement renderer state",
-    () =>
-      detectWidgetRootTransition(
-        branchRoot,
-        beforeBranch,
-        document.querySelector(".hypster-widget"),
-      ),
+  const publishedState = await waitFor(
+    "published remote branch state",
+    () => findPublishedRemoteState(document),
     deadline,
   );
-  const currentRoot = rootTransition.currentRoot;
-  const numeric = await waitFor(
-    "dependent numeric control",
-    () => currentRoot.querySelector("input[data-path='remote.temperature'][data-kind='float']"),
+  const { currentRoot, numeric } = publishedState;
+  const rootTransition = await waitFor(
+    "replacement renderer state",
+    () => detectWidgetRootTransition(branchRoot, beforeBranch, currentRoot),
     deadline,
   );
   if (numeric.value !== "0.25") {

--- a/tests/vscode_host/renderer.mjs
+++ b/tests/vscode_host/renderer.mjs
@@ -1,3 +1,5 @@
+import { detectWidgetRootTransition } from "./renderer-witness.mjs";
+
 const EXERCISE_TIMEOUT_MS = 20_000;
 const DIAGNOSTIC_TEXT_LIMIT = 20_000;
 const BASE_RENDERER_ID = "jupyter-ipywidget-renderer";
@@ -251,7 +253,6 @@ async function exerciseWidget(deadline) {
     throw new Error("dependent numeric control existed before the branch action");
   }
 
-  const beforeBranch = root.innerHTML;
   const trigger = root.querySelector(
     ".hypster-choice[data-path='mode'] .hypster-choice-trigger",
   );
@@ -268,20 +269,32 @@ async function exerciseWidget(deadline) {
       ),
     deadline,
   );
+  const branchRoot = document.querySelector(".hypster-widget");
+  if (!branchRoot?.isConnected) {
+    throw new Error("connected widget root disappeared before the branch action");
+  }
+  const beforeBranch = branchRoot.innerHTML;
   remoteOption.click();
 
+  const rootTransition = await waitFor(
+    "replacement renderer state",
+    () =>
+      detectWidgetRootTransition(
+        branchRoot,
+        beforeBranch,
+        document.querySelector(".hypster-widget"),
+      ),
+    deadline,
+  );
+  const currentRoot = rootTransition.currentRoot;
   const numeric = await waitFor(
     "dependent numeric control",
-    () => document.querySelector("input[data-path='remote.temperature'][data-kind='float']"),
+    () => currentRoot.querySelector("input[data-path='remote.temperature'][data-kind='float']"),
     deadline,
   );
   if (numeric.value !== "0.25") {
     throw new Error(`dependent numeric default was ${numeric.value}, expected 0.25`);
   }
-  if (root.innerHTML === beforeBranch) {
-    throw new Error("branch action did not publish replacement renderer state");
-  }
-
   numeric.value = "1.25";
   numeric.dispatchEvent(new Event("change", { bubbles: true }));
   await waitFor("detached prior numeric control", () => !numeric.isConnected, deadline);
@@ -308,6 +321,9 @@ async function exerciseWidget(deadline) {
 
   return {
     branch: "remote",
+    branchRootTransition: rootTransition.kind,
+    branchRootReplaced: rootTransition.kind === "replaced",
+    priorBranchRootDetached: !branchRoot.isConnected,
     numericBefore: "0.25",
     numericAfter: replacement.value,
     numericNodeReplaced: !numeric.isConnected,

--- a/tests/vscode_host/renderer.mjs
+++ b/tests/vscode_host/renderer.mjs
@@ -1,11 +1,88 @@
-const COMM_TIMEOUT_MS = 30_000;
+const EXERCISE_TIMEOUT_MS = 25_000;
+const DIAGNOSTIC_TEXT_LIMIT = 20_000;
+const browserEvents = [];
+const moduleLoadedAt = new Date().toISOString();
+const moduleLoadedPerformance = performance.now();
+
+function diagnosticValue(value) {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack ?? null,
+    };
+  }
+  if (typeof value === "string" || value == null) {
+    return value;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return "<unserializable>";
+    }
+  }
+}
+
+function recordBrowserEvent(event) {
+  browserEvents.push({
+    millisecondsSinceModuleLoad: Math.round(performance.now() - moduleLoadedPerformance),
+    ...event,
+  });
+  if (browserEvents.length > 100) {
+    browserEvents.shift();
+  }
+}
+
+window.addEventListener(
+  "error",
+  (event) => {
+    if (event.target && event.target !== window) {
+      recordBrowserEvent({
+        kind: "resource-error",
+        tagName: event.target.tagName ?? null,
+        id: event.target.id ?? null,
+        className: event.target.className ?? null,
+        src: event.target.src ?? event.target.href ?? null,
+      });
+      return;
+    }
+    recordBrowserEvent({
+      kind: "window-error",
+      message: event.message ?? null,
+      filename: event.filename ?? null,
+      line: event.lineno ?? null,
+      column: event.colno ?? null,
+      error: diagnosticValue(event.error),
+    });
+  },
+  true,
+);
+window.addEventListener("unhandledrejection", (event) => {
+  recordBrowserEvent({
+    kind: "unhandled-rejection",
+    reason: diagnosticValue(event.reason),
+  });
+});
+
+for (const channel of ["error", "warn"]) {
+  const original = console[channel].bind(console);
+  console[channel] = (...values) => {
+    recordBrowserEvent({
+      kind: `console-${channel}`,
+      values: values.map(diagnosticValue),
+    });
+    original(...values);
+  };
+}
 
 function delay(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-async function waitFor(description, predicate) {
-  const deadline = Date.now() + COMM_TIMEOUT_MS;
+async function waitFor(description, predicate, deadline) {
   while (Date.now() < deadline) {
     const value = predicate();
     if (value) {
@@ -13,11 +90,159 @@ async function waitFor(description, predicate) {
     }
     await delay(50);
   }
-  throw new Error(`${description} did not appear within ${COMM_TIMEOUT_MS}ms`);
+  throw new Error(`${description} did not appear within ${EXERCISE_TIMEOUT_MS}ms`);
 }
 
-async function exerciseWidget() {
-  const root = await waitFor(".hypster-widget", () => document.querySelector(".hypster-widget"));
+function objectKeys(value) {
+  return value && (typeof value === "object" || typeof value === "function")
+    ? Object.keys(value).sort()
+    : [];
+}
+
+function limitedText(value) {
+  if (!value) {
+    return "";
+  }
+  return value.length <= DIAGNOSTIC_TEXT_LIMIT
+    ? value
+    : `${value.slice(0, DIAGNOSTIC_TEXT_LIMIT)}<truncated>`;
+}
+
+function amdDiagnostics() {
+  const requireJs = globalThis.requirejs;
+  const context = requireJs?.s?.contexts?._;
+  const definedModules = objectKeys(context?.defined);
+  const registryModules = objectKeys(context?.registry);
+  const fetchedUrls = objectKeys(context?.urlFetched);
+  const relevant = (values) =>
+    values.filter(
+      (value) => value.includes("anywidget") || value.includes("jupyter-widgets"),
+    );
+  let anywidgetDefined = null;
+  let anywidgetSpecified = null;
+  try {
+    anywidgetDefined =
+      typeof requireJs?.defined === "function" ? requireJs.defined("anywidget") : null;
+    anywidgetSpecified =
+      typeof requireJs?.specified === "function" ? requireJs.specified("anywidget") : null;
+  } catch (error) {
+    return {
+      requireJsType: typeof requireJs,
+      inspectionError: diagnosticValue(error),
+    };
+  }
+  return {
+    requireJsType: typeof requireJs,
+    anywidgetDefined,
+    anywidgetSpecified,
+    relevantDefinedModules: relevant(definedModules),
+    relevantRegistryModules: relevant(registryModules),
+    relevantFetchedUrls: relevant(fetchedUrls),
+    definedModuleCount: definedModules.length,
+    registryModuleCount: registryModules.length,
+  };
+}
+
+function elementSummaries(selector) {
+  return [...document.querySelectorAll(selector)].slice(0, 20).map((element) => ({
+    tagName: element.tagName,
+    id: element.id || null,
+    className: typeof element.className === "string" ? element.className : null,
+    text: limitedText(element.textContent?.trim() ?? "").slice(0, 500),
+    html: limitedText(element.outerHTML).slice(0, 2_000),
+  }));
+}
+
+function rendererDiagnostics(context = {}) {
+  const baseRendererContext = globalThis.jupyter_vscode_rendererContext;
+  const ipywidgetsKernel = globalThis.ipywidgetsKernel;
+  return {
+    moduleLoadedAt,
+    capturedAt: new Date().toISOString(),
+    document: {
+      readyState: document.readyState,
+      visibilityState: document.visibilityState,
+      hasFocus: document.hasFocus(),
+      locationProtocol: location.protocol,
+      viewport: { width: innerWidth, height: innerHeight },
+      bodyChildCount: document.body?.children.length ?? null,
+      bodyText: limitedText(document.body?.innerText ?? ""),
+      bodyHtml: limitedText(document.body?.innerHTML ?? ""),
+      outputElements: elementSummaries(
+        ".cell-output-ipywidget-background, .widget-subarea, .vscode-cell-output, [data-output-id]",
+      ),
+      hypsterWidgetCount: document.querySelectorAll(".hypster-widget").length,
+      scripts: [...document.scripts].map((script) => script.src || "<inline>").slice(0, 100),
+      contentSecurityPolicy:
+        document.querySelector("meta[http-equiv='Content-Security-Policy']")?.content ?? null,
+    },
+    amd: amdDiagnostics(),
+    inheritedRenderer: {
+      baseRendererContextPresent: Boolean(baseRendererContext),
+      baseRendererContextKeys: objectKeys(baseRendererContext),
+      ipywidgetsKernelPresent: Boolean(ipywidgetsKernel),
+      ipywidgetsKernelKeys: objectKeys(ipywidgetsKernel),
+      widgets7Present: Boolean(globalThis.vscIPyWidgets7),
+      widgets8Present: Boolean(globalThis.vscIPyWidgets8),
+    },
+    browserEvents: [...browserEvents],
+    ...context,
+  };
+}
+
+function safeRendererDiagnostics(context) {
+  try {
+    return rendererDiagnostics(context);
+  } catch (error) {
+    return {
+      collectionError: diagnosticValue(error),
+      browserEvents: [...browserEvents],
+      ...context,
+    };
+  }
+}
+
+async function probeBlobModuleImport(deadline) {
+  let url;
+  try {
+    url = URL.createObjectURL(
+      new Blob(["export default 'hypster-blob-module-ok';"], { type: "text/javascript" }),
+    );
+    const importResult = import(url).then(
+      (module) => ({ kind: "loaded", module }),
+      (error) => ({ kind: "error", error }),
+    );
+    const remaining = Math.max(0, Math.min(2_000, deadline - Date.now()));
+    const result = await Promise.race([
+      importResult,
+      delay(remaining).then(() => ({ kind: "timeout" })),
+    ]);
+    if (result.kind === "loaded") {
+      return { ok: result.module.default === "hypster-blob-module-ok" };
+    }
+    if (result.kind === "error") {
+      return { ok: false, error: diagnosticValue(result.error) };
+    }
+    return { ok: false, timeoutMilliseconds: remaining };
+  } catch (error) {
+    return { ok: false, probeError: diagnosticValue(error) };
+  } finally {
+    if (url) {
+      try {
+        URL.revokeObjectURL(url);
+      } catch {
+        // The capability result above is more useful than a cleanup-only error.
+      }
+    }
+  }
+}
+
+async function exerciseWidget(deadline) {
+  const root = await waitFor(
+    ".hypster-widget",
+    () => document.querySelector(".hypster-widget"),
+    deadline,
+  );
   const prematureNumeric = document.querySelector(
     "input[data-path='remote.temperature'][data-kind='float']",
   );
@@ -34,15 +259,20 @@ async function exerciseWidget() {
   }
   trigger.click();
 
-  const remoteOption = await waitFor("remote branch option", () =>
-    [...document.querySelectorAll("[data-hypster-choice-option][data-path='mode']")].find(
-      (element) => element.textContent?.trim() === "remote",
-    ),
+  const remoteOption = await waitFor(
+    "remote branch option",
+    () =>
+      [...document.querySelectorAll("[data-hypster-choice-option][data-path='mode']")].find(
+        (element) => element.textContent?.trim() === "remote",
+      ),
+    deadline,
   );
   remoteOption.click();
 
-  const numeric = await waitFor("dependent numeric control", () =>
-    document.querySelector("input[data-path='remote.temperature'][data-kind='float']"),
+  const numeric = await waitFor(
+    "dependent numeric control",
+    () => document.querySelector("input[data-path='remote.temperature'][data-kind='float']"),
+    deadline,
   );
   if (numeric.value !== "0.25") {
     throw new Error(`dependent numeric default was ${numeric.value}, expected 0.25`);
@@ -53,13 +283,17 @@ async function exerciseWidget() {
 
   numeric.value = "1.25";
   numeric.dispatchEvent(new Event("change", { bubbles: true }));
-  await waitFor("detached prior numeric control", () => !numeric.isConnected);
-  const replacement = await waitFor("replacement numeric control", () => {
-    const candidate = document.querySelector(
-      "input[data-path='remote.temperature'][data-kind='float']",
-    );
-    return candidate && candidate !== numeric ? candidate : undefined;
-  });
+  await waitFor("detached prior numeric control", () => !numeric.isConnected, deadline);
+  const replacement = await waitFor(
+    "replacement numeric control",
+    () => {
+      const candidate = document.querySelector(
+        "input[data-path='remote.temperature'][data-kind='float']",
+      );
+      return candidate && candidate !== numeric ? candidate : undefined;
+    },
+    deadline,
+  );
   if (replacement.value !== "1.25") {
     throw new Error(`replacement numeric value was ${replacement.value}, expected 1.25`);
   }
@@ -87,13 +321,22 @@ export function activate(context) {
     if (!message || message.kind !== "hypster-probe-exercise") {
       return;
     }
+    const deadline = Date.now() + EXERCISE_TIMEOUT_MS;
+    const diagnosticContext = {
+      creationCellIndex: message.creationCellIndex ?? null,
+      hostCreationCellVisible: message.creationCellVisible ?? null,
+      blobModuleImport: await probeBlobModuleImport(deadline),
+    };
     try {
-      const evidence = await exerciseWidget();
+      const evidence = await exerciseWidget(deadline);
       context.postMessage({
         kind: "hypster-probe-result",
         requestId: message.requestId,
         ok: true,
-        evidence,
+        evidence: {
+          ...evidence,
+          diagnostics: safeRendererDiagnostics(diagnosticContext),
+        },
       });
     } catch (error) {
       context.postMessage({
@@ -101,6 +344,7 @@ export function activate(context) {
         requestId: message.requestId,
         ok: false,
         error: error instanceof Error ? `${error.message}\n${error.stack}` : String(error),
+        diagnostics: safeRendererDiagnostics(diagnosticContext),
       });
     }
   });

--- a/tests/vscode_host/renderer.mjs
+++ b/tests/vscode_host/renderer.mjs
@@ -1,5 +1,6 @@
-const EXERCISE_TIMEOUT_MS = 25_000;
+const EXERCISE_TIMEOUT_MS = 20_000;
 const DIAGNOSTIC_TEXT_LIMIT = 20_000;
+const BASE_RENDERER_ID = "jupyter-ipywidget-renderer";
 const browserEvents = [];
 const moduleLoadedAt = new Date().toISOString();
 const moduleLoadedPerformance = performance.now();
@@ -313,10 +314,22 @@ async function exerciseWidget(deadline) {
   };
 }
 
-export function activate(context) {
+export async function activate(context) {
   if (!context.onDidReceiveMessage || !context.postMessage) {
     throw new Error("NotebookRendererMessaging is unavailable");
   }
+  const baseRenderer = await context.getRenderer(BASE_RENDERER_ID);
+  if (!baseRenderer || typeof baseRenderer.renderOutputItem !== "function") {
+    throw new Error(`extended renderer could not resolve ${BASE_RENDERER_ID}`);
+  }
+  context.postMessage({
+    kind: "hypster-probe-ready",
+    evidence: safeRendererDiagnostics({
+      phase: "activate",
+      baseRendererId: BASE_RENDERER_ID,
+      baseRendererApiKeys: objectKeys(baseRenderer),
+    }),
+  });
   context.onDidReceiveMessage(async (message) => {
     if (!message || message.kind !== "hypster-probe-exercise") {
       return;

--- a/tests/vscode_host/run.cjs
+++ b/tests/vscode_host/run.cjs
@@ -1,0 +1,184 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const {
+  downloadAndUnzipVSCode,
+  resolveCliArgsFromVSCodeExecutablePath,
+  runTests,
+} = require("@vscode/test-electron");
+const pins = require("./pins.cjs");
+
+const HOST_ENVIRONMENT_KEYS = [
+  "CI",
+  "DBUS_SESSION_BUS_ADDRESS",
+  "DISPLAY",
+  "HOME",
+  "LANG",
+  "LC_ALL",
+  "LD_LIBRARY_PATH",
+  "LOGNAME",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "PATH",
+  "PWD",
+  "SHELL",
+  "SSL_CERT_FILE",
+  "TEMP",
+  "TERM",
+  "TMP",
+  "TMPDIR",
+  "TZ",
+  "USER",
+  "XAUTHORITY",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_RUNTIME_DIR",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+];
+
+function requiredPath(name) {
+  const value = process.env[name];
+  if (!value || !path.isAbsolute(value)) {
+    throw new Error(`${name} must be an explicit absolute path`);
+  }
+  return value;
+}
+
+function minimalEnvironment(extra = {}) {
+  const environment = {};
+  for (const name of HOST_ENVIRONMENT_KEYS) {
+    if (process.env[name] !== undefined) {
+      environment[name] = process.env[name];
+    }
+  }
+  return { ...environment, ...extra };
+}
+
+async function runWithEnvironment(environment, operation) {
+  // @vscode/test-electron merges process.env into the Electron child. Snapshot
+  // only so it can be restored; the child sees the explicit allowlist below.
+  const original = { ...process.env };
+  for (const name of Object.keys(process.env)) {
+    delete process.env[name];
+  }
+  Object.assign(process.env, environment);
+  try {
+    return await operation();
+  } finally {
+    for (const name of Object.keys(process.env)) {
+      delete process.env[name];
+    }
+    Object.assign(process.env, original);
+  }
+}
+
+function runCLI(cliPath, baseArgs, args, environment) {
+  const completed = spawnSync(cliPath, [...baseArgs, ...args], {
+    encoding: "utf8",
+    env: environment,
+    shell: process.platform === "win32",
+  });
+  if (completed.error || completed.status !== 0) {
+    throw new Error(
+      `VS Code CLI failed (${completed.status}): ${JSON.stringify(args)}\n` +
+        `stdout:\n${completed.stdout}\nstderr:\n${completed.stderr}\n${completed.error ?? ""}`,
+    );
+  }
+  return `${completed.stdout}${completed.stderr}`.trim();
+}
+
+async function main() {
+  const harnessRoot = __dirname;
+  const artifactDir = requiredPath("HYPSTER_VSCODE_ARTIFACT_DIR");
+  const runtimeDir = requiredPath("HYPSTER_VSCODE_RUNTIME_DIR");
+  const notebook = requiredPath("HYPSTER_NOTEBOOK");
+  const jupyterPath = requiredPath("JUPYTER_PATH");
+  const userDataDir = path.join(runtimeDir, "user-data");
+  const extensionsDir = path.join(runtimeDir, "extensions");
+  fs.mkdirSync(artifactDir, { recursive: true });
+  fs.mkdirSync(userDataDir, { recursive: true });
+  fs.mkdirSync(extensionsDir, { recursive: true });
+
+  const executable = await downloadAndUnzipVSCode({
+    version: pins.vscode,
+    cachePath: path.join(runtimeDir, "download"),
+  });
+  const [cliPath, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(executable, {
+    reuseMachineInstall: true,
+  });
+  const environment = minimalEnvironment({
+    HYPSTER_NOTEBOOK: notebook,
+    HYPSTER_VSCODE_ARTIFACT_DIR: artifactDir,
+    HYPSTER_VSCODE_RUNTIME_DIR: runtimeDir,
+    JUPYTER_PATH: jupyterPath,
+  });
+  fs.writeFileSync(
+    path.join(artifactDir, "electron-environment-keys.json"),
+    `${JSON.stringify(Object.keys(environment).sort(), null, 2)}\n`,
+  );
+  const profileArgs = ["--user-data-dir", userDataDir, "--extensions-dir", extensionsDir];
+
+  const installLog = [];
+  for (const [extension, version] of Object.entries(pins.extensions)) {
+    installLog.push(
+      runCLI(
+        cliPath,
+        cliArgs,
+        [
+          ...profileArgs,
+          "--install-extension",
+          `${extension}@${version}`,
+          "--force",
+          "--do-not-include-pack-dependencies",
+        ],
+        environment,
+      ),
+    );
+  }
+  fs.writeFileSync(path.join(artifactDir, "extension-install.log"), `${installLog.join("\n")}\n`);
+  const installed = runCLI(
+    cliPath,
+    cliArgs,
+    [...profileArgs, "--list-extensions", "--show-versions"],
+    environment,
+  );
+  fs.writeFileSync(path.join(artifactDir, "installed-extensions.txt"), `${installed}\n`);
+  for (const [extension, version] of Object.entries(pins.extensions)) {
+    if (!installed.split(/\r?\n/).includes(`${extension}@${version}`)) {
+      throw new Error(`exact extension pin missing after installation: ${extension}@${version}`);
+    }
+  }
+
+  const exitCode = await runWithEnvironment(environment, () =>
+    runTests({
+      vscodeExecutablePath: executable,
+      reuseMachineInstall: true,
+      extensionDevelopmentPath: harnessRoot,
+      extensionTestsPath: path.join(harnessRoot, "test", "index.cjs"),
+      extensionTestsEnv: environment,
+      launchArgs: [
+        path.dirname(notebook),
+        ...profileArgs,
+        "--disable-workspace-trust",
+        "--disable-updates",
+        "--skip-release-notes",
+        "--skip-welcome",
+      ],
+    }),
+  );
+  if (exitCode !== 0) {
+    throw new Error(`VS Code extension test exited with ${exitCode}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/vscode_host/run.cjs
+++ b/tests/vscode_host/run.cjs
@@ -98,6 +98,7 @@ async function main() {
   const artifactDir = requiredPath("HYPSTER_VSCODE_ARTIFACT_DIR");
   const runtimeDir = requiredPath("HYPSTER_VSCODE_RUNTIME_DIR");
   const notebook = requiredPath("HYPSTER_NOTEBOOK");
+  const pythonExecutable = requiredPath("HYPSTER_VSCODE_PYTHON");
   const jupyterPath = requiredPath("JUPYTER_PATH");
   const userDataDir = path.join(runtimeDir, "user-data");
   const extensionsDir = path.join(runtimeDir, "extensions");
@@ -116,6 +117,7 @@ async function main() {
     HYPSTER_NOTEBOOK: notebook,
     HYPSTER_VSCODE_ARTIFACT_DIR: artifactDir,
     HYPSTER_VSCODE_RUNTIME_DIR: runtimeDir,
+    HYPSTER_VSCODE_PYTHON: pythonExecutable,
     JUPYTER_PATH: jupyterPath,
   });
   fs.writeFileSync(

--- a/tests/vscode_host/run.cjs
+++ b/tests/vscode_host/run.cjs
@@ -12,7 +12,6 @@ const pins = require("./pins.cjs");
 
 const HOST_ENVIRONMENT_KEYS = [
   "CI",
-  "DBUS_SESSION_BUS_ADDRESS",
   "DISPLAY",
   "HOME",
   "LANG",

--- a/tests/vscode_host/run.cjs
+++ b/tests/vscode_host/run.cjs
@@ -2,12 +2,12 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
-const { spawnSync } = require("node:child_process");
 const {
   downloadAndUnzipVSCode,
   resolveCliArgsFromVSCodeExecutablePath,
   runTests,
 } = require("@vscode/test-electron");
+const { runCLI } = require("./cli-runner.cjs");
 const pins = require("./pins.cjs");
 
 const HOST_ENVIRONMENT_KEYS = [
@@ -76,21 +76,6 @@ async function runWithEnvironment(environment, operation) {
     }
     Object.assign(process.env, original);
   }
-}
-
-function runCLI(cliPath, baseArgs, args, environment) {
-  const completed = spawnSync(cliPath, [...baseArgs, ...args], {
-    encoding: "utf8",
-    env: environment,
-    shell: process.platform === "win32",
-  });
-  if (completed.error || completed.status !== 0) {
-    throw new Error(
-      `VS Code CLI failed (${completed.status}): ${JSON.stringify(args)}\n` +
-        `stdout:\n${completed.stdout}\nstderr:\n${completed.stderr}\n${completed.error ?? ""}`,
-    );
-  }
-  return `${completed.stdout}${completed.stderr}`.trim();
 }
 
 async function main() {

--- a/tests/vscode_host/scripts/assert-runtime.cjs
+++ b/tests/vscode_host/scripts/assert-runtime.cjs
@@ -1,0 +1,17 @@
+"use strict";
+
+const { execFileSync } = require("node:child_process");
+const pins = require("../pins.cjs");
+
+const actualNode = process.version;
+const expectedNode = `v${pins.node}`;
+if (actualNode !== expectedNode) {
+  throw new Error(`expected Node.js ${expectedNode}, got ${actualNode}`);
+}
+
+const actualNpm = execFileSync("npm", ["--version"], { encoding: "utf8" }).trim();
+if (actualNpm !== pins.npm) {
+  throw new Error(`expected npm ${pins.npm}, got ${actualNpm}`);
+}
+
+console.log(`exact JavaScript runtime selected: Node.js ${actualNode}, npm ${actualNpm}`);

--- a/tests/vscode_host/scripts/check.cjs
+++ b/tests/vscode_host/scripts/check.cjs
@@ -33,8 +33,8 @@ if (manifest.packageManager !== `npm@${pins.npm}` || manifest.engines.node !== p
 if (pins.vscode !== "1.128.0") {
   throw new Error("VS Code Desktop must remain exactly pinned");
 }
-if (JSON.stringify(pins.widgetScriptSources) !== JSON.stringify(["jsdelivr.com", "unpkg.com"])) {
-  throw new Error("Jupyter's exact standard-test widget script sources must remain pinned");
+if (pins.widgetScriptSourcePathTemplate !== "/${packageName}/${fileNameWithExt}") {
+  throw new Error("Jupyter's local widget source path template must remain exactly pinned");
 }
 
 const hostTestSource = fs.readFileSync(path.join(root, "test", "index.cjs"), "utf8");
@@ -45,6 +45,8 @@ for (const fragment of [
   'inspect("widgetScriptSources")',
   "effectiveBeforeActivation",
   "effectiveAfterActivation",
+  "startLocalWidgetSource(pythonExecutable)",
+  "localWidgetSource.assertUsed()",
 ]) {
   if (!hostTestSource.includes(fragment)) {
     throw new Error(`host test must configure and verify the global widget allowlist: ${fragment}`);
@@ -56,7 +58,7 @@ if (configurationReads.length < 3) {
 }
 const activationIndex = hostTestSource.indexOf("const jupyterApi = await jupyter.activate();");
 const consumerVerificationIndex = hostTestSource.indexOf(
-  "verifyWidgetScriptSourcesAfterActivation(evidence);",
+  "verifyWidgetScriptSourcesAfterActivation(evidence, localWidgetSource.template);",
 );
 if (activationIndex < 0 || consumerVerificationIndex < activationIndex) {
   throw new Error("effective widget settings must be verified after Jupyter activation");
@@ -87,8 +89,10 @@ for (const file of [
   "creation-gate.cjs",
   "renderer.mjs",
   "run.cjs",
+  "widget-source.cjs",
   "scripts/assert-runtime.cjs",
   "scripts/test-creation-gate.cjs",
+  "scripts/test-widget-source.cjs",
   "test/index.cjs",
 ]) {
   const completed = spawnSync(process.execPath, ["--check", path.join(root, file)], {
@@ -99,4 +103,4 @@ for (const file of [
   }
 }
 
-console.log("VS Code host structure and global widget allowlist are valid");
+console.log("VS Code host structure and fail-loud local widget source are valid");

--- a/tests/vscode_host/scripts/check.cjs
+++ b/tests/vscode_host/scripts/check.cjs
@@ -33,6 +33,21 @@ if (manifest.packageManager !== `npm@${pins.npm}` || manifest.engines.node !== p
 if (pins.vscode !== "1.128.0") {
   throw new Error("VS Code Desktop must remain exactly pinned");
 }
+if (JSON.stringify(pins.widgetScriptSources) !== JSON.stringify(["jsdelivr.com", "unpkg.com"])) {
+  throw new Error("Jupyter's exact standard-test widget script sources must remain pinned");
+}
+
+const hostTestSource = fs.readFileSync(path.join(root, "test", "index.cjs"), "utf8");
+for (const fragment of [
+  'getConfiguration("jupyter")',
+  '"widgetScriptSources"',
+  "vscode.ConfigurationTarget.Global",
+  'inspect("widgetScriptSources")',
+]) {
+  if (!hostTestSource.includes(fragment)) {
+    throw new Error(`host test must configure and verify the global widget allowlist: ${fragment}`);
+  }
+}
 
 const notebookPath = path.join(repository, "tests", "jupyterlab_host", "branch_round_trip.ipynb");
 const notebook = JSON.parse(fs.readFileSync(notebookPath, "utf8"));
@@ -71,4 +86,4 @@ for (const file of [
   }
 }
 
-console.log("VS Code host spike structure is valid");
+console.log("VS Code host structure and global widget allowlist are valid");

--- a/tests/vscode_host/scripts/check.cjs
+++ b/tests/vscode_host/scripts/check.cjs
@@ -35,6 +35,10 @@ for (const marker of ["HYPSTER_IMPORT_PATH=", "HYPSTER_PARAMS_VERIFIED="]) {
   if (matches.length !== 1) {
     throw new Error(`expected one shared-fixture cell containing ${marker}, got ${matches.length}`);
   }
+  const [cell] = matches;
+  if (cell.execution_count !== null || cell.outputs.length !== 0) {
+    throw new Error(`shared-fixture cell containing ${marker} must not carry stale execution state`);
+  }
 }
 const copiedNotebooks = fs.readdirSync(root).filter((name) => name.endsWith(".ipynb"));
 if (copiedNotebooks.length) {

--- a/tests/vscode_host/scripts/check.cjs
+++ b/tests/vscode_host/scripts/check.cjs
@@ -43,10 +43,23 @@ for (const fragment of [
   '"widgetScriptSources"',
   "vscode.ConfigurationTarget.Global",
   'inspect("widgetScriptSources")',
+  "effectiveBeforeActivation",
+  "effectiveAfterActivation",
 ]) {
   if (!hostTestSource.includes(fragment)) {
     throw new Error(`host test must configure and verify the global widget allowlist: ${fragment}`);
   }
+}
+const configurationReads = hostTestSource.match(/getConfiguration\("jupyter"\)/g) ?? [];
+if (configurationReads.length < 3) {
+  throw new Error("widget settings must be reacquired after update and after Jupyter activation");
+}
+const activationIndex = hostTestSource.indexOf("const jupyterApi = await jupyter.activate();");
+const consumerVerificationIndex = hostTestSource.indexOf(
+  "verifyWidgetScriptSourcesAfterActivation(evidence);",
+);
+if (activationIndex < 0 || consumerVerificationIndex < activationIndex) {
+  throw new Error("effective widget settings must be verified after Jupyter activation");
 }
 
 const notebookPath = path.join(repository, "tests", "jupyterlab_host", "branch_round_trip.ipynb");

--- a/tests/vscode_host/scripts/check.cjs
+++ b/tests/vscode_host/scripts/check.cjs
@@ -1,0 +1,61 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const pins = require("../pins.cjs");
+
+const root = path.resolve(__dirname, "..");
+const repository = path.resolve(root, "..", "..");
+const manifest = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+const renderer = manifest.contributes.notebookRenderer[0];
+if (renderer.entrypoint.extends !== "jupyter-ipywidget-renderer") {
+  throw new Error("probe must extend the real Jupyter IPyWidget renderer");
+}
+if (renderer.requiresMessaging !== "always") {
+  throw new Error("probe must require the supported renderer messaging boundary");
+}
+if (manifest.devDependencies["@vscode/test-electron"] !== "3.0.0") {
+  throw new Error("@vscode/test-electron must remain exactly pinned");
+}
+if (manifest.packageManager !== `npm@${pins.npm}` || manifest.engines.node !== pins.node) {
+  throw new Error("Node.js and npm must remain exactly pinned");
+}
+if (pins.vscode !== "1.128.0") {
+  throw new Error("VS Code Desktop must remain exactly pinned");
+}
+
+const notebookPath = path.join(repository, "tests", "jupyterlab_host", "branch_round_trip.ipynb");
+const notebook = JSON.parse(fs.readFileSync(notebookPath, "utf8"));
+if (notebook.metadata.kernelspec.name !== "hypster-host") {
+  throw new Error("the shared host fixture's clean kernelspec changed");
+}
+for (const marker of ["HYPSTER_IMPORT_PATH=", "HYPSTER_PARAMS_VERIFIED="]) {
+  const matches = notebook.cells.filter((cell) => cell.source.join("").includes(marker));
+  if (matches.length !== 1) {
+    throw new Error(`expected one shared-fixture cell containing ${marker}, got ${matches.length}`);
+  }
+}
+const copiedNotebooks = fs.readdirSync(root).filter((name) => name.endsWith(".ipynb"));
+if (copiedNotebooks.length) {
+  throw new Error(`VS Code-only notebook copies are forbidden: ${copiedNotebooks}`);
+}
+
+for (const file of [
+  "extension.cjs",
+  "creation-gate.cjs",
+  "renderer.mjs",
+  "run.cjs",
+  "scripts/assert-runtime.cjs",
+  "scripts/test-creation-gate.cjs",
+  "test/index.cjs",
+]) {
+  const completed = spawnSync(process.execPath, ["--check", path.join(root, file)], {
+    encoding: "utf8",
+  });
+  if (completed.status !== 0) {
+    throw new Error(`syntax check failed for ${file}:\n${completed.stderr}`);
+  }
+}
+
+console.log("VS Code host spike structure is valid");

--- a/tests/vscode_host/scripts/check.cjs
+++ b/tests/vscode_host/scripts/check.cjs
@@ -52,7 +52,7 @@ for (const fragment of [
   "effectiveBeforeActivation",
   "effectiveAfterActivation",
   "startLocalWidgetSource(pythonExecutable)",
-  "localWidgetSource.assertUsed()",
+  "localWidgetSource.assertUsed(",
   "prepareWidgetViewport(evidence, editor, creationCell)",
   "NotebookEditorRevealType.InCenter",
   "creationCellVisible",
@@ -117,14 +117,18 @@ if (copiedNotebooks.length) {
 
 for (const file of [
   "extension.cjs",
+  "cli-runner.cjs",
   "creation-gate.cjs",
   "renderer.mjs",
+  "renderer-witness.mjs",
   "renderer-gate.cjs",
   "run.cjs",
   "widget-source.cjs",
   "scripts/assert-runtime.cjs",
   "scripts/test-creation-gate.cjs",
+  "scripts/test-cli-runner.cjs",
   "scripts/test-renderer-gate.cjs",
+  "scripts/test-renderer-witness.mjs",
   "scripts/test-widget-source.cjs",
   "test/index.cjs",
 ]) {

--- a/tests/vscode_host/scripts/check.cjs
+++ b/tests/vscode_host/scripts/check.cjs
@@ -18,6 +18,15 @@ if (renderer.requiresMessaging !== "always") {
 if (manifest.devDependencies["@vscode/test-electron"] !== "3.0.0") {
   throw new Error("@vscode/test-electron must remain exactly pinned");
 }
+if (manifest.devDependencies["@vscode/python-extension"] !== "1.0.6") {
+  throw new Error("@vscode/python-extension must remain exactly pinned");
+}
+if (
+  JSON.stringify(manifest.extensionDependencies) !==
+  JSON.stringify(["ms-python.python", "ms-toolsai.jupyter"])
+) {
+  throw new Error("the host probe must activate the exact Python and Jupyter extension APIs");
+}
 if (manifest.packageManager !== `npm@${pins.npm}` || manifest.engines.node !== pins.node) {
   throw new Error("Node.js and npm must remain exactly pinned");
 }

--- a/tests/vscode_host/scripts/check.cjs
+++ b/tests/vscode_host/scripts/check.cjs
@@ -27,6 +27,12 @@ if (
 ) {
   throw new Error("the host probe must activate the exact Python and Jupyter extension APIs");
 }
+if (
+  JSON.stringify(manifest.activationEvents) !==
+  JSON.stringify(["onRenderer:hypster-vscode-host-probe"])
+) {
+  throw new Error("the extension host must activate from its renderer-originated ready message");
+}
 if (manifest.packageManager !== `npm@${pins.npm}` || manifest.engines.node !== pins.node) {
   throw new Error("Node.js and npm must remain exactly pinned");
 }
@@ -70,7 +76,9 @@ if (activationIndex < 0 || consumerVerificationIndex < activationIndex) {
 const rendererSource = fs.readFileSync(path.join(root, "renderer.mjs"), "utf8");
 const extensionSource = fs.readFileSync(path.join(root, "extension.cjs"), "utf8");
 for (const fragment of [
-  "const EXERCISE_TIMEOUT_MS = 25_000;",
+  "const EXERCISE_TIMEOUT_MS = 20_000;",
+  "context.getRenderer(BASE_RENDERER_ID)",
+  'kind: "hypster-probe-ready"',
   'window.addEventListener(\n  "error"',
   'window.addEventListener("unhandledrejection"',
   "RENDERER_DIAGNOSTICS",
@@ -111,10 +119,12 @@ for (const file of [
   "extension.cjs",
   "creation-gate.cjs",
   "renderer.mjs",
+  "renderer-gate.cjs",
   "run.cjs",
   "widget-source.cjs",
   "scripts/assert-runtime.cjs",
   "scripts/test-creation-gate.cjs",
+  "scripts/test-renderer-gate.cjs",
   "scripts/test-widget-source.cjs",
   "test/index.cjs",
 ]) {

--- a/tests/vscode_host/scripts/check.cjs
+++ b/tests/vscode_host/scripts/check.cjs
@@ -47,6 +47,9 @@ for (const fragment of [
   "effectiveAfterActivation",
   "startLocalWidgetSource(pythonExecutable)",
   "localWidgetSource.assertUsed()",
+  "prepareWidgetViewport(evidence, editor, creationCell)",
+  "NotebookEditorRevealType.InCenter",
+  "creationCellVisible",
 ]) {
   if (!hostTestSource.includes(fragment)) {
     throw new Error(`host test must configure and verify the global widget allowlist: ${fragment}`);
@@ -62,6 +65,26 @@ const consumerVerificationIndex = hostTestSource.indexOf(
 );
 if (activationIndex < 0 || consumerVerificationIndex < activationIndex) {
   throw new Error("effective widget settings must be verified after Jupyter activation");
+}
+
+const rendererSource = fs.readFileSync(path.join(root, "renderer.mjs"), "utf8");
+const extensionSource = fs.readFileSync(path.join(root, "extension.cjs"), "utf8");
+for (const fragment of [
+  "const EXERCISE_TIMEOUT_MS = 25_000;",
+  'window.addEventListener(\n  "error"',
+  'window.addEventListener("unhandledrejection"',
+  "RENDERER_DIAGNOSTICS",
+  "baseRendererContextPresent",
+  "blobModuleImport",
+  "bodyHtml",
+]) {
+  if (
+    !rendererSource.includes(fragment) &&
+    !extensionSource.includes(fragment) &&
+    !hostTestSource.includes(fragment)
+  ) {
+    throw new Error(`renderer diagnostics must remain fail-loud: ${fragment}`);
+  }
 }
 
 const notebookPath = path.join(repository, "tests", "jupyterlab_host", "branch_round_trip.ipynb");

--- a/tests/vscode_host/scripts/test-cli-runner.cjs
+++ b/tests/vscode_host/scripts/test-cli-runner.cjs
@@ -1,0 +1,40 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { CLI_TIMEOUT_MS, runCLI } = require("../cli-runner.cjs");
+
+let invocation;
+const output = runCLI(
+  "/vscode/bin/code",
+  ["--base"],
+  ["--install-extension", "publisher.extension@1.2.3"],
+  { PATH: "/bin" },
+  (...args) => {
+    invocation = args;
+    return { error: undefined, status: 0, stdout: "installed\n", stderr: "warning\n" };
+  },
+);
+assert.equal(CLI_TIMEOUT_MS, 120_000);
+assert.deepEqual(invocation.slice(0, 2), [
+  "/vscode/bin/code",
+  ["--base", "--install-extension", "publisher.extension@1.2.3"],
+]);
+assert.equal(invocation[2].timeout, CLI_TIMEOUT_MS);
+assert.equal(output, "installed\nwarning");
+
+assert.throws(
+  () =>
+    runCLI("code", [], ["--list-extensions"], {}, () => ({
+      error: Object.assign(new Error("spawnSync code ETIMEDOUT"), { code: "ETIMEDOUT" }),
+      status: null,
+      stdout: "partial stdout",
+      stderr: "partial stderr",
+    })),
+  (error) =>
+    error.message.includes("VS Code CLI failed (null)") &&
+    error.message.includes("partial stdout") &&
+    error.message.includes("partial stderr") &&
+    error.message.includes("ETIMEDOUT"),
+);
+
+console.log("bounded VS Code CLI runner and error evidence passed");

--- a/tests/vscode_host/scripts/test-creation-gate.cjs
+++ b/tests/vscode_host/scripts/test-creation-gate.cjs
@@ -1,0 +1,43 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { classifyMissingCreationMarker } = require("../creation-gate.cjs");
+
+const fulfilled = { status: "fulfilled" };
+const neverExecuted = {
+  selectorCommand: fulfilled,
+  creationCommand: fulfilled,
+  executionSummary: null,
+  outputCount: 0,
+  rawOutput: "",
+};
+
+assert.deepEqual(classifyMissingCreationMarker(neverExecuted), {
+  accepted: true,
+  outcome: "kernel_selection_gate_failure",
+  reason: "Kernel selection and execution commands fulfilled, but the creation cell never executed.",
+});
+
+for (const [name, falsifier] of Object.entries({
+  selectorRejected: { selectorCommand: { status: "rejected", error: "unknown controller" } },
+  selectorTimedOut: { selectorCommand: { status: "timeout" } },
+  missingKernelspec: {
+    creationCommand: { status: "rejected", error: "No kernel named hypster-host" },
+  },
+  creationTimedOut: { creationCommand: { status: "timeout" } },
+  executionFailed: { executionSummary: { success: false } },
+  executionCompleted: { executionSummary: { success: true } },
+  missingKernelspecOutput: {
+    executionSummary: { success: false },
+    outputCount: 1,
+    rawOutput: "Error: No kernel named hypster-host",
+  },
+  unrelatedErrorOutput: { outputCount: 1, rawOutput: "ImportError: unrelated dependency" },
+  nonTextOutput: { outputCount: 1 },
+})) {
+  const result = classifyMissingCreationMarker({ ...neverExecuted, ...falsifier });
+  assert.equal(result.accepted, false, `${name} must not be an accepted gate outcome`);
+  assert.equal(result.outcome, "runtime_failure", `${name} must be red`);
+}
+
+console.log("creation-gate classifier rejects command, execution, and output falsifiers");

--- a/tests/vscode_host/scripts/test-creation-gate.cjs
+++ b/tests/vscode_host/scripts/test-creation-gate.cjs
@@ -1,7 +1,10 @@
 "use strict";
 
 const assert = require("node:assert/strict");
-const { classifyMissingCreationMarker } = require("../creation-gate.cjs");
+const {
+  classifyCommandResult,
+  classifyMissingCreationMarker,
+} = require("../creation-gate.cjs");
 
 const fulfilled = { status: "fulfilled" };
 const neverExecuted = {
@@ -12,13 +15,8 @@ const neverExecuted = {
   rawOutput: "",
 };
 
-assert.deepEqual(classifyMissingCreationMarker(neverExecuted), {
-  accepted: true,
-  outcome: "kernel_selection_gate_failure",
-  reason: "Kernel selection and execution commands fulfilled, but the creation cell never executed.",
-});
-
 for (const [name, falsifier] of Object.entries({
+  transientEmptyState: {},
   selectorRejected: { selectorCommand: { status: "rejected", error: "unknown controller" } },
   selectorTimedOut: { selectorCommand: { status: "timeout" } },
   missingKernelspec: {
@@ -40,4 +38,15 @@ for (const [name, falsifier] of Object.entries({
   assert.equal(result.outcome, "runtime_failure", `${name} must be red`);
 }
 
-console.log("creation-gate classifier rejects command, execution, and output falsifiers");
+assert.deepEqual(classifyCommandResult("verification execution", fulfilled), { ok: true });
+for (const status of ["rejected", "timeout"]) {
+  assert.deepEqual(classifyCommandResult("verification execution", { status }), {
+    ok: false,
+    outcome: "runtime_failure",
+    reason: `verification execution command ${status}`,
+  });
+}
+
+console.log(
+  "host classifier rejects transient creation state and verification command failures",
+);

--- a/tests/vscode_host/scripts/test-creation-gate.cjs
+++ b/tests/vscode_host/scripts/test-creation-gate.cjs
@@ -4,6 +4,7 @@ const assert = require("node:assert/strict");
 const {
   classifyCommandResult,
   classifyMissingCreationMarker,
+  selectKernelStrategy,
 } = require("../creation-gate.cjs");
 
 const fulfilled = { status: "fulfilled" };
@@ -47,6 +48,20 @@ for (const status of ["rejected", "timeout"]) {
   });
 }
 
+assert.equal(
+  selectKernelStrategy({ openNotebookExported: true, commandRegistered: false }),
+  "ms-toolsai.jupyter.exports.openNotebook",
+  "the supported export must bypass the observed missing command",
+);
+assert.equal(
+  selectKernelStrategy({ openNotebookExported: false, commandRegistered: true }),
+  "notebook.selectKernel",
+);
+assert.equal(
+  selectKernelStrategy({ openNotebookExported: false, commandRegistered: false }),
+  "kernel_selection_gate_failure",
+);
+
 console.log(
-  "host classifier rejects transient creation state and verification command failures",
+  "host classifier rejects races and prefers the supported Jupyter export",
 );

--- a/tests/vscode_host/scripts/test-renderer-gate.cjs
+++ b/tests/vscode_host/scripts/test-renderer-gate.cjs
@@ -1,0 +1,40 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const {
+  ACTIVATION_TIMEOUT_MS,
+  OUTER_TIMEOUT_MS,
+  RENDERER_EXERCISE_TIMEOUT_MS,
+  RESPONSE_TIMEOUT_MS,
+  RendererActivationGate,
+} = require("../renderer-gate.cjs");
+
+async function main() {
+  assert.ok(ACTIVATION_TIMEOUT_MS + RESPONSE_TIMEOUT_MS < OUTER_TIMEOUT_MS);
+  assert.ok(RENDERER_EXERCISE_TIMEOUT_MS < RESPONSE_TIMEOUT_MS);
+
+  const earlyReady = new RendererActivationGate();
+  earlyReady.markReady("notebook-1", { phase: "activate" });
+  assert.deepEqual(await earlyReady.wait("notebook-1"), { phase: "activate" });
+  earlyReady.dispose();
+
+  const lateReady = new RendererActivationGate();
+  const waiting = lateReady.wait("notebook-2", 100);
+  lateReady.markReady("notebook-2", { phase: "activate-after-wait" });
+  assert.deepEqual(await waiting, { phase: "activate-after-wait" });
+  lateReady.dispose();
+
+  const missingReady = new RendererActivationGate();
+  await assert.rejects(
+    missingReady.wait("notebook-3", 10),
+    /renderer activation handshake timed out after 10ms for notebook-3/,
+  );
+  missingReady.dispose();
+
+  console.log("renderer ready handshake rejects the pre-activation message race before outer timeout");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/vscode_host/scripts/test-renderer-witness.mjs
+++ b/tests/vscode_host/scripts/test-renderer-witness.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { detectWidgetRootTransition } from "../renderer-witness.mjs";
+
+const previousRoot = { innerHTML: "before", isConnected: false };
+const replacementRoot = { innerHTML: "after", isConnected: true };
+assert.deepEqual(
+  detectWidgetRootTransition(previousRoot, "before", replacementRoot),
+  { kind: "replaced", currentRoot: replacementRoot },
+);
+
+previousRoot.isConnected = true;
+assert.equal(detectWidgetRootTransition(previousRoot, "before", replacementRoot), undefined);
+
+previousRoot.innerHTML = "after";
+assert.deepEqual(
+  detectWidgetRootTransition(previousRoot, "before", previousRoot),
+  { kind: "updated-in-place", currentRoot: previousRoot },
+);
+
+previousRoot.innerHTML = "before";
+assert.equal(detectWidgetRootTransition(previousRoot, "before", previousRoot), undefined);
+assert.equal(
+  detectWidgetRootTransition(previousRoot, "before", { innerHTML: "after", isConnected: false }),
+  undefined,
+);
+
+console.log("connected renderer root transition witness passed");

--- a/tests/vscode_host/scripts/test-renderer-witness.mjs
+++ b/tests/vscode_host/scripts/test-renderer-witness.mjs
@@ -1,5 +1,54 @@
 import assert from "node:assert/strict";
-import { detectWidgetRootTransition } from "../renderer-witness.mjs";
+import {
+  detectWidgetRootTransition,
+  findPublishedRemoteState,
+} from "../renderer-witness.mjs";
+
+const numericSelector = "input[data-path='remote.temperature'][data-kind='float']";
+const modeSelector = ".hypster-choice[data-path='mode'] .hypster-choice-value";
+
+const menuClosingRoot = {
+  innerHTML: "menu-closed-before-backend-publish",
+  isConnected: true,
+  querySelector(selector) {
+    return selector === modeSelector ? { textContent: "local" } : undefined;
+  },
+};
+assert.deepEqual(
+  detectWidgetRootTransition(menuClosingRoot, "menu-open", menuClosingRoot),
+  { kind: "updated-in-place", currentRoot: menuClosingRoot },
+  "menu close reproduces the premature HTML-only transition",
+);
+assert.equal(
+  findPublishedRemoteState({ querySelector: () => undefined }),
+  undefined,
+  "menu close alone is not published remote state",
+);
+
+const publishedRoot = {
+  innerHTML: "remote-published",
+  isConnected: true,
+  querySelector(selector) {
+    return selector === modeSelector ? { textContent: "remote" } : undefined;
+  },
+};
+const publishedNumeric = {
+  isConnected: true,
+  closest(selector) {
+    return selector === ".hypster-widget" ? publishedRoot : undefined;
+  },
+};
+const publishedState = findPublishedRemoteState({
+  querySelector(selector) {
+    return selector === numericSelector ? publishedNumeric : undefined;
+  },
+});
+assert.deepEqual(publishedState, { currentRoot: publishedRoot, numeric: publishedNumeric });
+menuClosingRoot.isConnected = false;
+assert.deepEqual(
+  detectWidgetRootTransition(menuClosingRoot, "menu-open", publishedState.currentRoot),
+  { kind: "replaced", currentRoot: publishedRoot },
+);
 
 const previousRoot = { innerHTML: "before", isConnected: false };
 const replacementRoot = { innerHTML: "after", isConnected: true };
@@ -24,4 +73,4 @@ assert.equal(
   undefined,
 );
 
-console.log("connected renderer root transition witness passed");
+console.log("semantic publication precedes connected renderer root transition");

--- a/tests/vscode_host/scripts/test-widget-source.cjs
+++ b/tests/vscode_host/scripts/test-widget-source.cjs
@@ -1,0 +1,75 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  ANYWIDGET_ROUTE,
+  anywidgetAssetPaths,
+  startLocalWidgetSource,
+  widgetSourceTemplate,
+} = require("../widget-source.cjs");
+
+const extensionSource = `define(function () {
+  "use strict";
+  window.requirejs?.config({
+    map: { "*": { anywidget: "nbextensions/anywidget/index" } },
+  });
+});\n`;
+const indexSource = "define('anywidget', [], function () { return {}; });\n";
+const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hypster-widget-source-"));
+const pythonExecutable = path.join(temporaryRoot, "kernel", "bin", "python");
+const assets = anywidgetAssetPaths(pythonExecutable);
+fs.mkdirSync(path.dirname(pythonExecutable), { recursive: true });
+fs.writeFileSync(pythonExecutable, "#!/bin/sh\n");
+fs.mkdirSync(assets.nbextensionRoot, { recursive: true });
+fs.writeFileSync(assets.extensionPath, extensionSource);
+fs.writeFileSync(assets.indexPath, indexSource);
+
+async function main() {
+  const source = await startLocalWidgetSource(pythonExecutable);
+  try {
+    assert.equal(
+      source.template,
+      `http://127.0.0.1:${source.evidence.port}/\${packageName}/\${fileNameWithExt}`,
+    );
+    assert.equal(widgetSourceTemplate(source.evidence.port), source.template);
+    assert.equal(source.evidence.asset.kernelPrefix, path.join(temporaryRoot, "kernel"));
+    assert.equal(
+      source.evidence.asset.indexSha256,
+      crypto.createHash("sha256").update(indexSource).digest("hex"),
+    );
+
+    const headResponse = await fetch(`http://127.0.0.1:${source.evidence.port}${ANYWIDGET_ROUTE}`, {
+      method: "HEAD",
+    });
+    assert.equal(headResponse.status, 200);
+    const getResponse = await fetch(`http://127.0.0.1:${source.evidence.port}${ANYWIDGET_ROUTE}`);
+    assert.equal(getResponse.status, 200);
+    assert.equal(await getResponse.text(), indexSource);
+    const rejectedResponse = await fetch(
+      `http://127.0.0.1:${source.evidence.port}/unexpected.js`,
+    );
+    assert.equal(rejectedResponse.status, 404);
+    source.assertUsed();
+    assert.equal(source.evidence.successfulIndexGetVerified, true);
+  } finally {
+    await source.close();
+  }
+
+  fs.writeFileSync(assets.extensionPath, "define(function () {});\n");
+  await assert.rejects(
+    startLocalWidgetSource(pythonExecutable),
+    /not compatible with Jupyter 2025\.9\.1's local widget-source parser/,
+  );
+  console.log("local anywidget source path, hash, route, and fail-loud parser gate passed");
+}
+
+main()
+  .finally(() => fs.rmSync(temporaryRoot, { recursive: true, force: true }))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/tests/vscode_host/scripts/test-widget-source.cjs
+++ b/tests/vscode_host/scripts/test-widget-source.cjs
@@ -46,7 +46,18 @@ async function main() {
       method: "HEAD",
     });
     assert.equal(headResponse.status, 200);
-    const getResponse = await fetch(`http://127.0.0.1:${source.evidence.port}${ANYWIDGET_ROUTE}`);
+    const extensionHostResponse = await fetch(
+      `http://127.0.0.1:${source.evidence.port}${ANYWIDGET_ROUTE}`,
+    );
+    assert.equal(extensionHostResponse.status, 200);
+    assert.throws(
+      () => source.assertUsed(),
+      /Electron webview did not fetch the exact local anywidget bundle/,
+    );
+    const getResponse = await fetch(
+      `http://127.0.0.1:${source.evidence.port}${ANYWIDGET_ROUTE}`,
+      { headers: { "User-Agent": "Code/1.128.0 Electron/42.5.0" } },
+    );
     assert.equal(getResponse.status, 200);
     assert.equal(await getResponse.text(), indexSource);
     const rejectedResponse = await fetch(

--- a/tests/vscode_host/scripts/test-widget-source.cjs
+++ b/tests/vscode_host/scripts/test-widget-source.cjs
@@ -52,7 +52,41 @@ async function main() {
     assert.equal(extensionHostResponse.status, 200);
     assert.throws(
       () => source.assertUsed(),
-      /Electron webview did not fetch the exact local anywidget bundle/,
+      /VS Code did not consume the exact local anywidget bundle/,
+    );
+    const copiedScriptPath = path.join(
+      temporaryRoot,
+      "extensions",
+      "ms-toolsai.jupyter-2025.9.1",
+      "temp",
+      "scripts",
+      "kernel-hash",
+      "jupyter",
+      "nbextensions",
+      "anywidget",
+      "index.js",
+    );
+    fs.mkdirSync(path.dirname(copiedScriptPath), { recursive: true });
+    const copiedScriptUrl =
+      `https://file+.vscode-resource.vscode-cdn.net${copiedScriptPath}`;
+    const copiedDiagnostics = {
+      amd: {
+        anywidgetDefined: true,
+        relevantFetchedUrls: [copiedScriptUrl],
+      },
+    };
+    fs.writeFileSync(copiedScriptPath, "define('anywidget', [], function () { return null; });\n");
+    assert.throws(
+      () => source.assertUsed(copiedDiagnostics),
+      /copied anywidget bundle did not match the selected kernel bytes/,
+    );
+    fs.writeFileSync(copiedScriptPath, indexSource);
+    source.assertUsed(copiedDiagnostics);
+    assert.equal(source.evidence.consumption.kind, "vscode-local-copy");
+    assert.equal(source.evidence.consumption.copiedScript.path, copiedScriptPath);
+    assert.equal(
+      source.evidence.consumption.copiedScript.sha256,
+      source.evidence.asset.indexSha256,
     );
     const getResponse = await fetch(
       `http://127.0.0.1:${source.evidence.port}${ANYWIDGET_ROUTE}`,

--- a/tests/vscode_host/test/index.cjs
+++ b/tests/vscode_host/test/index.cjs
@@ -127,20 +127,46 @@ async function configureWidgetScriptSources(evidence) {
     expected,
     vscode.ConfigurationTarget.Global,
   );
-  const inspected = configuration.inspect("widgetScriptSources");
-  const effective = configuration.get("widgetScriptSources");
+  const persistedConfiguration = vscode.workspace.getConfiguration("jupyter");
+  const inspected = persistedConfiguration.inspect("widgetScriptSources");
+  const effective = persistedConfiguration.get("widgetScriptSources");
   evidence.rendererBoundary.widgetScriptSources = {
     target: "global",
     expected,
+    globalLocalValue: inspected?.globalLocalValue ?? null,
     globalValue: inspected?.globalValue ?? null,
-    effectiveValue: effective ?? null,
+    effectiveBeforeActivation: effective ?? null,
   };
   if (
+    (inspected?.globalLocalValue !== undefined &&
+      JSON.stringify(inspected.globalLocalValue) !== JSON.stringify(expected)) ||
     JSON.stringify(inspected?.globalValue) !== JSON.stringify(expected) ||
     JSON.stringify(effective) !== JSON.stringify(expected)
   ) {
     throw new Error(
       `jupyter.widgetScriptSources did not persist globally: ${JSON.stringify(inspected)}`,
+    );
+  }
+}
+
+function verifyWidgetScriptSourcesAfterActivation(evidence) {
+  const configuration = vscode.workspace.getConfiguration("jupyter");
+  const expected = [...pins.widgetScriptSources];
+  const inspected = configuration.inspect("widgetScriptSources");
+  const effective = configuration.get("widgetScriptSources");
+  evidence.rendererBoundary.widgetScriptSources.globalLocalValueAfterActivation =
+    inspected?.globalLocalValue ?? null;
+  evidence.rendererBoundary.widgetScriptSources.globalValueAfterActivation =
+    inspected?.globalValue ?? null;
+  evidence.rendererBoundary.widgetScriptSources.effectiveAfterActivation = effective ?? null;
+  if (
+    (inspected?.globalLocalValue !== undefined &&
+      JSON.stringify(inspected.globalLocalValue) !== JSON.stringify(expected)) ||
+    JSON.stringify(inspected?.globalValue) !== JSON.stringify(expected) ||
+    JSON.stringify(effective) !== JSON.stringify(expected)
+  ) {
+    throw new Error(
+      `Jupyter did not consume the global widget script sources: ${JSON.stringify(inspected)}`,
     );
   }
 }
@@ -232,6 +258,7 @@ async function run() {
     const jupyter = vscode.extensions.getExtension("ms-toolsai.jupyter");
     const pythonApi = await PythonExtension.api();
     const jupyterApi = await jupyter.activate();
+    verifyWidgetScriptSourcesAfterActivation(evidence);
     evidence.selector.pythonFacade = {
       package: "@vscode/python-extension",
       version: pythonFacadePackage.version,

--- a/tests/vscode_host/test/index.cjs
+++ b/tests/vscode_host/test/index.cjs
@@ -119,6 +119,32 @@ function pythonEnvironmentEvidence(environment, requestedExecutable) {
   };
 }
 
+async function configureWidgetScriptSources(evidence) {
+  const configuration = vscode.workspace.getConfiguration("jupyter");
+  const expected = [...pins.widgetScriptSources];
+  await configuration.update(
+    "widgetScriptSources",
+    expected,
+    vscode.ConfigurationTarget.Global,
+  );
+  const inspected = configuration.inspect("widgetScriptSources");
+  const effective = configuration.get("widgetScriptSources");
+  evidence.rendererBoundary.widgetScriptSources = {
+    target: "global",
+    expected,
+    globalValue: inspected?.globalValue ?? null,
+    effectiveValue: effective ?? null,
+  };
+  if (
+    JSON.stringify(inspected?.globalValue) !== JSON.stringify(expected) ||
+    JSON.stringify(effective) !== JSON.stringify(expected)
+  ) {
+    throw new Error(
+      `jupyter.widgetScriptSources did not persist globally: ${JSON.stringify(inspected)}`,
+    );
+  }
+}
+
 function recordCreationState(roundTrip, cell) {
   roundTrip.creationExecutionSummary = executionSummary(cell);
   roundTrip.creationOutputCount = cell.outputs.length;
@@ -202,6 +228,7 @@ async function run() {
 
   let editor;
   try {
+    await configureWidgetScriptSources(evidence);
     const jupyter = vscode.extensions.getExtension("ms-toolsai.jupyter");
     const pythonApi = await PythonExtension.api();
     const jupyterApi = await jupyter.activate();

--- a/tests/vscode_host/test/index.cjs
+++ b/tests/vscode_host/test/index.cjs
@@ -176,6 +176,11 @@ async function run() {
 
   let editor;
   try {
+    const python = vscode.extensions.getExtension("ms-python.python");
+    const jupyter = vscode.extensions.getExtension("ms-toolsai.jupyter");
+    await python.activate();
+    await jupyter.activate();
+
     const commands = await vscode.commands.getCommands(true);
     if (!commands.includes("notebook.selectKernel")) {
       throw new Error("VS Code did not register the documented notebook.selectKernel command");
@@ -189,11 +194,6 @@ async function run() {
         `public controller discovery unexpectedly appeared: ${evidence.selector.publicControllerDiscoveryKeys}`,
       );
     }
-
-    const python = vscode.extensions.getExtension("ms-python.python");
-    const jupyter = vscode.extensions.getExtension("ms-toolsai.jupyter");
-    await python.activate();
-    await jupyter.activate();
 
     const document = await vscode.workspace.openNotebookDocument(vscode.Uri.file(notebookPath));
     const creationCell = cellBySourceMarker(document, "HYPSTER_IMPORT_PATH=");

--- a/tests/vscode_host/test/index.cjs
+++ b/tests/vscode_host/test/index.cjs
@@ -1,0 +1,301 @@
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const vscode = require("vscode");
+const { classifyMissingCreationMarker } = require("../creation-gate.cjs");
+const pins = require("../pins.cjs");
+
+const decoder = new TextDecoder();
+
+function requiredPath(name) {
+  const value = process.env[name];
+  if (!value || !path.isAbsolute(value)) {
+    throw new Error(`${name} must be an explicit absolute path`);
+  }
+  return value;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function settleWithin(promise, milliseconds) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise.then(
+        (value) => ({ status: "fulfilled", value }),
+        (error) => ({
+          status: "rejected",
+          error: error instanceof Error ? `${error.message}\n${error.stack}` : String(error),
+        }),
+      ),
+      new Promise((resolve) => {
+        timer = setTimeout(() => resolve({ status: "timeout", milliseconds }), milliseconds);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function outputText(cell) {
+  return cell.outputs
+    .flatMap((output) => output.items)
+    .map((item) => {
+      try {
+        return decoder.decode(item.data);
+      } catch (error) {
+        return `[decode error for ${item.mime}: ${error}]`;
+      }
+    })
+    .join("\n");
+}
+
+async function waitForMarker(cell, marker, milliseconds) {
+  const deadline = Date.now() + milliseconds;
+  while (Date.now() < deadline) {
+    const text = outputText(cell);
+    if (text.includes(marker)) {
+      return text;
+    }
+    await delay(100);
+  }
+  throw new Error(
+    `cell ${cell.index} did not emit ${JSON.stringify(marker)} within ${milliseconds}ms; ` +
+      `outputs were:\n${outputText(cell)}`,
+  );
+}
+
+function cellBySourceMarker(document, marker) {
+  const matches = document.getCells().filter((cell) => cell.document.getText().includes(marker));
+  if (matches.length !== 1) {
+    throw new Error(`expected one cell containing ${JSON.stringify(marker)}, got ${matches.length}`);
+  }
+  return matches[0];
+}
+
+function executionSummary(cell) {
+  const summary = cell.executionSummary;
+  if (!summary) {
+    return null;
+  }
+  return {
+    executionOrder: summary.executionOrder ?? null,
+    success: summary.success ?? null,
+    timing: summary.timing
+      ? {
+          startTime: summary.timing.startTime,
+          endTime: summary.timing.endTime,
+        }
+      : null,
+  };
+}
+
+function recordCreationState(roundTrip, cell) {
+  roundTrip.creationExecutionSummary = executionSummary(cell);
+  roundTrip.creationOutputCount = cell.outputs.length;
+  roundTrip.creationRawOutput = outputText(cell);
+}
+
+function classifyRecordedCreationState(evidence) {
+  return classifyMissingCreationMarker({
+    selectorCommand: evidence.selector.commandResult,
+    creationCommand: evidence.roundTrip.creationCommand,
+    executionSummary: evidence.roundTrip.creationExecutionSummary,
+    outputCount: evidence.roundTrip.creationOutputCount,
+    rawOutput: evidence.roundTrip.creationRawOutput,
+  });
+}
+
+function extensionVersions() {
+  return Object.fromEntries(
+    Object.entries(pins.extensions).map(([id, expected]) => {
+      const extension = vscode.extensions.getExtension(id);
+      if (!extension) {
+        throw new Error(`required extension ${id}@${expected} is not installed`);
+      }
+      const actual = extension.packageJSON.version;
+      if (actual !== expected) {
+        throw new Error(`required extension ${id} expected ${expected}, got ${actual}`);
+      }
+      return [id, actual];
+    }),
+  );
+}
+
+async function run() {
+  const notebookPath = requiredPath("HYPSTER_NOTEBOOK");
+  const artifactDir = requiredPath("HYPSTER_VSCODE_ARTIFACT_DIR");
+  fs.mkdirSync(artifactDir, { recursive: true });
+
+  const evidence = {
+    platform: {
+      arch: os.arch(),
+      platform: os.platform(),
+      release: os.release(),
+    },
+    processVersions: process.versions,
+    extensionHostEnvironmentKeys: Object.keys(process.env).sort(),
+    vscode: {
+      expected: pins.vscode,
+      actual: vscode.version,
+      electron: process.versions.electron,
+      chromium: process.versions.chrome,
+    },
+    extensions: extensionVersions(),
+    notebookPath,
+    notebooksApiKeys: Object.keys(vscode.notebooks).sort(),
+    rendererBoundary: {
+      id: "hypster-vscode-host-probe",
+      extends: "jupyter-ipywidget-renderer",
+      messaging: "NotebookRendererMessaging",
+    },
+    selector: {
+      command: "notebook.selectKernel",
+      documentedReturn: "void",
+      attemptedArgument: {
+        id: "hypster-host",
+        extension: "ms-toolsai.jupyter",
+      },
+    },
+    roundTrip: { attempted: false },
+  };
+
+  if (vscode.version !== pins.vscode) {
+    throw new Error(`expected VS Code ${pins.vscode}, got ${vscode.version}`);
+  }
+  if (process.platform !== "linux") {
+    throw new Error(`physical witness requires Ubuntu/Linux, got ${process.platform}`);
+  }
+  if (!process.versions.electron || !process.versions.chrome) {
+    throw new Error("Electron or Chromium runtime version is missing from the physical witness");
+  }
+
+  let editor;
+  try {
+    const commands = await vscode.commands.getCommands(true);
+    if (!commands.includes("notebook.selectKernel")) {
+      throw new Error("VS Code did not register the documented notebook.selectKernel command");
+    }
+    const forbiddenDiscoveryKeys = ["controllers", "getControllers", "getNotebookControllers"];
+    evidence.selector.publicControllerDiscoveryKeys = forbiddenDiscoveryKeys.filter((key) =>
+      Object.prototype.hasOwnProperty.call(vscode.notebooks, key),
+    );
+    if (evidence.selector.publicControllerDiscoveryKeys.length) {
+      throw new Error(
+        `public controller discovery unexpectedly appeared: ${evidence.selector.publicControllerDiscoveryKeys}`,
+      );
+    }
+
+    const python = vscode.extensions.getExtension("ms-python.python");
+    const jupyter = vscode.extensions.getExtension("ms-toolsai.jupyter");
+    await python.activate();
+    await jupyter.activate();
+
+    const document = await vscode.workspace.openNotebookDocument(vscode.Uri.file(notebookPath));
+    const creationCell = cellBySourceMarker(document, "HYPSTER_IMPORT_PATH=");
+    const verificationCell = cellBySourceMarker(document, "HYPSTER_PARAMS_VERIFIED=");
+    evidence.fixture = {
+      cellCount: document.cellCount,
+      creationCellIndex: creationCell.index,
+      verificationCellIndex: verificationCell.index,
+    };
+    editor = await vscode.window.showNotebookDocument(document);
+    await delay(2_000);
+
+    evidence.selector.commandResult = await settleWithin(
+      vscode.commands.executeCommand("notebook.selectKernel", {
+        notebookEditor: editor,
+        id: "hypster-host",
+        extension: "ms-toolsai.jupyter",
+      }),
+      10_000,
+    );
+
+    evidence.roundTrip.attempted = true;
+    evidence.roundTrip.creationCommand = await settleWithin(
+      vscode.commands.executeCommand("notebook.cell.execute", {
+        ranges: [{ start: creationCell.index, end: creationCell.index + 1 }],
+        document: document.uri,
+      }),
+      30_000,
+    );
+    if (
+      evidence.selector.commandResult.status !== "fulfilled" ||
+      evidence.roundTrip.creationCommand.status !== "fulfilled"
+    ) {
+      recordCreationState(evidence.roundTrip, creationCell);
+      const classification = classifyRecordedCreationState(evidence);
+      evidence.roundTrip.creationGateClassification = classification;
+      throw new Error(classification.reason);
+    }
+
+    try {
+      evidence.roundTrip.creationOutput = await waitForMarker(
+        creationCell,
+        "HYPSTER_IMPORT_PATH=",
+        20_000,
+      );
+      recordCreationState(evidence.roundTrip, creationCell);
+    } catch (error) {
+      evidence.roundTrip.creationMarkerError =
+        error instanceof Error ? `${error.message}\n${error.stack}` : String(error);
+      recordCreationState(evidence.roundTrip, creationCell);
+      const classification = classifyRecordedCreationState(evidence);
+      evidence.roundTrip.creationGateClassification = classification;
+      evidence.roundTrip.completed = false;
+      if (!classification.accepted) {
+        throw new Error(classification.reason);
+      }
+      evidence.outcome = classification.outcome;
+      evidence.reason = classification.reason;
+      console.log("HYPSTER_VSCODE_KERNEL_SELECTION_GATE_REPRODUCED");
+      return;
+    }
+
+    const probeExtension = vscode.extensions.getExtension("hypster.hypster-vscode-host-spike");
+    if (!probeExtension) {
+      throw new Error("test renderer extension is not registered");
+    }
+    const probe = await probeExtension.activate();
+    evidence.roundTrip.renderer = await probe.exercise(editor);
+
+    evidence.roundTrip.verificationCommand = await settleWithin(
+      vscode.commands.executeCommand("notebook.cell.execute", {
+        ranges: [{ start: verificationCell.index, end: verificationCell.index + 1 }],
+        document: document.uri,
+      }),
+      30_000,
+    );
+    evidence.roundTrip.verificationOutput = await waitForMarker(
+      verificationCell,
+      "HYPSTER_PARAMS_VERIFIED=",
+      20_000,
+    );
+    if (!evidence.roundTrip.verificationOutput.includes("'remote.temperature': 1.25")) {
+      throw new Error(`Python oracle did not contain the falsifier value: ${evidence.roundTrip.verificationOutput}`);
+    }
+    evidence.roundTrip.completed = true;
+    evidence.outcome = "basic_scenario_green";
+    console.log("HYPSTER_VSCODE_BASIC_SCENARIO_GREEN");
+  } catch (error) {
+    evidence.outcome = "runtime_failure";
+    evidence.roundTrip.completed = false;
+    evidence.error = error instanceof Error ? `${error.message}\n${error.stack}` : String(error);
+    throw error;
+  } finally {
+    fs.writeFileSync(
+      path.join(artifactDir, "spike-result.json"),
+      `${JSON.stringify(evidence, null, 2)}\n`,
+    );
+    if (editor) {
+      await vscode.commands.executeCommand("workbench.action.closeActiveEditor");
+    }
+  }
+  console.log(JSON.stringify(evidence, null, 2));
+}
+
+module.exports = { run };

--- a/tests/vscode_host/test/index.cjs
+++ b/tests/vscode_host/test/index.cjs
@@ -4,9 +4,12 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const vscode = require("vscode");
+const { PythonExtension } = require("@vscode/python-extension");
+const pythonFacadePackage = require("@vscode/python-extension/package.json");
 const {
   classifyCommandResult,
   classifyMissingCreationMarker,
+  selectKernelStrategy,
 } = require("../creation-gate.cjs");
 const pins = require("../pins.cjs");
 
@@ -97,6 +100,25 @@ function executionSummary(cell) {
   };
 }
 
+function apiKeys(exports) {
+  return exports && (typeof exports === "object" || typeof exports === "function")
+    ? Object.keys(exports).sort()
+    : [];
+}
+
+function pythonEnvironmentEvidence(environment, requestedExecutable) {
+  const executable = environment?.executable;
+  return {
+    requestedExecutable,
+    id: environment?.id ?? environment?.environment?.id ?? null,
+    path: environment?.path ?? null,
+    executable:
+      typeof executable === "string"
+        ? executable
+        : (executable?.uri?.fsPath ?? executable?.path ?? null),
+  };
+}
+
 function recordCreationState(roundTrip, cell) {
   roundTrip.creationExecutionSummary = executionSummary(cell);
   roundTrip.creationOutputCount = cell.outputs.length;
@@ -131,6 +153,7 @@ function extensionVersions() {
 
 async function run() {
   const notebookPath = requiredPath("HYPSTER_NOTEBOOK");
+  const pythonExecutable = requiredPath("HYPSTER_VSCODE_PYTHON");
   const artifactDir = requiredPath("HYPSTER_VSCODE_ARTIFACT_DIR");
   fs.mkdirSync(artifactDir, { recursive: true });
 
@@ -179,28 +202,29 @@ async function run() {
 
   let editor;
   try {
-    const python = vscode.extensions.getExtension("ms-python.python");
     const jupyter = vscode.extensions.getExtension("ms-toolsai.jupyter");
-    await python.activate();
-    await jupyter.activate();
+    const pythonApi = await PythonExtension.api();
+    const jupyterApi = await jupyter.activate();
+    evidence.selector.pythonFacade = {
+      package: "@vscode/python-extension",
+      version: pythonFacadePackage.version,
+      apiKeys: apiKeys(pythonApi),
+    };
+    evidence.selector.jupyterApiKeys = apiKeys(jupyterApi);
+    evidence.selector.openNotebookExported = typeof jupyterApi?.openNotebook === "function";
 
     const commands = await vscode.commands.getCommands(true);
     evidence.selector.commandRegistered = commands.includes("notebook.selectKernel");
-    if (!evidence.selector.commandRegistered) {
+    evidence.selector.strategy = selectKernelStrategy({
+      openNotebookExported: evidence.selector.openNotebookExported,
+      commandRegistered: evidence.selector.commandRegistered,
+    });
+    if (evidence.selector.strategy === "kernel_selection_gate_failure") {
       evidence.outcome = "kernel_selection_gate_failure";
       evidence.reason =
-        "VS Code did not register the documented notebook.selectKernel command after Jupyter activation.";
+        "Jupyter exported no openNotebook API and VS Code did not register notebook.selectKernel after activation.";
       console.log("HYPSTER_VSCODE_KERNEL_SELECTION_GATE_REPRODUCED");
       return;
-    }
-    const forbiddenDiscoveryKeys = ["controllers", "getControllers", "getNotebookControllers"];
-    evidence.selector.publicControllerDiscoveryKeys = forbiddenDiscoveryKeys.filter((key) =>
-      Object.prototype.hasOwnProperty.call(vscode.notebooks, key),
-    );
-    if (evidence.selector.publicControllerDiscoveryKeys.length) {
-      throw new Error(
-        `public controller discovery unexpectedly appeared: ${evidence.selector.publicControllerDiscoveryKeys}`,
-      );
     }
 
     const document = await vscode.workspace.openNotebookDocument(vscode.Uri.file(notebookPath));
@@ -214,14 +238,59 @@ async function run() {
     editor = await vscode.window.showNotebookDocument(document);
     await delay(2_000);
 
-    evidence.selector.commandResult = await settleWithin(
-      vscode.commands.executeCommand("notebook.selectKernel", {
-        notebookEditor: editor,
-        id: "hypster-host",
-        extension: "ms-toolsai.jupyter",
-      }),
-      10_000,
-    );
+    if (evidence.selector.strategy === "ms-toolsai.jupyter.exports.openNotebook") {
+      if (typeof pythonApi?.environments?.resolveEnvironment !== "function") {
+        throw new Error("Python extension exported no environments.resolveEnvironment API");
+      }
+      const environmentResult = await settleWithin(
+        pythonApi.environments.resolveEnvironment(pythonExecutable),
+        30_000,
+      );
+      evidence.selector.pythonEnvironmentResolution = {
+        status: environmentResult.status,
+        ...(environmentResult.error ? { error: environmentResult.error } : {}),
+      };
+      if (environmentResult.status !== "fulfilled" || !environmentResult.value) {
+        throw new Error(
+          `Python environment resolution ${environmentResult.status} for ${pythonExecutable}`,
+        );
+      }
+      evidence.selector.pythonEnvironment = pythonEnvironmentEvidence(
+        environmentResult.value,
+        pythonExecutable,
+      );
+      if (
+        !evidence.selector.pythonEnvironment.executable ||
+        path.normalize(evidence.selector.pythonEnvironment.executable) !==
+          path.normalize(pythonExecutable)
+      ) {
+        throw new Error(
+          `Python facade resolved ${evidence.selector.pythonEnvironment.executable} instead of ${pythonExecutable}`,
+        );
+      }
+      evidence.selector.commandResult = await settleWithin(
+        jupyterApi.openNotebook(document.uri, environmentResult.value).then(() => undefined),
+        60_000,
+      );
+    } else {
+      const forbiddenDiscoveryKeys = ["controllers", "getControllers", "getNotebookControllers"];
+      evidence.selector.publicControllerDiscoveryKeys = forbiddenDiscoveryKeys.filter((key) =>
+        Object.prototype.hasOwnProperty.call(vscode.notebooks, key),
+      );
+      if (evidence.selector.publicControllerDiscoveryKeys.length) {
+        throw new Error(
+          `public controller discovery unexpectedly appeared: ${evidence.selector.publicControllerDiscoveryKeys}`,
+        );
+      }
+      evidence.selector.commandResult = await settleWithin(
+        vscode.commands.executeCommand("notebook.selectKernel", {
+          notebookEditor: editor,
+          id: "hypster-host",
+          extension: "ms-toolsai.jupyter",
+        }),
+        10_000,
+      );
+    }
 
     evidence.roundTrip.attempted = true;
     evidence.roundTrip.creationCommand = await settleWithin(

--- a/tests/vscode_host/test/index.cjs
+++ b/tests/vscode_host/test/index.cjs
@@ -172,6 +172,47 @@ function verifyWidgetScriptSourcesAfterActivation(evidence, sourceTemplate) {
   }
 }
 
+async function prepareWidgetViewport(evidence, editor, creationCell) {
+  const commands = [
+    "workbench.action.problems.focus",
+    "workbench.action.togglePanel",
+    "workbench.action.maximizeEditorHideSidebar",
+    "notebook.cell.collapseAllCellInputs",
+  ];
+  const commandResults = [];
+  for (const command of commands) {
+    const result = await settleWithin(vscode.commands.executeCommand(command), 5_000);
+    commandResults.push({ command, status: result.status, error: result.error ?? null });
+    if (result.status !== "fulfilled") {
+      throw new Error(`widget viewport command ${command} ${result.status}: ${result.error ?? ""}`);
+    }
+  }
+  const range = new vscode.NotebookRange(creationCell.index, creationCell.index + 1);
+  editor.revealRange(range, vscode.NotebookEditorRevealType.InCenter);
+  await delay(500);
+  const visibleRanges = editor.visibleRanges.map((visibleRange) => ({
+    start: visibleRange.start,
+    end: visibleRange.end,
+  }));
+  const creationCellVisible = visibleRanges.some(
+    (visibleRange) =>
+      visibleRange.start <= creationCell.index && visibleRange.end > creationCell.index,
+  );
+  evidence.rendererBoundary.viewport = {
+    commands: commandResults,
+    creationCellIndex: creationCell.index,
+    revealRange: { start: range.start, end: range.end, type: "InCenter" },
+    visibleRanges,
+    creationCellVisible,
+  };
+  if (!creationCellVisible) {
+    throw new Error(
+      `creation cell ${creationCell.index} is outside visible notebook ranges ` +
+        JSON.stringify(visibleRanges),
+    );
+  }
+}
+
 function recordCreationState(roundTrip, cell) {
   roundTrip.creationExecutionSummary = executionSummary(cell);
   roundTrip.creationOutputCount = cell.outputs.length;
@@ -294,6 +335,7 @@ async function run() {
       verificationCellIndex: verificationCell.index,
     };
     editor = await vscode.window.showNotebookDocument(document);
+    await prepareWidgetViewport(evidence, editor, creationCell);
     await delay(2_000);
 
     if (evidence.selector.strategy === "ms-toolsai.jupyter.exports.openNotebook") {
@@ -390,8 +432,28 @@ async function run() {
       throw new Error("test renderer extension is not registered");
     }
     const probe = await probeExtension.activate();
-    evidence.roundTrip.renderer = await probe.exercise(editor);
-    localWidgetSource.assertUsed();
+    let rendererError;
+    try {
+      evidence.roundTrip.renderer = await probe.exercise(editor, {
+        creationCellIndex: creationCell.index,
+        creationCellVisible: evidence.rendererBoundary.viewport.creationCellVisible,
+      });
+    } catch (error) {
+      rendererError = error;
+    }
+    try {
+      localWidgetSource.assertUsed();
+    } catch (sourceError) {
+      if (rendererError && sourceError instanceof Error) {
+        sourceError.message += `\nRENDERER_FAILURE=${
+          rendererError instanceof Error ? rendererError.message : String(rendererError)
+        }`;
+      }
+      throw sourceError;
+    }
+    if (rendererError) {
+      throw rendererError;
+    }
 
     evidence.roundTrip.verificationCommand = await settleWithin(
       vscode.commands.executeCommand("notebook.cell.execute", {

--- a/tests/vscode_host/test/index.cjs
+++ b/tests/vscode_host/test/index.cjs
@@ -442,7 +442,9 @@ async function run() {
       rendererError = error;
     }
     try {
-      localWidgetSource.assertUsed();
+      localWidgetSource.assertUsed(
+        evidence.roundTrip.renderer?.diagnostics ?? rendererError?.rendererDiagnostics,
+      );
     } catch (sourceError) {
       if (rendererError && sourceError instanceof Error) {
         sourceError.message += `\nRENDERER_FAILURE=${

--- a/tests/vscode_host/test/index.cjs
+++ b/tests/vscode_host/test/index.cjs
@@ -182,8 +182,13 @@ async function run() {
     await jupyter.activate();
 
     const commands = await vscode.commands.getCommands(true);
-    if (!commands.includes("notebook.selectKernel")) {
-      throw new Error("VS Code did not register the documented notebook.selectKernel command");
+    evidence.selector.commandRegistered = commands.includes("notebook.selectKernel");
+    if (!evidence.selector.commandRegistered) {
+      evidence.outcome = "kernel_selection_gate_failure";
+      evidence.reason =
+        "VS Code did not register the documented notebook.selectKernel command after Jupyter activation.";
+      console.log("HYPSTER_VSCODE_KERNEL_SELECTION_GATE_REPRODUCED");
+      return;
     }
     const forbiddenDiscoveryKeys = ["controllers", "getControllers", "getNotebookControllers"];
     evidence.selector.publicControllerDiscoveryKeys = forbiddenDiscoveryKeys.filter((key) =>

--- a/tests/vscode_host/test/index.cjs
+++ b/tests/vscode_host/test/index.cjs
@@ -4,7 +4,10 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const vscode = require("vscode");
-const { classifyMissingCreationMarker } = require("../creation-gate.cjs");
+const {
+  classifyCommandResult,
+  classifyMissingCreationMarker,
+} = require("../creation-gate.cjs");
 const pins = require("../pins.cjs");
 
 const decoder = new TextDecoder();
@@ -252,13 +255,7 @@ async function run() {
       const classification = classifyRecordedCreationState(evidence);
       evidence.roundTrip.creationGateClassification = classification;
       evidence.roundTrip.completed = false;
-      if (!classification.accepted) {
-        throw new Error(classification.reason);
-      }
-      evidence.outcome = classification.outcome;
-      evidence.reason = classification.reason;
-      console.log("HYPSTER_VSCODE_KERNEL_SELECTION_GATE_REPRODUCED");
-      return;
+      throw new Error(classification.reason);
     }
 
     const probeExtension = vscode.extensions.getExtension("hypster.hypster-vscode-host-spike");
@@ -275,6 +272,13 @@ async function run() {
       }),
       30_000,
     );
+    evidence.roundTrip.verificationCommandClassification = classifyCommandResult(
+      "verification execution",
+      evidence.roundTrip.verificationCommand,
+    );
+    if (!evidence.roundTrip.verificationCommandClassification.ok) {
+      throw new Error(evidence.roundTrip.verificationCommandClassification.reason);
+    }
     evidence.roundTrip.verificationOutput = await waitForMarker(
       verificationCell,
       "HYPSTER_PARAMS_VERIFIED=",

--- a/tests/vscode_host/test/index.cjs
+++ b/tests/vscode_host/test/index.cjs
@@ -12,6 +12,7 @@ const {
   selectKernelStrategy,
 } = require("../creation-gate.cjs");
 const pins = require("../pins.cjs");
+const { startLocalWidgetSource } = require("../widget-source.cjs");
 
 const decoder = new TextDecoder();
 
@@ -119,9 +120,9 @@ function pythonEnvironmentEvidence(environment, requestedExecutable) {
   };
 }
 
-async function configureWidgetScriptSources(evidence) {
+async function configureWidgetScriptSources(evidence, sourceTemplate) {
   const configuration = vscode.workspace.getConfiguration("jupyter");
-  const expected = [...pins.widgetScriptSources];
+  const expected = [sourceTemplate];
   await configuration.update(
     "widgetScriptSources",
     expected,
@@ -149,9 +150,9 @@ async function configureWidgetScriptSources(evidence) {
   }
 }
 
-function verifyWidgetScriptSourcesAfterActivation(evidence) {
+function verifyWidgetScriptSourcesAfterActivation(evidence, sourceTemplate) {
   const configuration = vscode.workspace.getConfiguration("jupyter");
-  const expected = [...pins.widgetScriptSources];
+  const expected = [sourceTemplate];
   const inspected = configuration.inspect("widgetScriptSources");
   const effective = configuration.get("widgetScriptSources");
   evidence.rendererBoundary.widgetScriptSources.globalLocalValueAfterActivation =
@@ -253,12 +254,15 @@ async function run() {
   }
 
   let editor;
+  let localWidgetSource;
   try {
-    await configureWidgetScriptSources(evidence);
+    localWidgetSource = await startLocalWidgetSource(pythonExecutable);
+    evidence.rendererBoundary.localWidgetSource = localWidgetSource.evidence;
+    await configureWidgetScriptSources(evidence, localWidgetSource.template);
     const jupyter = vscode.extensions.getExtension("ms-toolsai.jupyter");
     const pythonApi = await PythonExtension.api();
     const jupyterApi = await jupyter.activate();
-    verifyWidgetScriptSourcesAfterActivation(evidence);
+    verifyWidgetScriptSourcesAfterActivation(evidence, localWidgetSource.template);
     evidence.selector.pythonFacade = {
       package: "@vscode/python-extension",
       version: pythonFacadePackage.version,
@@ -387,6 +391,7 @@ async function run() {
     }
     const probe = await probeExtension.activate();
     evidence.roundTrip.renderer = await probe.exercise(editor);
+    localWidgetSource.assertUsed();
 
     evidence.roundTrip.verificationCommand = await settleWithin(
       vscode.commands.executeCommand("notebook.cell.execute", {
@@ -419,6 +424,9 @@ async function run() {
     evidence.error = error instanceof Error ? `${error.message}\n${error.stack}` : String(error);
     throw error;
   } finally {
+    if (localWidgetSource) {
+      await localWidgetSource.close();
+    }
     fs.writeFileSync(
       path.join(artifactDir, "spike-result.json"),
       `${JSON.stringify(evidence, null, 2)}\n`,

--- a/tests/vscode_host/widget-source.cjs
+++ b/tests/vscode_host/widget-source.cjs
@@ -147,12 +147,14 @@ async function startLocalWidgetSource(pythonExecutable) {
         (request) =>
           request.method === "GET" &&
           request.path === ANYWIDGET_ROUTE &&
-          request.status === 200,
+          request.status === 200 &&
+          request.userAgent?.includes("Code/") &&
+          request.userAgent?.includes("Electron/"),
       );
       evidence.successfulIndexGetVerified = used;
       if (!used) {
         throw new Error(
-          `renderer did not fetch the exact local anywidget bundle at ${ANYWIDGET_ROUTE}; ` +
+          `Electron webview did not fetch the exact local anywidget bundle at ${ANYWIDGET_ROUTE}; ` +
             `requests=${JSON.stringify(requests)}`,
         );
       }

--- a/tests/vscode_host/widget-source.cjs
+++ b/tests/vscode_host/widget-source.cjs
@@ -1,0 +1,175 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const http = require("node:http");
+const path = require("node:path");
+const pins = require("./pins.cjs");
+
+const ANYWIDGET_ROUTE = "/anywidget/index.js";
+
+function sha256(contents) {
+  return crypto.createHash("sha256").update(contents).digest("hex");
+}
+
+function anywidgetAssetPaths(pythonExecutable) {
+  const kernelPrefix = path.dirname(path.dirname(pythonExecutable));
+  const nbextensionRoot = path.join(
+    kernelPrefix,
+    "share",
+    "jupyter",
+    "nbextensions",
+    "anywidget",
+  );
+  return {
+    kernelPrefix,
+    nbextensionRoot,
+    extensionPath: path.join(nbextensionRoot, "extension.js"),
+    indexPath: path.join(nbextensionRoot, "index.js"),
+  };
+}
+
+function readRegularFile(filePath, label) {
+  let stat;
+  try {
+    stat = fs.statSync(filePath);
+  } catch (error) {
+    throw new Error(`${label} is missing at ${filePath}: ${error.message}`);
+  }
+  if (!stat.isFile()) {
+    throw new Error(`${label} is not a regular file: ${filePath}`);
+  }
+  return fs.readFileSync(filePath);
+}
+
+function inspectAnywidgetAssets(pythonExecutable) {
+  const pythonStat = fs.statSync(pythonExecutable);
+  if (!pythonStat.isFile()) {
+    throw new Error(`selected kernel Python is not a regular file: ${pythonExecutable}`);
+  }
+
+  const paths = anywidgetAssetPaths(pythonExecutable);
+  const extension = readRegularFile(paths.extensionPath, "anywidget extension.js");
+  const index = readRegularFile(paths.indexPath, "anywidget index.js");
+  const extensionSource = extension.toString("utf8");
+  const requireJsConfigPresent = extensionSource.includes("window.requirejs?.config({");
+  const anywidgetMappingPresent =
+    /anywidget\s*:\s*["']nbextensions\/anywidget\/index["']/.test(extensionSource);
+  if (!requireJsConfigPresent || !anywidgetMappingPresent) {
+    throw new Error(
+      `anywidget extension.js at ${paths.extensionPath} is not compatible with ` +
+        "Jupyter 2025.9.1's local widget-source parser",
+    );
+  }
+  if (index.length === 0) {
+    throw new Error(`anywidget index.js is empty: ${paths.indexPath}`);
+  }
+
+  return {
+    paths,
+    extension,
+    index,
+    evidence: {
+      ...paths,
+      extensionBytes: extension.length,
+      extensionSha256: sha256(extension),
+      indexBytes: index.length,
+      indexSha256: sha256(index),
+      requireJsConfigPresent,
+      anywidgetMapping: "anywidget -> nbextensions/anywidget/index",
+    },
+  };
+}
+
+function widgetSourceTemplate(port) {
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    throw new Error(`invalid local widget-source port: ${port}`);
+  }
+  return `http://127.0.0.1:${port}${pins.widgetScriptSourcePathTemplate}`;
+}
+
+async function startLocalWidgetSource(pythonExecutable) {
+  const assets = inspectAnywidgetAssets(pythonExecutable);
+  const requests = [];
+  const server = http.createServer((request, response) => {
+    const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+    const methodAllowed = request.method === "GET" || request.method === "HEAD";
+    const routeAllowed = requestUrl.pathname === ANYWIDGET_ROUTE && requestUrl.search === "";
+    const status = methodAllowed && routeAllowed ? 200 : 404;
+    requests.push({
+      method: request.method ?? null,
+      path: `${requestUrl.pathname}${requestUrl.search}`,
+      status,
+      origin: request.headers.origin ?? null,
+      userAgent: request.headers["user-agent"] ?? null,
+    });
+
+    response.writeHead(status, {
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "no-store",
+      "Content-Length": status === 200 ? assets.index.length : 0,
+      "Content-Type": "text/javascript; charset=utf-8",
+    });
+    if (status === 200 && request.method === "GET") {
+      response.end(assets.index);
+    } else {
+      response.end();
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error(`local widget source returned an invalid address: ${address}`);
+  }
+  server.unref();
+
+  const evidence = {
+    transport: "loopback-http",
+    host: "127.0.0.1",
+    port: address.port,
+    route: ANYWIDGET_ROUTE,
+    template: widgetSourceTemplate(address.port),
+    asset: assets.evidence,
+    requests,
+    successfulIndexGetVerified: false,
+  };
+
+  return {
+    template: evidence.template,
+    evidence,
+    assertUsed() {
+      const used = requests.some(
+        (request) =>
+          request.method === "GET" &&
+          request.path === ANYWIDGET_ROUTE &&
+          request.status === 200,
+      );
+      evidence.successfulIndexGetVerified = used;
+      if (!used) {
+        throw new Error(
+          `renderer did not fetch the exact local anywidget bundle at ${ANYWIDGET_ROUTE}; ` +
+            `requests=${JSON.stringify(requests)}`,
+        );
+      }
+    },
+    async close() {
+      await new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections?.();
+      });
+    },
+  };
+}
+
+module.exports = {
+  ANYWIDGET_ROUTE,
+  anywidgetAssetPaths,
+  inspectAnywidgetAssets,
+  startLocalWidgetSource,
+  widgetSourceTemplate,
+};

--- a/tests/vscode_host/widget-source.cjs
+++ b/tests/vscode_host/widget-source.cjs
@@ -7,6 +7,8 @@ const path = require("node:path");
 const pins = require("./pins.cjs");
 
 const ANYWIDGET_ROUTE = "/anywidget/index.js";
+const ANYWIDGET_COPY_SUFFIX = "/jupyter/nbextensions/anywidget/index.js";
+const VSCODE_RESOURCE_HOST = "file+.vscode-resource.vscode-cdn.net";
 
 function sha256(contents) {
   return crypto.createHash("sha256").update(contents).digest("hex");
@@ -88,6 +90,64 @@ function widgetSourceTemplate(port) {
   return `http://127.0.0.1:${port}${pins.widgetScriptSourcePathTemplate}`;
 }
 
+function vscodeResourceFilePath(scriptUrl) {
+  let parsed;
+  try {
+    parsed = new URL(scriptUrl);
+  } catch {
+    return undefined;
+  }
+  if (parsed.protocol !== "https:" || parsed.hostname.toLowerCase() !== VSCODE_RESOURCE_HOST) {
+    return undefined;
+  }
+  let filePath;
+  try {
+    filePath = decodeURIComponent(parsed.pathname);
+  } catch {
+    return undefined;
+  }
+  if (process.platform === "win32" && /^\/[A-Za-z]:\//.test(filePath)) {
+    filePath = filePath.slice(1);
+  }
+  if (!path.isAbsolute(filePath)) {
+    return undefined;
+  }
+  const portablePath = filePath.replaceAll("\\", "/");
+  return portablePath.endsWith(ANYWIDGET_COPY_SUFFIX) ? filePath : undefined;
+}
+
+function inspectCopiedWidgetSource(diagnostics, expectedContents) {
+  if (diagnostics?.amd?.anywidgetDefined !== true) {
+    return undefined;
+  }
+  const scriptUrls = [
+    ...(diagnostics.amd.relevantFetchedUrls ?? []),
+    ...(diagnostics.document?.scripts ?? []),
+  ];
+  for (const url of new Set(scriptUrls)) {
+    const copiedPath = vscodeResourceFilePath(url);
+    if (!copiedPath) {
+      continue;
+    }
+    const copiedContents = readRegularFile(copiedPath, "VS Code copied anywidget bundle");
+    if (!copiedContents.equals(expectedContents)) {
+      throw new Error(
+        `VS Code copied anywidget bundle did not match the selected kernel bytes: ${copiedPath}`,
+      );
+    }
+    return {
+      kind: "vscode-local-copy",
+      copiedScript: {
+        url,
+        path: copiedPath,
+        bytes: copiedContents.length,
+        sha256: sha256(copiedContents),
+      },
+    };
+  }
+  return undefined;
+}
+
 async function startLocalWidgetSource(pythonExecutable) {
   const assets = inspectAnywidgetAssets(pythonExecutable);
   const requests = [];
@@ -142,8 +202,8 @@ async function startLocalWidgetSource(pythonExecutable) {
   return {
     template: evidence.template,
     evidence,
-    assertUsed() {
-      const used = requests.some(
+    assertUsed(rendererDiagnostics) {
+      const directElectronGet = requests.some(
         (request) =>
           request.method === "GET" &&
           request.path === ANYWIDGET_ROUTE &&
@@ -151,10 +211,14 @@ async function startLocalWidgetSource(pythonExecutable) {
           request.userAgent?.includes("Code/") &&
           request.userAgent?.includes("Electron/"),
       );
-      evidence.successfulIndexGetVerified = used;
-      if (!used) {
+      const consumption = directElectronGet
+        ? { kind: "electron-loopback-get", route: ANYWIDGET_ROUTE }
+        : inspectCopiedWidgetSource(rendererDiagnostics, assets.index);
+      evidence.successfulIndexGetVerified = Boolean(consumption);
+      evidence.consumption = consumption ?? null;
+      if (!consumption) {
         throw new Error(
-          `Electron webview did not fetch the exact local anywidget bundle at ${ANYWIDGET_ROUTE}; ` +
+          `VS Code did not consume the exact local anywidget bundle at ${ANYWIDGET_ROUTE}; ` +
             `requests=${JSON.stringify(requests)}`,
         );
       }
@@ -172,6 +236,8 @@ module.exports = {
   ANYWIDGET_ROUTE,
   anywidgetAssetPaths,
   inspectAnywidgetAssets,
+  inspectCopiedWidgetSource,
   startLocalWidgetSource,
+  vscodeResourceFilePath,
   widgetSourceTemplate,
 };


### PR DESCRIPTION
Closes #98
Closes #107

## Before / after

Before:

```text
No real VS Code Desktop process, no isolated extension install, and no
supported renderer bridge were exercised by Hypster CI.
```

After:

```text
VS Code 1.128.0 Electron on Ubuntu/Xvfb
  -> exact Python/Jupyter/Jupyter-renderers extension pins
  -> clean installed-wheel Python resolved by the official Python facade
  -> Jupyter's public openNotebook(uri, environment) controller-selection API
  -> supported NotebookRendererMessaging bridge
  -> complete DOM -> Python oracle round trip
```

The first physical witness exposed a missing documented
`notebook.selectKernel` command and filed #107. Source review then found the
supported exported Jupyter seam used by Jupyter's own smoke test, so this PR now
adopts it without copying private controller IDs.

Selection/execution rejection or timeout, an inconclusive empty creation cell,
renderer/messaging failure, stale output, or oracle failure is red. The only
green runtime outcome after a supported selection route exists is the complete
`basic_scenario_green` round trip.

## Proof before the final Ubuntu witness

- Exact Node `24.18.0`, npm `11.16.0`, and Python facade `1.0.6`
- Fresh npm install: 40 packages, 0 vulnerabilities
- Structural renderer/workflow checks: passed
- Race and strategy falsifiers: passed
- `uv run pytest -q`: 190 passed, 1 skipped
- Ruff: passed
- mypy: passed

The PR workflow is the required final physical Ubuntu/Xvfb witness. Its
uploaded artifact must prove the exported selection route, exact clean Python,
renderer bridge, fresh oracle, and complete process cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added an end-to-end VS Code Desktop host test covering notebook opening, kernel selection, widget rendering, interactive value updates, and execution results.
  - Added validation for local widget assets, runtime configuration, dependency versions, process cleanup, and failure evidence.
  - Added automated checks for test setup, creation gates, renderer messaging, and local asset serving.

- **Documentation**
  - Documented supported workflows, runtime requirements, troubleshooting guidance, reproducibility steps, and acceptance criteria for host validation.

- **Chores**
  - Added automated CI execution with pinned runtimes and artifact collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->