### PR TITLE
test: add Notebook 7 Firefox real-host gate

### DIFF
--- a/.github/workflows/jupyterlab-host.yml
+++ b/.github/workflows/jupyterlab-host.yml
@@ -1,4 +1,4 @@
-name: JupyterLab host
+name: Notebook hosts
 
 on:
   pull_request:
@@ -10,8 +10,19 @@ permissions:
 
 jobs:
   real-host-round-trip:
+    name: ${{ matrix.host }} (${{ matrix.browser }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - host: jupyterlab
+            browser: chromium
+            test: test_real_jupyterlab_round_trip
+          - host: notebook7
+            browser: firefox
+            test: test_real_notebook7_round_trip
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -28,32 +39,32 @@ jobs:
 
       - name: Capture setup versions
         run: |
-          mkdir -p host-evidence
-          uv --version > host-evidence/setup.txt
-          uv run --project tests/jupyterlab_host --frozen python --version >> host-evidence/setup.txt
+          mkdir -p host-evidence-${{ matrix.host }}
+          uv --version > host-evidence-${{ matrix.host }}/setup.txt
+          uv run --project tests/jupyterlab_host --frozen python --version >> host-evidence-${{ matrix.host }}/setup.txt
           uv run --project tests/jupyterlab_host --frozen python -c \
-            'import importlib.metadata as m; print("jupyterlab", m.version("jupyterlab")); print("playwright", m.version("playwright"))' \
-            >> host-evidence/setup.txt
+            'import importlib.metadata as m; names=("jupyter-server", "jupyterlab", "notebook", "playwright"); print("\n".join(f"{name} {m.version(name)}" for name in names))' \
+            >> host-evidence-${{ matrix.host }}/setup.txt
 
       - name: Build repository wheel
         run: uv build --wheel --out-dir dist
 
-      - name: Install Chromium
-        run: uv run --project tests/jupyterlab_host --frozen playwright install --with-deps chromium
+      - name: Install ${{ matrix.browser }}
+        run: uv run --project tests/jupyterlab_host --frozen playwright install --with-deps ${{ matrix.browser }}
 
-      - name: Run real JupyterLab round trip
+      - name: Run real ${{ matrix.host }} round trip
         run: |
           WHEEL=$(find "$PWD/dist" -maxdepth 1 -name '*.whl' -print -quit)
           test -n "$WHEEL"
           HYPSTER_HOST_WHEEL="$WHEEL" \
-          HYPSTER_HOST_ARTIFACT_DIR="$PWD/host-evidence" \
+          HYPSTER_HOST_ARTIFACT_DIR="$PWD/host-evidence-${{ matrix.host }}" \
           uv run --project tests/jupyterlab_host --frozen \
-            pytest tests/jupyterlab_host/test_jupyterlab_host.py -o addopts= -q -s
+            pytest tests/jupyterlab_host/test_jupyterlab_host.py::${{ matrix.test }} -o addopts= -q -s
 
       - name: Upload host evidence
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: jupyterlab-host-${{ github.run_id }}
-          path: host-evidence/
+          name: ${{ matrix.host }}-${{ matrix.browser }}-${{ github.run_id }}
+          path: host-evidence-${{ matrix.host }}/
           if-no-files-found: error

--- a/tests/jupyterlab_host/README.md
+++ b/tests/jupyterlab_host/README.md
@@ -1,27 +1,25 @@
-# JupyterLab real-host harness
+# Notebook real-host harness
 
-This harness proves the current Hypster anywidget through a real JupyterLab 4
-server, kernel, and Chromium page. Its sole notebook fixture is
-`branch_round_trip.ipynb`.
+This harness proves the current Hypster anywidget through real JupyterLab 4 +
+Chromium and Notebook 7 + Firefox hosts. Both use the sole notebook fixture,
+`branch_round_trip.ipynb`, and the same basic branch/numeric round trip.
 
 The test creates a temporary kernel environment, installs the repository's
 built wheel with `[viz]` from the checked-in kernel lock, and copies the fixture
 outside the source checkout. It then crosses the real boundary:
 
 ```text
-Chromium DOM event -> anywidget comm -> Python controller -> replacement DOM
+Browser DOM event -> anywidget comm -> Python controller -> replacement DOM
 ```
 
-Notebook verification cells are independent Python oracles for auto-applied,
-staged, invalid, applied, and reset `result.params` values. The canonical
-scenario also switches the real JupyterLab theme, verifies Branch Choice
-Memory, drives Apply and Reset in manual mode, and sends a mismatched Protocol
-V1 snapshot through the live widget comm before recovering with a valid
-snapshot. Reused Python oracle cells must publish a new execution count and
-unique output identity. Browser errors, cell errors, unexpected visible widget
-errors, missing comm-driven replacement DOM, and timeouts fail the run. The
-browser, Jupyter server, kernel, and their process group are terminated on
-every exit.
+The Notebook 7 job runs the shared basic scenario and its fresh Python oracle.
+The canonical JupyterLab scenario additionally switches the real host theme,
+verifies Branch Choice Memory, drives Apply and Reset in manual mode, and sends
+a mismatched Protocol V1 snapshot through the live widget comm before recovery.
+Reused Python oracle cells must publish a new execution count and unique output
+identity. Browser errors, cell errors, unexpected visible widget errors,
+missing comm-driven replacement DOM, and timeouts fail the run. The browser,
+Jupyter server, kernel, and their process group terminate on every exit.
 
 ## Local run
 
@@ -30,13 +28,33 @@ From the repository root:
 ```bash
 uv sync --project tests/jupyterlab_host --frozen
 uv build --wheel --out-dir dist
-uv run --project tests/jupyterlab_host --frozen playwright install chromium
+uv run --project tests/jupyterlab_host --frozen playwright install chromium firefox
 WHEEL=$(find "$PWD/dist" -maxdepth 1 -name '*.whl' -print -quit)
 HYPSTER_HOST_WHEEL="$WHEEL" \
-HYPSTER_HOST_ARTIFACT_DIR="$PWD/host-evidence" \
+HYPSTER_HOST_ARTIFACT_DIR="$PWD/host-evidence-jupyterlab" \
 uv run --project tests/jupyterlab_host --frozen \
-  pytest tests/jupyterlab_host/test_jupyterlab_host.py -o addopts= -q -s
+  pytest tests/jupyterlab_host/test_jupyterlab_host.py::test_real_jupyterlab_round_trip -o addopts= -q -s
+
+HYPSTER_HOST_WHEEL="$WHEEL" \
+HYPSTER_HOST_ARTIFACT_DIR="$PWD/host-evidence-notebook7" \
+uv run --project tests/jupyterlab_host --frozen \
+  pytest tests/jupyterlab_host/test_jupyterlab_host.py::test_real_notebook7_round_trip -o addopts= -q -s
 ```
 
 The wheel path and artifact directory are mandatory; the harness has no source
 checkout or evidence-path fallback.
+
+## Current Notebook 7 blocker
+
+Issue #108 records a Notebook `7.6.0` page exception observed in Firefox before
+any Hypster cell executes. The Notebook node intentionally remains red on that
+exception: the harness records errors before widget execution, after the basic
+round trip, and at shutdown, then fails without filtering host errors.
+
+The required fault injections were also exercised against the physical host:
+
+- Sending `1.50` while the shared oracle requires `1.25` failed at the
+  replacement-DOM value assertion (`1.5 != 1.25`).
+- Leaving the previous verification output in place while making the next cell
+  execution a no-op failed because the prompt stayed at `[2]:`; stale marker
+  text did not satisfy the fresh-execution check.

--- a/tests/jupyterlab_host/README.md
+++ b/tests/jupyterlab_host/README.md
@@ -44,12 +44,14 @@ uv run --project tests/jupyterlab_host --frozen \
 The wheel path and artifact directory are mandatory; the harness has no source
 checkout or evidence-path fallback.
 
-## Current Notebook 7 blocker
+## Notebook 7.6.0 regression
 
-Issue #108 records a Notebook `7.6.0` page exception observed in Firefox before
-any Hypster cell executes. The Notebook node intentionally remains red on that
-exception: the harness records errors before widget execution, after the basic
-round trip, and at shutdown, then fails without filtering host errors.
+Issue #108 records a Notebook `7.6.0` / JupyterLab `4.6.1` page exception
+observed in Firefox before any Hypster cell executes. The currently-tested host
+pair is pinned to Notebook `7.5.7` / JupyterLab `4.5.9`, the newest prior
+coherent pair proven to load with zero page errors and complete the physical
+round trip. The harness still records errors before widget execution, after the
+basic round trip, and at shutdown, then fails without filtering host errors.
 
 The required fault injections were also exercised against the physical host:
 

--- a/tests/jupyterlab_host/pyproject.toml
+++ b/tests/jupyterlab_host/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "anywidget>=0.9,<0.12",
     "jupyterlab>=4,<5",
     "jupyterlab-widgets>=3,<4",
+    "notebook>=7,<8",
     "playwright>=1.55,<2",
     "pytest>=8,<10",
 ]

--- a/tests/jupyterlab_host/pyproject.toml
+++ b/tests/jupyterlab_host/pyproject.toml
@@ -4,9 +4,9 @@ version = "0.0.0"
 requires-python = ">=3.13,<3.14"
 dependencies = [
     "anywidget>=0.9,<0.12",
-    "jupyterlab>=4,<5",
+    "jupyterlab==4.5.9",
     "jupyterlab-widgets>=3,<4",
-    "notebook>=7,<8",
+    "notebook==7.5.7",
     "playwright>=1.55,<2",
     "pytest>=8,<10",
 ]

--- a/tests/jupyterlab_host/test_jupyterlab_host.py
+++ b/tests/jupyterlab_host/test_jupyterlab_host.py
@@ -16,7 +16,7 @@ import time
 import urllib.request
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlsplit
 
 from playwright.sync_api import Locator, Page, sync_playwright
@@ -28,9 +28,11 @@ KERNEL_LOCK = HARNESS_ROOT / "kernel-requirements.lock"
 SERVER_TIMEOUT_SECONDS = 60
 SERVER_PORT_RETRIES = 5
 COMM_TIMEOUT_MS = 30_000
-REQUIRED_CELL_MARKERS = (
+BASIC_CELL_MARKERS = (
     "create-auto",
     "verify-auto",
+)
+JUPYTERLAB_CELL_MARKERS = BASIC_CELL_MARKERS + (
     "create-manual",
     "verify-manual-staged",
     "verify-manual-applied",
@@ -39,6 +41,34 @@ REQUIRED_CELL_MARKERS = (
     "inject-protocol-mismatch",
     "verify-protocol-unchanged",
     "recover-protocol",
+)
+
+
+@dataclass(frozen=True)
+class HostConfig:
+    name: str
+    server_module: str
+    route: str
+    browser: Literal["chromium", "firefox"]
+    required_cell_markers: tuple[str, ...]
+    extended: bool
+
+
+JUPYTERLAB = HostConfig(
+    name="jupyterlab",
+    server_module="jupyterlab",
+    route="lab/tree",
+    browser="chromium",
+    required_cell_markers=JUPYTERLAB_CELL_MARKERS,
+    extended=True,
+)
+NOTEBOOK7 = HostConfig(
+    name="notebook7",
+    server_module="notebook",
+    route="tree",
+    browser="firefox",
+    required_cell_markers=BASIC_CELL_MARKERS,
+    extended=False,
 )
 
 
@@ -70,10 +100,16 @@ class ThemeEvidence:
 
 
 @dataclass(frozen=True)
-class AutoEvidence:
+class BasicAutoEvidence:
     numeric_dom_before: str
     numeric_dom_after: str
     numeric_dom_replaced: bool
+    oracle: OracleEvidence
+    transcript: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BranchMemoryEvidence:
     branch_memory_dom_restored: str
     branch_memory_python: str
     oracle: OracleEvidence
@@ -126,10 +162,10 @@ def available_port() -> int:
         return int(listener.getsockname()[1])
 
 
-def wait_for_server(url: str, token: str, process: subprocess.Popen[str]) -> None:
+def wait_for_server(url: str, token: str, process: subprocess.Popen[str], host_name: str) -> None:
     deadline = time.monotonic() + SERVER_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
-        assert process.poll() is None, f"JupyterLab exited before readiness with code {process.returncode}"
+        assert process.poll() is None, f"{host_name} exited before readiness with code {process.returncode}"
         try:
             with urllib.request.urlopen(f"{url}/api/status?token={token}", timeout=1) as response:
                 if response.status == 200:
@@ -137,15 +173,20 @@ def wait_for_server(url: str, token: str, process: subprocess.Popen[str]) -> Non
         except OSError:
             time.sleep(0.25)
     raise AssertionError(
-        f"JupyterLab did not become ready within {SERVER_TIMEOUT_SECONDS}s; process return code: {process.poll()}"
+        f"{host_name} did not become ready within {SERVER_TIMEOUT_SECONDS}s; process return code: {process.poll()}"
     )
 
 
-def wait_for_server_info(runtime_dir: Path, token: str, process: subprocess.Popen[str]) -> str:
+def wait_for_server_info(
+    runtime_dir: Path,
+    token: str,
+    process: subprocess.Popen[str],
+    host_name: str,
+) -> str:
     deadline = time.monotonic() + SERVER_TIMEOUT_SECONDS
     info_file = runtime_dir / f"jpserver-{process.pid}.json"
     while time.monotonic() < deadline:
-        assert process.poll() is None, f"JupyterLab exited before publishing server info: {process.returncode}"
+        assert process.poll() is None, f"{host_name} exited before publishing server info: {process.returncode}"
         try:
             info = json.loads(info_file.read_text())
         except (FileNotFoundError, json.JSONDecodeError):
@@ -161,17 +202,17 @@ def wait_for_server_info(runtime_dir: Path, token: str, process: subprocess.Pope
         assert parsed_url.port == info["port"], f"server info URL and port disagree: {info}"
         return url
 
-    raise AssertionError(f"JupyterLab did not publish {info_file.name} within {SERVER_TIMEOUT_SECONDS}s")
+    raise AssertionError(f"{host_name} did not publish {info_file.name} within {SERVER_TIMEOUT_SECONDS}s")
 
 
-def wait_for_kernel(url: str, token: str, process: subprocess.Popen[str]) -> None:
+def wait_for_kernel(url: str, token: str, process: subprocess.Popen[str], host_name: str) -> None:
     deadline = time.monotonic() + SERVER_TIMEOUT_SECONDS
     request = urllib.request.Request(
         f"{url}/api/sessions",
         headers={"Authorization": f"token {token}"},
     )
     while time.monotonic() < deadline:
-        assert process.poll() is None, f"JupyterLab exited while the kernel was connecting: {process.returncode}"
+        assert process.poll() is None, f"{host_name} exited while the kernel was connecting: {process.returncode}"
         try:
             with urllib.request.urlopen(request, timeout=1) as response:
                 sessions = json.load(response)
@@ -273,9 +314,9 @@ def widget_appearance(widget: Locator) -> WidgetAppearance:
     assert isinstance(theme, str), f"widget theme must be text, got {theme!r}"
     assert isinstance(color, str), f"widget color must be text, got {color!r}"
     assert isinstance(background, str), f"widget background must be text, got {background!r}"
-    assert isinstance(contrast, (int, float)) and not isinstance(contrast, bool), (
-        f"widget contrast must be numeric, got {contrast!r}"
-    )
+    assert isinstance(contrast, (int, float)) and not isinstance(
+        contrast, bool
+    ), f"widget contrast must be numeric, got {contrast!r}"
     return WidgetAppearance(
         theme=theme,
         color=color,
@@ -299,9 +340,9 @@ def notebook_model(url: str, token: str) -> dict[str, Any]:
         return json.load(response)["content"]
 
 
-def assert_saved_cells_succeeded(model: dict[str, Any]) -> None:
+def assert_saved_cells_succeeded(model: dict[str, Any], required_markers: tuple[str, ...]) -> None:
     cells = model["cells"]
-    for marker in REQUIRED_CELL_MARKERS:
+    for marker in required_markers:
         matching = [cell for cell in cells if f"HYPSTER_HOST_CELL:{marker}" in "".join(cell["source"])]
         assert len(matching) == 1, f"expected one saved cell marked {marker!r}, got {len(matching)}"
         cell = matching[0]
@@ -310,7 +351,7 @@ def assert_saved_cells_succeeded(model: dict[str, Any]) -> None:
         assert not errors, f"cell {marker!r} saved kernel errors: {errors}"
 
 
-def wait_for_saved_notebook(url: str, token: str) -> dict[str, Any]:
+def wait_for_saved_notebook(url: str, token: str, required_markers: tuple[str, ...]) -> dict[str, Any]:
     deadline = time.monotonic() + 10
     last_model: dict[str, Any] | None = None
     while time.monotonic() < deadline:
@@ -318,13 +359,13 @@ def wait_for_saved_notebook(url: str, token: str) -> dict[str, Any]:
         cells = last_model["cells"]
         executed_markers = {
             marker
-            for marker in REQUIRED_CELL_MARKERS
+            for marker in required_markers
             if any(
                 f"HYPSTER_HOST_CELL:{marker}" in "".join(cell["source"]) and cell["execution_count"] is not None
                 for cell in cells
             )
         }
-        if executed_markers == set(REQUIRED_CELL_MARKERS):
+        if executed_markers == set(required_markers):
             return last_model
         time.sleep(0.1)
     raise AssertionError(f"executed notebook was not saved within 10s: {last_model}")
@@ -374,10 +415,10 @@ def exercise_theme(page: Page, widget: Locator) -> ThemeEvidence:
     return ThemeEvidence(dark=dark, light=light)
 
 
-def exercise_auto_mode(
+def exercise_basic_auto_mode(
     page: Page,
     widget: Locator,
-) -> AutoEvidence:
+) -> BasicAutoEvidence:
     numeric = widget.locator("input[data-path='remote.temperature'][data-kind='float']")
     assert numeric.count() == 0, "dependent numeric control was reachable before the branch action"
     before_branch_html = widget.inner_html()
@@ -402,9 +443,25 @@ def exercise_auto_mode(
     numeric_dom_after = replacement_numeric.input_value()
     assert_widget_has_no_error(page)
 
+    verification = execute_cell(page, "verify-auto", "HYPSTER_PARAMS_VERIFIED=")
+    assert "'remote.temperature': 1.25" in verification.output, verification.output
+    return BasicAutoEvidence(
+        numeric_dom_before=numeric_dom_before,
+        numeric_dom_after=numeric_dom_after,
+        numeric_dom_replaced=True,
+        oracle=OracleEvidence(count=verification.count, identity=verification.identity),
+        transcript=(verification.output,),
+    )
+
+
+def exercise_branch_memory(page: Page, widget: Locator) -> BranchMemoryEvidence:
+    numeric = widget.locator("input[data-path='remote.temperature'][data-kind='float']")
+    numeric.wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
+    assert numeric.input_value() == "1.25", "Branch Choice Memory did not start from the chosen value"
+
     widget.locator(".hypster-choice[data-path='mode'] .hypster-choice-trigger").click()
     widget.locator("[data-hypster-choice-option][data-path='mode']", has_text="local").click()
-    replacement_numeric.wait_for(state="detached", timeout=COMM_TIMEOUT_MS)
+    numeric.wait_for(state="detached", timeout=COMM_TIMEOUT_MS)
     widget.locator(".hypster-choice[data-path='mode'] .hypster-choice-trigger").click()
     widget.locator("[data-hypster-choice-option][data-path='mode']", has_text="remote").click()
     restored_numeric = widget.locator("input[data-path='remote.temperature'][data-kind='float']")
@@ -414,10 +471,7 @@ def exercise_auto_mode(
 
     verification = execute_cell(page, "verify-auto", "HYPSTER_PARAMS_VERIFIED=")
     assert "'remote.temperature': 1.25" in verification.output, verification.output
-    return AutoEvidence(
-        numeric_dom_before=numeric_dom_before,
-        numeric_dom_after=numeric_dom_after,
-        numeric_dom_replaced=True,
+    return BranchMemoryEvidence(
         branch_memory_dom_restored=branch_memory_dom_restored,
         branch_memory_python=verification.output,
         oracle=OracleEvidence(count=verification.count, identity=verification.identity),
@@ -544,13 +598,13 @@ def exercise_protocol_guard(page: Page) -> ProtocolEvidence:
     )
 
 
-def test_real_jupyterlab_round_trip() -> None:
+def run_real_host_round_trip(host: HostConfig) -> None:
     wheel = required_path("HYPSTER_HOST_WHEEL").resolve(strict=True)
     artifact_dir = required_path("HYPSTER_HOST_ARTIFACT_DIR")
     artifact_dir.mkdir(parents=True, exist_ok=True)
     assert wheel.suffix == ".whl", f"expected a built wheel, got {wheel}"
 
-    with tempfile.TemporaryDirectory(prefix="hypster-jupyterlab-host-") as temp_raw:
+    with tempfile.TemporaryDirectory(prefix=f"hypster-{host.name}-host-") as temp_raw:
         temp = Path(temp_raw)
         notebook_root = temp / "notebooks"
         notebook_root.mkdir()
@@ -595,7 +649,7 @@ def test_real_jupyterlab_round_trip() -> None:
 
         token = "hypster-host-test"
         port = available_port()
-        server_log_path = artifact_dir / "jupyterlab.log"
+        server_log_path = artifact_dir / f"{host.name}.log"
         server_log = server_log_path.open("w")
         runtime_dir = temp / "jupyter-runtime"
         server_env = os.environ.copy()
@@ -610,7 +664,7 @@ def test_real_jupyterlab_round_trip() -> None:
             [
                 sys.executable,
                 "-m",
-                "jupyterlab",
+                host.server_module,
                 "--no-browser",
                 f"--ServerApp.root_dir={notebook_root}",
                 f"--ServerApp.port={port}",
@@ -649,9 +703,18 @@ def test_real_jupyterlab_round_trip() -> None:
             "uv": run_checked(["uv", "--version"], cwd=temp),
             "wheel": wheel.name,
             "wheel_sha256": hashlib.sha256(wheel.read_bytes()).hexdigest(),
+            "host": asdict(host),
             "host_packages": {
                 name: importlib.metadata.version(name)
-                for name in ["anywidget", "jupyterlab", "jupyterlab-widgets", "playwright", "pytest"]
+                for name in [
+                    "anywidget",
+                    "jupyter-server",
+                    "jupyterlab",
+                    "jupyterlab-widgets",
+                    "notebook",
+                    "playwright",
+                    "pytest",
+                ]
             },
             "kernel": kernel_packages,
             "kernel_lock": KERNEL_LOCK.name,
@@ -659,13 +722,14 @@ def test_real_jupyterlab_round_trip() -> None:
         (artifact_dir / "versions.json").write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n")
 
         try:
-            server_url = wait_for_server_info(runtime_dir, token, server)
+            server_url = wait_for_server_info(runtime_dir, token, server, host.name)
             evidence["jupyter_server_pid"] = server.pid
             evidence["jupyter_server_url"] = server_url
-            wait_for_server(server_url, token, server)
+            wait_for_server(server_url, token, server, host.name)
             with sync_playwright() as playwright:
-                browser = playwright.chromium.launch()
-                evidence["chromium"] = browser.version
+                browser_type = playwright.chromium if host.browser == "chromium" else playwright.firefox
+                browser = browser_type.launch()
+                evidence["browser"] = {"engine": host.browser, "version": browser.version}
                 context = browser.new_context()
                 page = context.new_page()
                 page.on(
@@ -675,12 +739,14 @@ def test_real_jupyterlab_round_trip() -> None:
 
                 try:
                     page.goto(
-                        f"{server_url}/lab/tree/{NOTEBOOK.name}?token={token}",
+                        f"{server_url}/{host.route}/{NOTEBOOK.name}?token={token}",
                         wait_until="domcontentloaded",
                         timeout=COMM_TIMEOUT_MS,
                     )
                     page.locator(".jp-NotebookPanel").wait_for(state="visible", timeout=COMM_TIMEOUT_MS)
-                    wait_for_kernel(server_url, token, server)
+                    wait_for_kernel(server_url, token, server, host.name)
+                    page.wait_for_timeout(1_000)
+                    evidence["page_errors_before_widget_execution"] = list(page_errors)
 
                     creation = execute_cell(page, "create-auto", "HYPSTER_IMPORT_PATH=")
                     import_match = re.search(r"HYPSTER_IMPORT_PATH=([^;]+)", creation.output)
@@ -694,41 +760,50 @@ def test_real_jupyterlab_round_trip() -> None:
                     assert auto_widget.count() == 1, f"expected one rendered widget, got {auto_widget.count()}"
                     assert_widget_has_no_error(page)
 
-                    theme_evidence = exercise_theme(page, auto_widget)
-                    auto_evidence = exercise_auto_mode(page, auto_widget)
-                    manual_evidence = exercise_manual_mode(page)
-                    protocol_evidence = exercise_protocol_guard(page)
+                    basic_evidence = exercise_basic_auto_mode(page, auto_widget)
+                    evidence["numeric_dom_before"] = basic_evidence.numeric_dom_before
+                    evidence["numeric_dom_after"] = basic_evidence.numeric_dom_after
+                    evidence["numeric_dom_replaced"] = basic_evidence.numeric_dom_replaced
+                    evidence["auto_oracle"] = asdict(basic_evidence.oracle)
+                    evidence["page_errors_after_basic_round_trip"] = list(page_errors)
+                    transcript.extend(basic_evidence.transcript)
 
-                    evidence["theme_dark"] = asdict(theme_evidence.dark)
-                    evidence["theme_light"] = asdict(theme_evidence.light)
-                    evidence["numeric_dom_before"] = auto_evidence.numeric_dom_before
-                    evidence["numeric_dom_after"] = auto_evidence.numeric_dom_after
-                    evidence["numeric_dom_replaced"] = auto_evidence.numeric_dom_replaced
-                    evidence["branch_memory_dom_restored"] = auto_evidence.branch_memory_dom_restored
-                    evidence["branch_memory_python"] = auto_evidence.branch_memory_python
-                    evidence["auto_oracle"] = asdict(auto_evidence.oracle)
-                    evidence["manual_staged_dom"] = manual_evidence.staged_dom
-                    evidence["manual_staged_python"] = manual_evidence.staged_python
-                    evidence["manual_applied_python"] = manual_evidence.applied_python
-                    evidence["invalid_dom_error"] = manual_evidence.invalid_dom_error
-                    evidence["invalid_python_unchanged"] = manual_evidence.invalid_python_unchanged
-                    evidence["manual_reset_dom"] = manual_evidence.reset_dom
-                    evidence["manual_reset_python"] = manual_evidence.reset_python
-                    evidence["manual_applied_oracles"] = [asdict(oracle) for oracle in manual_evidence.applied_oracles]
-                    evidence["protocol_error_dom"] = protocol_evidence.error_dom
-                    evidence["protocol_action_emitted"] = protocol_evidence.action_emitted
-                    evidence["protocol_python_unchanged"] = protocol_evidence.python_unchanged
-                    evidence["protocol_recovered_dom"] = protocol_evidence.recovered_dom
-                    evidence["protocol_oracles"] = [asdict(oracle) for oracle in protocol_evidence.oracles]
+                    if host.extended:
+                        theme_evidence = exercise_theme(page, auto_widget)
+                        branch_memory_evidence = exercise_branch_memory(page, auto_widget)
+                        manual_evidence = exercise_manual_mode(page)
+                        protocol_evidence = exercise_protocol_guard(page)
 
-                    transcript.extend(auto_evidence.transcript)
-                    transcript.extend(manual_evidence.transcript)
-                    transcript.extend(protocol_evidence.transcript)
+                        evidence["theme_dark"] = asdict(theme_evidence.dark)
+                        evidence["theme_light"] = asdict(theme_evidence.light)
+                        evidence["branch_memory_dom_restored"] = branch_memory_evidence.branch_memory_dom_restored
+                        evidence["branch_memory_python"] = branch_memory_evidence.branch_memory_python
+                        evidence["branch_memory_oracle"] = asdict(branch_memory_evidence.oracle)
+                        evidence["manual_staged_dom"] = manual_evidence.staged_dom
+                        evidence["manual_staged_python"] = manual_evidence.staged_python
+                        evidence["manual_applied_python"] = manual_evidence.applied_python
+                        evidence["invalid_dom_error"] = manual_evidence.invalid_dom_error
+                        evidence["invalid_python_unchanged"] = manual_evidence.invalid_python_unchanged
+                        evidence["manual_reset_dom"] = manual_evidence.reset_dom
+                        evidence["manual_reset_python"] = manual_evidence.reset_python
+                        evidence["manual_applied_oracles"] = [
+                            asdict(oracle) for oracle in manual_evidence.applied_oracles
+                        ]
+                        evidence["protocol_error_dom"] = protocol_evidence.error_dom
+                        evidence["protocol_action_emitted"] = protocol_evidence.action_emitted
+                        evidence["protocol_python_unchanged"] = protocol_evidence.python_unchanged
+                        evidence["protocol_recovered_dom"] = protocol_evidence.recovered_dom
+                        evidence["protocol_oracles"] = [asdict(oracle) for oracle in protocol_evidence.oracles]
+
+                        transcript.extend(branch_memory_evidence.transcript)
+                        transcript.extend(manual_evidence.transcript)
+                        transcript.extend(protocol_evidence.transcript)
 
                     (artifact_dir / "notebook-output.txt").write_text("\n\n".join(transcript) + "\n")
 
                     page.keyboard.press("ControlOrMeta+S")
-                    assert_saved_cells_succeeded(wait_for_saved_notebook(server_url, token))
+                    saved_notebook = wait_for_saved_notebook(server_url, token, host.required_cell_markers)
+                    assert_saved_cells_succeeded(saved_notebook, host.required_cell_markers)
 
                     assert not browser_errors, f"error-level browser console entries: {browser_errors}"
                     assert not page_errors, f"browser page errors: {page_errors}"
@@ -746,3 +821,11 @@ def test_real_jupyterlab_round_trip() -> None:
             (artifact_dir / "versions.json").write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n")
             terminate_process_group(server)
             server_log.close()
+
+
+def test_real_jupyterlab_round_trip() -> None:
+    run_real_host_round_trip(JUPYTERLAB)
+
+
+def test_real_notebook7_round_trip() -> None:
+    run_real_host_round_trip(NOTEBOOK7)

--- a/tests/jupyterlab_host/test_jupyterlab_host.py
+++ b/tests/jupyterlab_host/test_jupyterlab_host.py
@@ -314,9 +314,9 @@ def widget_appearance(widget: Locator) -> WidgetAppearance:
     assert isinstance(theme, str), f"widget theme must be text, got {theme!r}"
     assert isinstance(color, str), f"widget color must be text, got {color!r}"
     assert isinstance(background, str), f"widget background must be text, got {background!r}"
-    assert isinstance(contrast, (int, float)) and not isinstance(
-        contrast, bool
-    ), f"widget contrast must be numeric, got {contrast!r}"
+    assert isinstance(contrast, (int, float)) and not isinstance(contrast, bool), (
+        f"widget contrast must be numeric, got {contrast!r}"
+    )
     return WidgetAppearance(
         theme=theme,
         color=color,

--- a/tests/jupyterlab_host/uv.lock
+++ b/tests/jupyterlab_host/uv.lock
@@ -352,9 +352,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "anywidget", specifier = ">=0.9,<0.12" },
-    { name = "jupyterlab", specifier = ">=4,<5" },
+    { name = "jupyterlab", specifier = "==4.5.9" },
     { name = "jupyterlab-widgets", specifier = ">=3,<4" },
-    { name = "notebook", specifier = ">=7,<8" },
+    { name = "notebook", specifier = "==7.5.7" },
     { name = "playwright", specifier = ">=1.55,<2" },
     { name = "pytest", specifier = ">=8,<10" },
 ]
@@ -546,19 +546,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jupyter-builder"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jupyter-core" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/df/db5efc4e28803a1421350445e53d85ec571a4e6928e3524ccc39f4e16584/jupyter_builder-1.1.0.tar.gz", hash = "sha256:b996e8af616900f18724fa34883169d869be2205497940bec78a3a1031eb897d", size = 971142, upload-time = "2026-07-11T07:24:02.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/fb/53adbc72931b4429275b160044c3e1bcbc8fbb5ea6b8f318a357834842fb/jupyter_builder-1.1.0-py3-none-any.whl", hash = "sha256:d9d5280e8845f726663545c3a6db55bd205127616eeb8958481091d6cba71b6a", size = 912964, upload-time = "2026-07-11T07:24:00.279Z" },
-]
-
-[[package]]
 name = "jupyter-client"
 version = "8.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -663,26 +650,26 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.6.1"
+version = "4.5.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
     { name = "httpx" },
     { name = "ipykernel" },
     { name = "jinja2" },
-    { name = "jupyter-builder" },
     { name = "jupyter-core" },
     { name = "jupyter-lsp" },
     { name = "jupyter-server" },
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
     { name = "packaging" },
+    { name = "setuptools" },
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/2a/d6af53bfd45a43a5bfe7e40ba47ee7a8921a807daf4bb708e3a295bbb54d/jupyterlab-4.6.1.tar.gz", hash = "sha256:75315982ed28427edaa62bb85eadb5105e4043a757643c910efd787fe6ed0837", size = 28179125, upload-time = "2026-06-29T12:48:45.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/a8d4895bef501ffeb6af448e8bf7079541c7772978211963aa653518c2d9/jupyterlab-4.5.9.tar.gz", hash = "sha256:dd79a073fecae7a39066ea99e4627ed6c76269ac926e95a810e1e1df6358d865", size = 23994445, upload-time = "2026-06-17T15:42:16.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/81/90ac6cc31d248e83a0d1eab343a5e6e68bc783d3f74fbe61640f42a61da4/jupyterlab-4.6.1-py3-none-any.whl", hash = "sha256:85a58546c831f3dce6cf919468c26874c9065e99c42279fb4abb8e1b552a98bb", size = 17164660, upload-time = "2026-06-29T12:48:41.21Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/2f9b425062416fba58f580c9b89c3b07277ccdf0a292501fedbca8ea00ea/jupyterlab-4.5.9-py3-none-any.whl", hash = "sha256:5ff0f908e8ac0afbed32b106fdef360f101c0a6654d1bf4a81e98a293ae1b336", size = 12449803, upload-time = "2026-06-17T15:42:12.18Z" },
 ]
 
 [[package]]
@@ -847,19 +834,18 @@ wheels = [
 
 [[package]]
 name = "notebook"
-version = "7.6.0"
+version = "7.5.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupyter-builder" },
     { name = "jupyter-server" },
     { name = "jupyterlab" },
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
     { name = "tornado" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/44/d5c65783f490298473bb1c05722e05ee2256231389559c2c5ae0a3e5d975/notebook-7.6.0.tar.gz", hash = "sha256:ea13e79e601bf273074895fdfb17dd3f2da916d3c045e0b9c47d18b16ab62481", size = 5497344, upload-time = "2026-06-18T16:18:55.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/c4/f71f8716f2903e9e817a47f534b9fd84831e155e2acb32c26691c8e06243/notebook-7.5.7.tar.gz", hash = "sha256:d6d59288a25303b25e1dcb71e9b017ec3a785f7d92f38b9bc288ca1970d5b0a8", size = 14171612, upload-time = "2026-06-04T18:33:45.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/d1/e617c40db57ff40e75f43a7d4d1c305e3a54c053ab5cb0534a6c314664f9/notebook-7.6.0-py3-none-any.whl", hash = "sha256:98aa2811b54ac191321d5dfce12ca700f8a511a33a26e4de2fa106a357c43d6a", size = 5544575, upload-time = "2026-06-18T16:18:52.551Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4d/b3347f7073a377273531efe4ffc738fc910e93718fd2838c7ebf6736c6af/notebook-7.5.7-py3-none-any.whl", hash = "sha256:1f95f79d117e47d20b5555b5c85a397d2cfecf136978aaab767cf0314b09165b", size = 14583767, upload-time = "2026-06-04T18:33:40.987Z" },
 ]
 
 [[package]]
@@ -1246,6 +1232,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]

--- a/tests/jupyterlab_host/uv.lock
+++ b/tests/jupyterlab_host/uv.lock
@@ -344,6 +344,7 @@ dependencies = [
     { name = "anywidget" },
     { name = "jupyterlab" },
     { name = "jupyterlab-widgets" },
+    { name = "notebook" },
     { name = "playwright" },
     { name = "pytest" },
 ]
@@ -353,6 +354,7 @@ requires-dist = [
     { name = "anywidget", specifier = ">=0.9,<0.12" },
     { name = "jupyterlab", specifier = ">=4,<5" },
     { name = "jupyterlab-widgets", specifier = ">=3,<4" },
+    { name = "notebook", specifier = ">=7,<8" },
     { name = "playwright", specifier = ">=1.55,<2" },
     { name = "pytest", specifier = ">=8,<10" },
 ]
@@ -841,6 +843,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
+]
+
+[[package]]
+name = "notebook"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-builder" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/44/d5c65783f490298473bb1c05722e05ee2256231389559c2c5ae0a3e5d975/notebook-7.6.0.tar.gz", hash = "sha256:ea13e79e601bf273074895fdfb17dd3f2da916d3c045e0b9c47d18b16ab62481", size = 5497344, upload-time = "2026-06-18T16:18:55.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d1/e617c40db57ff40e75f43a7d4d1c305e3a54c053ab5cb0534a6c314664f9/notebook-7.6.0-py3-none-any.whl", hash = "sha256:98aa2811b54ac191321d5dfce12ca700f8a511a33a26e4de2fa106a357c43d6a", size = 5544575, upload-time = "2026-06-18T16:18:52.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #97
Closes #108

## Before / after

Before:

```text
One JupyterLab + Chromium host job
No real Notebook 7 + Firefox witness
Broad host ranges resolved Notebook 7.6.0 / JupyterLab 4.6.1,
which raises a Notebook-core page error before Hypster imports
```

After:

```text
Shared branch_round_trip.ipynb and shared host runner
  -> JupyterLab 4.5.9 + Chromium
  -> Notebook 7.5.7 + Firefox
  -> real DOM event -> anywidget comm -> Python -> replacement DOM
  -> fresh exact {'mode': 'remote', 'remote.temperature': 1.25} oracle
  -> zero browser/page/kernel errors and complete process cleanup
```

The harness records the exact 7.6.0/4.6.1 upstream regression discovered by
the fail-loud gate. The currently-tested pair is pinned to the newest prior
coherent green versions, Notebook 7.5.7 and JupyterLab 4.5.9; no page-error
filter, retry, browser substitution, or Hypster-side suppression was added.

## Proof

- Fresh JupyterLab + Chromium: `1 passed in 19.87s`
- Fresh Notebook 7 + Firefox 151.0: `1 passed in 14.34s`
- Wrong `1.50` value falsifier: rejected at `1.5 != 1.25`
- Stale oracle falsifier: rejected because execution prompt stayed `[2]:`
- Ruff lint/format: passed
- mypy: passed
- Full Python suite: `196 passed`
- Sole tracked notebook: unchanged

CI runs both exact real-host nodes independently and uploads their version,
wheel, browser, notebook-output, and server-log evidence on every exit.
