### PR TITLE
Extend the real JupyterLab host scenario

### DIFF
--- a/tests/jupyterlab_host/README.md
+++ b/tests/jupyterlab_host/README.md
@@ -12,10 +12,16 @@ outside the source checkout. It then crosses the real boundary:
 Chromium DOM event -> anywidget comm -> Python controller -> replacement DOM
 ```
 
-The notebook's second cell is the independent oracle for the final exact
-`result.params` value. Browser errors, cell errors, visible widget errors,
-missing comm-driven replacement DOM, and timeouts fail the run. The browser,
-Jupyter server, kernel, and their process group are terminated on every exit.
+Notebook verification cells are independent Python oracles for auto-applied,
+staged, invalid, applied, and reset `result.params` values. The canonical
+scenario also switches the real JupyterLab theme, verifies Branch Choice
+Memory, drives Apply and Reset in manual mode, and sends a mismatched Protocol
+V1 snapshot through the live widget comm before recovering with a valid
+snapshot. Reused Python oracle cells must publish a new execution count and
+unique output identity. Browser errors, cell errors, unexpected visible widget
+errors, missing comm-driven replacement DOM, and timeouts fail the run. The
+browser, Jupyter server, kernel, and their process group are terminated on
+every exit.
 
 ## Local run
 

--- a/tests/jupyterlab_host/branch_round_trip.ipynb
+++ b/tests/jupyterlab_host/branch_round_trip.ipynb
@@ -7,14 +7,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# HYPSTER_HOST_CELL:create-auto\n",
     "from pathlib import Path\n",
+    "from uuid import uuid4\n",
     "\n",
     "import hypster\n",
     "from hypster import HP\n",
     "\n",
     "hypster_path = Path(hypster.__file__).resolve()\n",
     "assert \"site-packages\" in hypster_path.parts, f\"expected installed wheel import, got {hypster_path}\"\n",
-    "print(f\"HYPSTER_IMPORT_PATH={hypster_path}\")\n",
+    "print(f\"HYPSTER_IMPORT_PATH={hypster_path}; EXECUTION_ID={uuid4().hex}\")\n",
     "\n",
     "\n",
     "def remote(hp: HP):\n",
@@ -39,9 +41,122 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# HYPSTER_HOST_CELL:verify-auto\n",
     "expected = {\"mode\": \"remote\", \"remote.temperature\": 1.25}\n",
     "assert result.params == expected, f\"{result.params!r} != {expected!r}\"\n",
-    "print(f\"HYPSTER_PARAMS_VERIFIED={result.params!r}\")"
+    "print(f\"HYPSTER_PARAMS_VERIFIED={result.params!r}; EXECUTION_ID={uuid4().hex}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "create-manual-result",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HYPSTER_HOST_CELL:create-manual\n",
+    "manual_result = hypster.interact(config, auto_apply=False)\n",
+    "print(f\"HYPSTER_MANUAL_READY; EXECUTION_ID={uuid4().hex}\")\n",
+    "manual_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "verify-manual-staged",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HYPSTER_HOST_CELL:verify-manual-staged\n",
+    "expected = {\"mode\": \"local\"}\n",
+    "assert manual_result.params == expected, f\"{manual_result.params!r} != {expected!r}\"\n",
+    "print(f\"HYPSTER_MANUAL_STAGED_VERIFIED={manual_result.params!r}; EXECUTION_ID={uuid4().hex}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "verify-manual-applied",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HYPSTER_HOST_CELL:verify-manual-applied\n",
+    "expected = {\"mode\": \"remote\", \"remote.temperature\": 1.25}\n",
+    "assert manual_result.params == expected, f\"{manual_result.params!r} != {expected!r}\"\n",
+    "print(f\"HYPSTER_MANUAL_APPLIED_VERIFIED={manual_result.params!r}; EXECUTION_ID={uuid4().hex}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "verify-manual-reset",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HYPSTER_HOST_CELL:verify-manual-reset\n",
+    "expected = {\"mode\": \"local\"}\n",
+    "assert manual_result.params == expected, f\"{manual_result.params!r} != {expected!r}\"\n",
+    "print(f\"HYPSTER_MANUAL_RESET_VERIFIED={manual_result.params!r}; EXECUTION_ID={uuid4().hex}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "create-protocol-result",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HYPSTER_HOST_CELL:create-protocol\n",
+    "from IPython.display import display\n",
+    "\n",
+    "protocol_result = hypster.interact(config)\n",
+    "protocol_widget = protocol_result.interact()\n",
+    "protocol_params_before = protocol_result.params\n",
+    "protocol_action_before = dict(protocol_widget.action)\n",
+    "display(protocol_widget)\n",
+    "print(f\"HYPSTER_PROTOCOL_READY; EXECUTION_ID={uuid4().hex}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "inject-protocol-mismatch",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HYPSTER_HOST_CELL:inject-protocol-mismatch\n",
+    "mismatched_snapshot = dict(protocol_result.snapshot)\n",
+    "mismatched_snapshot[\"protocol_version\"] = 2\n",
+    "protocol_widget.snapshot = mismatched_snapshot\n",
+    "print(f\"HYPSTER_PROTOCOL_MISMATCH_SENT=2; EXECUTION_ID={uuid4().hex}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "verify-protocol-unchanged",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HYPSTER_HOST_CELL:verify-protocol-unchanged\n",
+    "assert protocol_widget.action == protocol_action_before == {}, protocol_widget.action\n",
+    "assert protocol_result.params == protocol_params_before == {\"mode\": \"local\"}\n",
+    "print(\n",
+    "    f\"HYPSTER_PROTOCOL_UNCHANGED={protocol_result.params!r}; \"\n",
+    "    f\"ACTION={protocol_widget.action!r}; EXECUTION_ID={uuid4().hex}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "recover-protocol-snapshot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HYPSTER_HOST_CELL:recover-protocol\n",
+    "protocol_widget.snapshot = protocol_result.snapshot\n",
+    "print(f\"HYPSTER_PROTOCOL_RECOVERED=1; EXECUTION_ID={uuid4().hex}\")"
    ]
   }
  ],

--- a/tests/jupyterlab_host/test_jupyterlab_host.py
+++ b/tests/jupyterlab_host/test_jupyterlab_host.py
@@ -14,11 +14,12 @@ import sys
 import tempfile
 import time
 import urllib.request
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
-from playwright.sync_api import Page, sync_playwright
+from playwright.sync_api import Locator, Page, sync_playwright
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 HARNESS_ROOT = Path(__file__).resolve().parent
@@ -27,6 +28,79 @@ KERNEL_LOCK = HARNESS_ROOT / "kernel-requirements.lock"
 SERVER_TIMEOUT_SECONDS = 60
 SERVER_PORT_RETRIES = 5
 COMM_TIMEOUT_MS = 30_000
+REQUIRED_CELL_MARKERS = (
+    "create-auto",
+    "verify-auto",
+    "create-manual",
+    "verify-manual-staged",
+    "verify-manual-applied",
+    "verify-manual-reset",
+    "create-protocol",
+    "inject-protocol-mismatch",
+    "verify-protocol-unchanged",
+    "recover-protocol",
+)
+
+
+@dataclass(frozen=True)
+class CellExecution:
+    output: str
+    count: int
+    identity: str
+
+
+@dataclass(frozen=True)
+class OracleEvidence:
+    count: int
+    identity: str
+
+
+@dataclass(frozen=True)
+class WidgetAppearance:
+    theme: str
+    color: str
+    background: str
+    contrast: float
+
+
+@dataclass(frozen=True)
+class ThemeEvidence:
+    dark: WidgetAppearance
+    light: WidgetAppearance
+
+
+@dataclass(frozen=True)
+class AutoEvidence:
+    numeric_dom_before: str
+    numeric_dom_after: str
+    numeric_dom_replaced: bool
+    branch_memory_dom_restored: str
+    branch_memory_python: str
+    oracle: OracleEvidence
+    transcript: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ManualEvidence:
+    staged_dom: str
+    staged_python: str
+    applied_python: str
+    invalid_dom_error: str
+    invalid_python_unchanged: str
+    reset_dom: str
+    reset_python: str
+    applied_oracles: tuple[OracleEvidence, ...]
+    transcript: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ProtocolEvidence:
+    error_dom: str
+    action_emitted: bool
+    python_unchanged: str
+    recovered_dom: str
+    oracles: tuple[OracleEvidence, ...]
+    transcript: tuple[str, ...]
 
 
 def required_path(name: str) -> Path:
@@ -110,25 +184,110 @@ def wait_for_kernel(url: str, token: str, process: subprocess.Popen[str]) -> Non
     raise AssertionError(f"notebook kernel did not become idle within {SERVER_TIMEOUT_SECONDS}s")
 
 
-def execute_cell(page: Page, index: int, marker: str) -> str:
-    cell = page.locator(".jp-Notebook-cell").nth(index)
+def notebook_cell(page: Page, marker: str) -> Locator:
+    matches: list[Locator] = []
+    cells = page.locator(".jp-Notebook-cell")
+    for index in range(cells.count()):
+        cell = cells.nth(index)
+        if f"HYPSTER_HOST_CELL:{marker}" in cell.locator(".jp-Cell-inputArea").inner_text():
+            matches.append(cell)
+    assert len(matches) == 1, f"expected one notebook cell marked {marker!r}, got {len(matches)}"
+    return matches[0]
+
+
+def execute_cell(page: Page, cell_marker: str, output_marker: str) -> CellExecution:
+    cell = notebook_cell(page, cell_marker)
+    prompt = cell.locator(".jp-InputPrompt")
+    before_prompt = prompt.inner_text()
+    output = cell.locator(".jp-OutputArea")
+    before_output = output.inner_text()
     cell.locator(".jp-Cell-inputArea").click()
     page.keyboard.press("Control+Enter")
-    output = cell.locator(".jp-OutputArea")
+
+    deadline = time.monotonic() + COMM_TIMEOUT_MS / 1000
+    count_match: re.Match[str] | None = None
+    while time.monotonic() < deadline:
+        current_prompt = prompt.inner_text()
+        candidate = re.search(r"\[(\d+)\]:", current_prompt)
+        if current_prompt != before_prompt and candidate is not None:
+            count_match = candidate
+            break
+        page.wait_for_timeout(25)
+    assert count_match is not None, (
+        f"cell {cell_marker!r} did not publish a new execution count; before was {before_prompt!r}, "
+        f"after was {prompt.inner_text()!r}"
+    )
+
     try:
-        output.get_by_text(re.compile(re.escape(marker))).wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+        output.get_by_text(re.compile(re.escape(output_marker))).wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
     except PlaywrightTimeoutError as error:
         raise AssertionError(
-            f"cell {index} did not emit {marker!r}; kernel output was:\n{output.inner_text()}"
+            f"cell {cell_marker!r} did not emit {output_marker!r}; kernel output was:\n{output.inner_text()}"
         ) from error
+    current_output = output.inner_text()
+    identity_match = re.search(r"EXECUTION_ID=([0-9a-f]{32})", current_output)
+    assert identity_match is not None, f"cell {cell_marker!r} output has no execution identity: {current_output}"
+    identity = identity_match.group(1)
+    assert current_output != before_output, f"cell {cell_marker!r} retained stale output"
+    assert identity not in before_output, f"cell {cell_marker!r} reused stale execution identity {identity}"
     error_output = output.locator("[data-mime-type='application/vnd.jupyter.error']")
-    assert error_output.count() == 0, f"cell {index} produced a kernel error: {output.inner_text()}"
-    return output.inner_text()
+    assert error_output.count() == 0, f"cell {cell_marker!r} produced a kernel error: {current_output}"
+    return CellExecution(output=current_output, count=int(count_match.group(1)), identity=identity)
 
 
 def assert_widget_has_no_error(page: Page) -> None:
     errors = page.locator(".hypster-status-error, .hypster-status-draft_error")
     assert errors.count() == 0, f"widget surfaced an error: {errors.all_inner_texts()}"
+
+
+def widget_appearance(widget: Locator) -> WidgetAppearance:
+    raw = widget.evaluate(
+        """element => {
+            const rgb = value => (value.match(/[0-9.]+/g) || []).slice(0, 3).map(Number);
+            const luminance = value => {
+                const channels = rgb(value).map(channel => {
+                    const normalized = channel / 255;
+                    return normalized <= 0.04045
+                        ? normalized / 12.92
+                        : ((normalized + 0.055) / 1.055) ** 2.4;
+                });
+                return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+            };
+            const style = getComputedStyle(element);
+            const foreground = luminance(style.color);
+            const background = luminance(style.backgroundColor);
+            return {
+                theme: element.dataset.hypsterTheme,
+                color: style.color,
+                background: style.backgroundColor,
+                contrast: (Math.max(foreground, background) + 0.05) /
+                    (Math.min(foreground, background) + 0.05),
+            };
+        }"""
+    )
+    assert isinstance(raw, dict), f"widget appearance must be an object, got {raw!r}"
+    theme = raw.get("theme")
+    color = raw.get("color")
+    background = raw.get("background")
+    contrast = raw.get("contrast")
+    assert isinstance(theme, str), f"widget theme must be text, got {theme!r}"
+    assert isinstance(color, str), f"widget color must be text, got {color!r}"
+    assert isinstance(background, str), f"widget background must be text, got {background!r}"
+    assert isinstance(contrast, (int, float)) and not isinstance(
+        contrast, bool
+    ), f"widget contrast must be numeric, got {contrast!r}"
+    return WidgetAppearance(
+        theme=theme,
+        color=color,
+        background=background,
+        contrast=float(contrast),
+    )
+
+
+def switch_jupyterlab_theme(page: Page, theme: str) -> None:
+    page.locator(".lm-MenuBar-itemLabel", has_text="Settings").click()
+    page.locator(".lm-Menu-itemLabel").filter(has_text=re.compile(r"^Theme$")).filter(visible=True).hover()
+    page.locator(".lm-Menu-itemLabel").filter(has_text=re.compile(f"^{re.escape(theme)}$")).filter(visible=True).click()
 
 
 def notebook_model(url: str, token: str) -> dict[str, Any]:
@@ -142,11 +301,13 @@ def notebook_model(url: str, token: str) -> dict[str, Any]:
 
 def assert_saved_cells_succeeded(model: dict[str, Any]) -> None:
     cells = model["cells"]
-    assert len(cells) == 2, f"expected exactly two cells, got {len(cells)}"
-    for index, cell in enumerate(cells):
-        assert cell["execution_count"] is not None, f"cell {index} was not executed"
+    for marker in REQUIRED_CELL_MARKERS:
+        matching = [cell for cell in cells if f"HYPSTER_HOST_CELL:{marker}" in "".join(cell["source"])]
+        assert len(matching) == 1, f"expected one saved cell marked {marker!r}, got {len(matching)}"
+        cell = matching[0]
+        assert cell["execution_count"] is not None, f"cell {marker!r} was not executed"
         errors = [output for output in cell["outputs"] if output["output_type"] == "error"]
-        assert not errors, f"cell {index} saved kernel errors: {errors}"
+        assert not errors, f"cell {marker!r} saved kernel errors: {errors}"
 
 
 def wait_for_saved_notebook(url: str, token: str) -> dict[str, Any]:
@@ -155,7 +316,15 @@ def wait_for_saved_notebook(url: str, token: str) -> dict[str, Any]:
     while time.monotonic() < deadline:
         last_model = notebook_model(url, token)
         cells = last_model["cells"]
-        if len(cells) == 2 and all(cell["execution_count"] is not None for cell in cells):
+        executed_markers = {
+            marker
+            for marker in REQUIRED_CELL_MARKERS
+            if any(
+                f"HYPSTER_HOST_CELL:{marker}" in "".join(cell["source"]) and cell["execution_count"] is not None
+                for cell in cells
+            )
+        }
+        if executed_markers == set(REQUIRED_CELL_MARKERS):
             return last_model
         time.sleep(0.1)
     raise AssertionError(f"executed notebook was not saved within 10s: {last_model}")
@@ -178,6 +347,201 @@ def terminate_process_group(process: subprocess.Popen[str]) -> None:
         except ProcessLookupError:
             pass
         process.wait(timeout=5)
+
+
+def exercise_theme(page: Page, widget: Locator) -> ThemeEvidence:
+    widget_handle = widget.element_handle()
+    assert widget_handle is not None, "rendered widget root disappeared"
+
+    switch_jupyterlab_theme(page, "JupyterLab Dark")
+    page.wait_for_function(
+        "element => element.dataset.hypsterTheme === 'dark'",
+        arg=widget_handle,
+        timeout=COMM_TIMEOUT_MS,
+    )
+    dark = widget_appearance(widget)
+    assert dark.contrast >= 4.5, dark
+
+    switch_jupyterlab_theme(page, "JupyterLab Light")
+    page.wait_for_function(
+        "element => element.dataset.hypsterTheme === 'light'",
+        arg=widget_handle,
+        timeout=COMM_TIMEOUT_MS,
+    )
+    light = widget_appearance(widget)
+    assert light.contrast >= 4.5, light
+    assert light.background != dark.background, (light, dark)
+    return ThemeEvidence(dark=dark, light=light)
+
+
+def exercise_auto_mode(
+    page: Page,
+    widget: Locator,
+) -> AutoEvidence:
+    numeric = widget.locator("input[data-path='remote.temperature'][data-kind='float']")
+    assert numeric.count() == 0, "dependent numeric control was reachable before the branch action"
+    before_branch_html = widget.inner_html()
+    widget.locator(".hypster-choice[data-path='mode'] .hypster-choice-trigger").click()
+    widget.locator("[data-hypster-choice-option][data-path='mode']", has_text="remote").click()
+
+    numeric.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    assert numeric.input_value() == "0.25", "branch round trip did not publish the expected dependent default"
+    assert widget.inner_html() != before_branch_html, "branch action did not publish replacement DOM"
+    assert_widget_has_no_error(page)
+
+    old_numeric = numeric.element_handle()
+    assert old_numeric is not None, "numeric control disappeared before its DOM event"
+    numeric_dom_before = numeric.input_value()
+    numeric.fill("1.25")
+    numeric.press("Tab")
+    page.wait_for_function("element => !element.isConnected", arg=old_numeric, timeout=COMM_TIMEOUT_MS)
+    replacement_numeric = widget.locator("input[data-path='remote.temperature'][data-kind='float']")
+    replacement_numeric.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    assert replacement_numeric.input_value() == "1.25", "numeric comm round trip lost the chosen value"
+    assert not old_numeric.is_visible(), "numeric action did not detach the prior DOM control"
+    numeric_dom_after = replacement_numeric.input_value()
+    assert_widget_has_no_error(page)
+
+    widget.locator(".hypster-choice[data-path='mode'] .hypster-choice-trigger").click()
+    widget.locator("[data-hypster-choice-option][data-path='mode']", has_text="local").click()
+    replacement_numeric.wait_for(state="detached", timeout=COMM_TIMEOUT_MS)
+    widget.locator(".hypster-choice[data-path='mode'] .hypster-choice-trigger").click()
+    widget.locator("[data-hypster-choice-option][data-path='mode']", has_text="remote").click()
+    restored_numeric = widget.locator("input[data-path='remote.temperature'][data-kind='float']")
+    restored_numeric.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    assert restored_numeric.input_value() == "1.25", "Branch Choice Memory lost the compatible numeric choice"
+    branch_memory_dom_restored = restored_numeric.input_value()
+
+    verification = execute_cell(page, "verify-auto", "HYPSTER_PARAMS_VERIFIED=")
+    assert "'remote.temperature': 1.25" in verification.output, verification.output
+    return AutoEvidence(
+        numeric_dom_before=numeric_dom_before,
+        numeric_dom_after=numeric_dom_after,
+        numeric_dom_replaced=True,
+        branch_memory_dom_restored=branch_memory_dom_restored,
+        branch_memory_python=verification.output,
+        oracle=OracleEvidence(count=verification.count, identity=verification.identity),
+        transcript=(verification.output,),
+    )
+
+
+def exercise_manual_mode(page: Page) -> ManualEvidence:
+    manual_ready = execute_cell(page, "create-manual", "HYPSTER_MANUAL_READY")
+    transcript = [manual_ready.output]
+    widget = notebook_cell(page, "create-manual").locator(".hypster-widget")
+    widget.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    widget.locator(".hypster-choice[data-path='mode'] .hypster-choice-trigger").click()
+    widget.locator("[data-hypster-choice-option][data-path='mode']", has_text="remote").click()
+    numeric = widget.locator("input[data-path='remote.temperature'][data-kind='float']")
+    numeric.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    numeric.fill("1.25")
+    numeric.press("Tab")
+    widget.locator(".hypster-status-pending").wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    assert numeric.input_value() == "1.25"
+
+    staged = execute_cell(page, "verify-manual-staged", "HYPSTER_MANUAL_STAGED_VERIFIED=")
+    assert "{'mode': 'local'}" in staged.output, staged.output
+    staged_dom = f"remote.temperature={numeric.input_value()}"
+    transcript.append(staged.output)
+
+    widget.get_by_role("button", name="Apply", exact=True).click()
+    widget.locator(".hypster-status-applied").wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    assert numeric.input_value() == "1.25"
+    applied = execute_cell(page, "verify-manual-applied", "HYPSTER_MANUAL_APPLIED_VERIFIED=")
+    assert "'remote.temperature': 1.25" in applied.output, applied.output
+    transcript.append(applied.output)
+
+    numeric = widget.locator("input[data-path='remote.temperature'][data-kind='float']")
+    numeric.fill("")
+    numeric.press("Tab")
+    visible_error = widget.locator(".hypster-status-draft_error")
+    visible_error.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    assert visible_error.inner_text().startswith("Error:"), visible_error.inner_text()
+    assert numeric.input_value() == ""
+    assert widget.get_by_role("button", name="Apply", exact=True).is_disabled()
+    invalid = execute_cell(page, "verify-manual-applied", "HYPSTER_MANUAL_APPLIED_VERIFIED=")
+    assert "'remote.temperature': 1.25" in invalid.output, invalid.output
+    invalid_dom_error = visible_error.inner_text()
+    transcript.append(invalid.output)
+
+    numeric = widget.locator("input[data-path='remote.temperature'][data-kind='float']")
+    numeric.fill("1.5")
+    numeric.press("Tab")
+    widget.locator(".hypster-status-pending").wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    assert numeric.input_value() == "1.5"
+    pending = execute_cell(page, "verify-manual-applied", "HYPSTER_MANUAL_APPLIED_VERIFIED=")
+    assert "'remote.temperature': 1.25" in pending.output, pending.output
+    assert applied.count < invalid.count < pending.count
+    assert len({applied.identity, invalid.identity, pending.identity}) == 3
+    transcript.append(pending.output)
+
+    widget.get_by_role("button", name="Reset", exact=True).click()
+    widget.locator(".hypster-status-applied").wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    assert widget.locator("input[data-path='remote.temperature'][data-kind='float']").count() == 0
+    mode = widget.locator(".hypster-choice[data-path='mode'] .hypster-choice-value").inner_text()
+    assert mode == "local"
+    reset = execute_cell(page, "verify-manual-reset", "HYPSTER_MANUAL_RESET_VERIFIED=")
+    assert "{'mode': 'local'}" in reset.output, reset.output
+    transcript.append(reset.output)
+    return ManualEvidence(
+        staged_dom=staged_dom,
+        staged_python=staged.output,
+        applied_python=applied.output,
+        invalid_dom_error=invalid_dom_error,
+        invalid_python_unchanged=invalid.output,
+        reset_dom="mode=local; remote.temperature absent",
+        reset_python=reset.output,
+        applied_oracles=tuple(
+            OracleEvidence(count=execution.count, identity=execution.identity)
+            for execution in (applied, invalid, pending)
+        ),
+        transcript=tuple(transcript),
+    )
+
+
+def exercise_protocol_guard(page: Page) -> ProtocolEvidence:
+    ready = execute_cell(page, "create-protocol", "HYPSTER_PROTOCOL_READY")
+    transcript = [ready.output]
+    widget = notebook_cell(page, "create-protocol").locator(".hypster-widget")
+    widget.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    assert_widget_has_no_error(page)
+
+    mismatch = execute_cell(page, "inject-protocol-mismatch", "HYPSTER_PROTOCOL_MISMATCH_SENT=2")
+    transcript.append(mismatch.output)
+    protocol_error = widget.locator(".hypster-status-protocol_error[role='alert']")
+    protocol_error.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    error_text = protocol_error.inner_text()
+    assert "expected 1, received 2" in error_text, error_text
+    assert widget.get_attribute("data-status") == "protocol_error"
+    assert widget.locator(".hypster-field, .hypster-actions, input, select, textarea, button").count() == 0
+
+    unchanged = execute_cell(page, "verify-protocol-unchanged", "HYPSTER_PROTOCOL_UNCHANGED=")
+    assert "{'mode': 'local'}" in unchanged.output, unchanged.output
+    assert "ACTION={}" in unchanged.output, unchanged.output
+    transcript.append(unchanged.output)
+
+    recovered = execute_cell(page, "recover-protocol", "HYPSTER_PROTOCOL_RECOVERED=1")
+    transcript.append(recovered.output)
+    protocol_error.wait_for(state="detached", timeout=COMM_TIMEOUT_MS)
+    widget.locator(".hypster-status-applied").wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    assert widget.locator(".hypster-choice[data-path='mode'] .hypster-choice-value").inner_text() == "local"
+    recovered_oracle = execute_cell(page, "verify-protocol-unchanged", "HYPSTER_PROTOCOL_UNCHANGED=")
+    assert unchanged.count < recovered_oracle.count
+    assert unchanged.identity != recovered_oracle.identity
+    assert "{'mode': 'local'}" in recovered_oracle.output, recovered_oracle.output
+    assert "ACTION={}" in recovered_oracle.output, recovered_oracle.output
+    transcript.append(recovered_oracle.output)
+    return ProtocolEvidence(
+        error_dom=error_text,
+        action_emitted=False,
+        python_unchanged=unchanged.output,
+        recovered_dom="mode=local; controls restored",
+        oracles=tuple(
+            OracleEvidence(count=execution.count, identity=execution.identity)
+            for execution in (unchanged, recovered_oracle)
+        ),
+        transcript=tuple(transcript),
+    )
 
 
 def test_real_jupyterlab_round_trip() -> None:
@@ -318,63 +682,54 @@ def test_real_jupyterlab_round_trip() -> None:
                     page.locator(".jp-NotebookPanel").wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
                     wait_for_kernel(server_url, token, server)
 
-                    # 1. The creation cell executes in the real kernel.
-                    creation_output = execute_cell(page, 0, "HYPSTER_IMPORT_PATH=")
-                    import_match = re.search(r"HYPSTER_IMPORT_PATH=(.+)", creation_output)
-                    assert import_match, f"missing import-path proof in output: {creation_output}"
+                    creation = execute_cell(page, "create-auto", "HYPSTER_IMPORT_PATH=")
+                    import_match = re.search(r"HYPSTER_IMPORT_PATH=([^;]+)", creation.output)
+                    assert import_match, f"missing import-path proof in output: {creation.output}"
                     evidence["hypster_import_path"] = import_match.group(1).strip()
+                    evidence["creation_oracle"] = {"count": creation.count, "identity": creation.identity}
+                    transcript = [creation.output]
 
-                    # 2. The current renderer creates a real widget root.
-                    root = page.locator(".hypster-widget")
-                    root.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
-                    assert root.count() == 1, f"expected one rendered widget, got {root.count()}"
+                    auto_widget = notebook_cell(page, "create-auto").locator(".hypster-widget")
+                    auto_widget.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+                    assert auto_widget.count() == 1, f"expected one rendered widget, got {auto_widget.count()}"
                     assert_widget_has_no_error(page)
 
-                    # 3. Real branch and numeric DOM events change the live controls.
-                    numeric = page.locator("input[data-path='remote.temperature'][data-kind='float']")
-                    assert numeric.count() == 0, "dependent numeric control was reachable before the branch action"
-                    before_branch_html = root.inner_html()
-                    page.locator(".hypster-choice[data-path='mode'] .hypster-choice-trigger").click()
-                    page.locator("[data-hypster-choice-option][data-path='mode']", has_text="remote").click()
+                    theme_evidence = exercise_theme(page, auto_widget)
+                    auto_evidence = exercise_auto_mode(page, auto_widget)
+                    manual_evidence = exercise_manual_mode(page)
+                    protocol_evidence = exercise_protocol_guard(page)
 
-                    # 4. The dependent control appears only after replacement snapshot DOM arrives.
-                    numeric.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
-                    assert numeric.input_value() == "0.25", (
-                        "branch round trip did not publish the expected dependent default"
-                    )
-                    after_branch_html = root.inner_html()
-                    assert after_branch_html != before_branch_html, "branch action did not publish replacement DOM"
-                    assert_widget_has_no_error(page)
+                    evidence["theme_dark"] = asdict(theme_evidence.dark)
+                    evidence["theme_light"] = asdict(theme_evidence.light)
+                    evidence["numeric_dom_before"] = auto_evidence.numeric_dom_before
+                    evidence["numeric_dom_after"] = auto_evidence.numeric_dom_after
+                    evidence["numeric_dom_replaced"] = auto_evidence.numeric_dom_replaced
+                    evidence["branch_memory_dom_restored"] = auto_evidence.branch_memory_dom_restored
+                    evidence["branch_memory_python"] = auto_evidence.branch_memory_python
+                    evidence["auto_oracle"] = asdict(auto_evidence.oracle)
+                    evidence["manual_staged_dom"] = manual_evidence.staged_dom
+                    evidence["manual_staged_python"] = manual_evidence.staged_python
+                    evidence["manual_applied_python"] = manual_evidence.applied_python
+                    evidence["invalid_dom_error"] = manual_evidence.invalid_dom_error
+                    evidence["invalid_python_unchanged"] = manual_evidence.invalid_python_unchanged
+                    evidence["manual_reset_dom"] = manual_evidence.reset_dom
+                    evidence["manual_reset_python"] = manual_evidence.reset_python
+                    evidence["manual_applied_oracles"] = [asdict(oracle) for oracle in manual_evidence.applied_oracles]
+                    evidence["protocol_error_dom"] = protocol_evidence.error_dom
+                    evidence["protocol_action_emitted"] = protocol_evidence.action_emitted
+                    evidence["protocol_python_unchanged"] = protocol_evidence.python_unchanged
+                    evidence["protocol_recovered_dom"] = protocol_evidence.recovered_dom
+                    evidence["protocol_oracles"] = [asdict(oracle) for oracle in protocol_evidence.oracles]
 
-                    old_numeric = numeric.element_handle()
-                    assert old_numeric is not None, "numeric control disappeared before its DOM event"
-                    evidence["numeric_dom_before"] = numeric.input_value()
-                    old_numeric.evaluate(
-                        """element => {
-                            element.value = '1.25';
-                            element.dispatchEvent(new Event('change', { bubbles: true }));
-                        }"""
-                    )
-                    page.wait_for_function("element => !element.isConnected", arg=old_numeric, timeout=COMM_TIMEOUT_MS)
-                    replacement_numeric = page.locator("input[data-path='remote.temperature'][data-kind='float']")
-                    replacement_numeric.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
-                    assert replacement_numeric.input_value() == "1.25", (
-                        "numeric comm round trip did not publish the chosen value"
-                    )
-                    assert not old_numeric.is_visible(), "numeric action did not detach the prior DOM control"
-                    evidence["numeric_dom_after"] = replacement_numeric.input_value()
-                    evidence["numeric_dom_replaced"] = True
-                    assert_widget_has_no_error(page)
+                    transcript.extend(auto_evidence.transcript)
+                    transcript.extend(manual_evidence.transcript)
+                    transcript.extend(protocol_evidence.transcript)
 
-                    # 5. The notebook's Python oracle verifies the exact selected params.
-                    verification_output = execute_cell(page, 1, "HYPSTER_PARAMS_VERIFIED=")
-                    assert "'remote.temperature': 1.25" in verification_output, verification_output
-                    (artifact_dir / "notebook-output.txt").write_text(f"{creation_output}\n\n{verification_output}\n")
+                    (artifact_dir / "notebook-output.txt").write_text("\n\n".join(transcript) + "\n")
 
                     page.keyboard.press("ControlOrMeta+S")
                     assert_saved_cells_succeeded(wait_for_saved_notebook(server_url, token))
 
-                    # 6. Browser, page, protocol/widget, kernel, and missing-comm failures are loud.
                     assert not browser_errors, f"error-level browser console entries: {browser_errors}"
                     assert not page_errors, f"browser page errors: {page_errors}"
                 except Exception:

--- a/tests/jupyterlab_host/test_jupyterlab_host.py
+++ b/tests/jupyterlab_host/test_jupyterlab_host.py
@@ -273,9 +273,9 @@ def widget_appearance(widget: Locator) -> WidgetAppearance:
     assert isinstance(theme, str), f"widget theme must be text, got {theme!r}"
     assert isinstance(color, str), f"widget color must be text, got {color!r}"
     assert isinstance(background, str), f"widget background must be text, got {background!r}"
-    assert isinstance(contrast, (int, float)) and not isinstance(
-        contrast, bool
-    ), f"widget contrast must be numeric, got {contrast!r}"
+    assert isinstance(contrast, (int, float)) and not isinstance(contrast, bool), (
+        f"widget contrast must be numeric, got {contrast!r}"
+    )
     return WidgetAppearance(
         theme=theme,
         color=color,


### PR DESCRIPTION
Closes #96

## Before / after

Before:

```text
JupyterLab proved only the basic branch + numeric round trip.
```

After:

```text
real JupyterLab + Chromium
  -> light/dark theme contrast
  -> Branch Choice Memory restoration
  -> manual staging, Apply, invalid draft, baseline Reset
  -> Protocol V1 mismatch, zero action surface, unchanged Python state, recovery
```

The sole tracked notebook remains the fixture. Every reused Python oracle now requires a new execution count, changed output, and a unique execution UUID, so stale output cannot pass. Scenario phases return frozen typed evidence; only the top-level harness serializes the artifact dictionary.

## Physical proof

- Fresh built wheel installed with `[viz]` into a clean Python 3.13 kernel
- Real JupyterLab 4.6.1 + Playwright 1.61.0 + Chromium 149.0.7827.55
- Host gate: `1 passed in 14.82s`
- Theme contrast: dark `18.73:1`; light `21:1`
- Manual oracle executions: increasing counts with distinct IDs
- Protocol mismatch: visible `expected 1, received 2`, `ACTION={}`, Python remained `{'mode': 'local'}`, controls recovered under V1
- Browser console errors: `[]`; page errors: `[]`
- Root suite: 190 passed, 1 skipped; Ruff and mypy passed
