### PR TITLE
Prove the React renderer against Python and Panda

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -61,3 +61,4 @@ jobs:
         with:
           name: react-host-${{ github.run_id }}
           path: react-host-evidence/
+          if-no-files-found: error

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -47,3 +47,17 @@ jobs:
       - run: npm test
       - run: npm run build
       - run: npm pack --dry-run
+
+      - name: Install Chromium for the physical React host witness
+        run: |
+          uv sync --project ../../tests/jupyterlab_host --frozen
+          uv run --project ../../tests/jupyterlab_host --frozen playwright install --with-deps chromium
+      - name: Run physical Python-to-React host witness
+        env:
+          HYPSTER_REACT_HOST_ARTIFACT_DIR: ../../react-host-evidence
+        run: uv run --project ../../tests/jupyterlab_host --frozen pytest ../../tests/jupyterlab_host/test_react_renderer_host.py -o addopts= -q -s
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: react-host-${{ github.run_id }}
+          path: react-host-evidence/

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,26 @@
+# `@hypster/react`
+
+`@hypster/react` is an experimental React renderer for Hypster interactive
+configuration snapshots. It is a presentation adapter: Python owns exploration,
+validation, branch memory, application, and the selected parameters.
+
+```tsx
+import { HypsterRenderer } from "@hypster/react";
+
+<HypsterRenderer
+  snapshot={snapshotFromPython}
+  onAction={(action) => sendActionToPython(action)}
+/>
+```
+
+The host sends each emitted action to the Python `InteractiveSession`, replaces
+the old snapshot with the response, and uses `snapshot.selected_params` as the
+authoritative applied configuration. React must not reconcile values or rebuild
+branch semantics locally.
+
+The renderer currently recognizes Interactive Protocol V1. A different version
+produces a visible mismatch and no controls, which detects an incompatible host;
+V1 is not a stability promise for a future 1.x release.
+
+This package is experimental and private to the repository. Publishing it to npm
+is explicitly out of scope.

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "esbuild": "^0.25.12",
         "jsdom": "^26.1.0",
         "react-dom": "^19.2.0",
         "typescript": "^6.0.3"
@@ -182,6 +183,448 @@
         }
       ],
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">=18"
       }
@@ -399,6 +842,48 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/html-encoding-sniffer": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "esbuild": "^0.25.12",
     "jsdom": "^26.1.0",
     "react-dom": "^19.2.0",
     "typescript": "^6.0.3"

--- a/packages/react/test/host-entry.tsx
+++ b/packages/react/test/host-entry.tsx
@@ -50,7 +50,10 @@ async function onAction(action: InteractiveAction) {
     body: JSON.stringify({ execution_id: current.bridge_execution_id, action }),
   });
   if (!response.ok) throw new Error(`Action failed: ${response.status}`);
-  render((await response.json()) as BridgeSnapshot);
+  const snapshot = (await response.json()) as BridgeSnapshot;
+  if (snapshot.bridge_sequence > current.bridge_sequence) {
+    render(snapshot);
+  }
 }
 
 const v2 = new URLSearchParams(location.search).has("v2");

--- a/packages/react/test/host-entry.tsx
+++ b/packages/react/test/host-entry.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+import {
+  HypsterRenderer,
+  type InteractiveAction,
+  type InteractiveSnapshot,
+} from "../dist/index.js";
+
+declare global {
+  interface Window {
+    __hypsterHost: { executionId: string; sequence: number; renderer: string };
+  }
+}
+
+type BridgeSnapshot = InteractiveSnapshot & {
+  bridge_execution_id: string;
+  bridge_sequence: number;
+};
+
+const rootElement = document.querySelector<HTMLElement>("#root");
+if (!rootElement) throw new Error("Missing #root host element");
+const root = createRoot(rootElement);
+let current: BridgeSnapshot;
+
+function render(snapshot: BridgeSnapshot) {
+  current = snapshot;
+  window.__hypsterHost = {
+    executionId: snapshot.bridge_execution_id,
+    sequence: snapshot.bridge_sequence,
+    renderer: "@hypster/react",
+  };
+  rootElement.dataset.renderer = "@hypster/react";
+  rootElement.dataset.executionId = snapshot.bridge_execution_id;
+  rootElement.dataset.sequence = String(snapshot.bridge_sequence);
+  root.render(<HypsterRenderer snapshot={snapshot} onAction={onAction} />);
+}
+
+async function onAction(action: InteractiveAction) {
+  const response = await fetch("/action", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ execution_id: current.bridge_execution_id, action }),
+  });
+  if (!response.ok) throw new Error(`Action failed: ${response.status}`);
+  render((await response.json()) as BridgeSnapshot);
+}
+
+const v2 = new URLSearchParams(location.search).has("v2");
+const response = await fetch(v2 ? "/snapshot?v2=1" : "/snapshot");
+if (!response.ok) throw new Error(`Snapshot failed: ${response.status}`);
+render((await response.json()) as BridgeSnapshot);

--- a/packages/react/test/host-entry.tsx
+++ b/packages/react/test/host-entry.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useLayoutEffect } from "react";
 import { createRoot } from "react-dom/client";
 
 import {
@@ -23,6 +23,13 @@ if (!rootElement) throw new Error("Missing #root host element");
 const root = createRoot(rootElement);
 let current: BridgeSnapshot;
 
+function HostRenderer({ snapshot }: { snapshot: BridgeSnapshot }) {
+  useLayoutEffect(() => {
+    rootElement.dataset.renderedSequence = String(snapshot.bridge_sequence);
+  }, [snapshot.bridge_sequence]);
+  return <HypsterRenderer snapshot={snapshot} onAction={onAction} />;
+}
+
 function render(snapshot: BridgeSnapshot) {
   current = snapshot;
   window.__hypsterHost = {
@@ -33,13 +40,7 @@ function render(snapshot: BridgeSnapshot) {
   rootElement.dataset.renderer = "@hypster/react";
   rootElement.dataset.executionId = snapshot.bridge_execution_id;
   rootElement.dataset.sequence = String(snapshot.bridge_sequence);
-  root.render(
-    <HypsterRenderer
-      key={snapshot.bridge_sequence}
-      snapshot={snapshot}
-      onAction={onAction}
-    />,
-  );
+  root.render(<HostRenderer snapshot={snapshot} />);
 }
 
 async function onAction(action: InteractiveAction) {

--- a/packages/react/test/host-entry.tsx
+++ b/packages/react/test/host-entry.tsx
@@ -33,7 +33,13 @@ function render(snapshot: BridgeSnapshot) {
   rootElement.dataset.renderer = "@hypster/react";
   rootElement.dataset.executionId = snapshot.bridge_execution_id;
   rootElement.dataset.sequence = String(snapshot.bridge_sequence);
-  root.render(<HypsterRenderer snapshot={snapshot} onAction={onAction} />);
+  root.render(
+    <HypsterRenderer
+      key={snapshot.bridge_sequence}
+      snapshot={snapshot}
+      onAction={onAction}
+    />,
+  );
 }
 
 async function onAction(action: InteractiveAction) {

--- a/tests/jupyterlab_host/test_react_renderer_host.py
+++ b/tests/jupyterlab_host/test_react_renderer_host.py
@@ -170,8 +170,15 @@ def test_production_react_renderer_round_trips_through_python() -> None:
                 assert page.locator(".hypster-renderer").count() == 1
                 assert page.locator(".hypster-widget").count() == 0
                 page.get_by_label("Mode").select_option(label="remote")
-                page.get_by_label("Temperature").fill("1.25")
+                old_temperature = page.get_by_label("Temperature").element_handle()
+                assert old_temperature is not None
+                old_temperature.evaluate("element => { element.dataset.hostNode = 'old'; }")
+                old_temperature.fill("1.25")
                 page.wait_for_function("window.__hypsterHost.sequence === 2")
+                page.wait_for_function("element => !element.isConnected", arg=old_temperature)
+                new_temperature = page.get_by_label("Temperature")
+                assert new_temperature.get_attribute("data-host-node") is None
+                assert new_temperature.input_value() == "1.25"
                 assert bridge.session.params == {"mode": "remote", "remote.temperature": 1.25}
                 assert page.locator("#root").get_attribute("data-execution-id") == bridge.execution_id
                 page.screenshot(path=artifact_dir / "react-round-trip.png")

--- a/tests/jupyterlab_host/test_react_renderer_host.py
+++ b/tests/jupyterlab_host/test_react_renderer_host.py
@@ -175,9 +175,9 @@ def test_production_react_renderer_round_trips_through_python() -> None:
                 old_temperature.evaluate("element => { element.dataset.hostNode = 'old'; }")
                 old_temperature.fill("1.25")
                 page.wait_for_function("window.__hypsterHost.sequence === 2")
-                page.wait_for_function("element => !element.isConnected", arg=old_temperature)
+                page.locator("#root[data-rendered-sequence='2']").wait_for()
                 new_temperature = page.get_by_label("Temperature")
-                assert new_temperature.get_attribute("data-host-node") is None
+                assert new_temperature.get_attribute("data-host-node") == "old"
                 assert new_temperature.input_value() == "1.25"
                 assert bridge.session.params == {"mode": "remote", "remote.temperature": 1.25}
                 assert page.locator("#root").get_attribute("data-execution-id") == bridge.execution_id

--- a/tests/jupyterlab_host/test_react_renderer_host.py
+++ b/tests/jupyterlab_host/test_react_renderer_host.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.metadata import version
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Iterator
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+from uuid import uuid4
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+from playwright.sync_api import sync_playwright  # noqa: E402
+
+from hypster import HP  # noqa: E402
+from hypster.interactive.session import InteractiveSession  # noqa: E402
+
+REACT = ROOT / "packages" / "react"
+
+
+def _remote_config(hp: HP) -> dict[str, float]:
+    return {"temperature": hp.float(0.5, name="temperature")}
+
+
+def _host_config(hp: HP) -> dict[str, Any]:
+    mode = hp.select(["local", "remote"], name="mode", default="local")
+    result: dict[str, Any] = {"mode": mode}
+    if mode == "remote":
+        result["remote"] = hp.nest(_remote_config, name="remote")
+    return result
+
+
+class _Bridge:
+    def __init__(self, bundle: Path) -> None:
+        self.bundle = bundle
+        self.execution_id = str(uuid4())
+        self.sequence = 0
+        self.actions: list[dict[str, Any]] = []
+        self.session = InteractiveSession(_host_config)
+        self.lock = threading.Lock()
+
+    def snapshot(self, *, v2: bool = False) -> dict[str, Any]:
+        snapshot = self.session.snapshot
+        if v2:
+            snapshot["protocol_version"] = 2
+        snapshot["bridge_execution_id"] = self.execution_id
+        snapshot["bridge_sequence"] = self.sequence
+        return snapshot
+
+    def dispatch(self, execution_id: str, action: dict[str, Any]) -> dict[str, Any]:
+        if execution_id != self.execution_id:
+            raise PermissionError("stale host execution marker")
+        with self.lock:
+            self.actions.append(action)
+            self.session.dispatch(action)
+            self.sequence += 1
+            return self.snapshot()
+
+
+def _handler(bridge: _Bridge) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path.startswith("/snapshot"):
+                self._json(bridge.snapshot(v2="v2=1" in self.path))
+                return
+            if self.path == "/app.js":
+                content = bridge.bundle.read_bytes()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/javascript")
+                self.send_header("Content-Length", str(len(content)))
+                self.end_headers()
+                self.wfile.write(content)
+                return
+            if self.path.startswith("/"):
+                body = (
+                    b'<!doctype html><html><body><main id="root"></main>'
+                    b'<script type="module" src="/app.js"></script></body></html>'
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            self.send_error(404)
+
+        def do_POST(self) -> None:  # noqa: N802
+            if self.path != "/action":
+                self.send_error(404)
+                return
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length))
+            try:
+                self._json(bridge.dispatch(payload["execution_id"], payload["action"]))
+            except PermissionError as error:
+                self._json({"error": str(error)}, status=409)
+
+        def _json(self, value: Any, *, status: int = 200) -> None:
+            body = json.dumps(value).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *args: Any) -> None:
+            del args
+
+    return Handler
+
+
+@contextmanager
+def _server(bridge: _Bridge) -> Iterator[str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _handler(bridge))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "React host HTTP server did not stop"
+
+
+def test_production_react_renderer_round_trips_through_python() -> None:
+    artifact_dir = Path(os.environ.get("HYPSTER_REACT_HOST_ARTIFACT_DIR", ROOT / "react-host-evidence"))
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(["npm", "run", "build"], cwd=REACT, check=True)
+    chromium_version = "not-started"
+    with TemporaryDirectory(prefix="hypster-react-host-") as temporary:
+        bundle = Path(temporary) / "app.js"
+        subprocess.run(
+            ["npx", "esbuild", "test/host-entry.tsx", "--bundle", "--format=esm", f"--outfile={bundle}"],
+            cwd=REACT,
+            check=True,
+        )
+        bridge = _Bridge(bundle)
+        with _server(bridge) as url:
+            stale = Request(
+                f"{url}/action",
+                data=json.dumps(
+                    {"execution_id": "old-execution", "action": {"protocol_version": 1, "type": "reset"}}
+                ).encode(),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            try:
+                urlopen(stale)
+            except HTTPError as error:
+                assert error.code == 409
+            else:
+                raise AssertionError("stale execution marker was accepted")
+
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch()
+                chromium_version = browser.version
+                page = browser.new_page()
+                page.goto(url)
+                page.locator("#root[data-renderer='@hypster/react']").wait_for()
+                assert page.locator(".hypster-renderer").count() == 1
+                assert page.locator(".hypster-widget").count() == 0
+                page.get_by_label("Mode").select_option(label="remote")
+                page.get_by_label("Temperature").fill("1.25")
+                page.wait_for_function("window.__hypsterHost.sequence === 2")
+                assert bridge.session.params == {"mode": "remote", "remote.temperature": 1.25}
+                assert page.locator("#root").get_attribute("data-execution-id") == bridge.execution_id
+                page.screenshot(path=artifact_dir / "react-round-trip.png")
+
+                v2 = browser.new_page()
+                v2.goto(f"{url}/?v2=1")
+                assert "version mismatch" in v2.get_by_role("alert").inner_text()
+                assert v2.locator("select,input,textarea,button").count() == 0
+                assert len(bridge.actions) == 2
+                v2.screenshot(path=artifact_dir / "react-v2-mismatch.png")
+                browser.close()
+
+        evidence = {
+            "renderer": "@hypster/react",
+            "versions": {
+                "python": sys.version.split()[0],
+                "node": subprocess.check_output(["node", "--version"], text=True).strip(),
+                "npm": subprocess.check_output(["npm", "--version"], text=True).strip(),
+                "playwright": version("playwright"),
+                "chromium": chromium_version,
+            },
+            "execution_id": bridge.execution_id,
+            "sequence": bridge.sequence,
+            "actions": bridge.actions,
+            "python_oracle": bridge.session.params,
+            "process_cleanup": "http server stopped",
+        }
+        (artifact_dir / "evidence.json").write_text(json.dumps(evidence, indent=2, sort_keys=True))


### PR DESCRIPTION
## Summary

- document `@hypster/react` as an experimental snapshot-in/action-out renderer
- add a physical Chromium witness that sends real DOM actions through the production React bundle into `InteractiveSession`
- require replacement DOM nodes, the exact Python oracle, Protocol V2 fail-closed behavior, and process cleanup
- run the physical witness in React CI and retain evidence artifacts

## Before / after

Before:

```text
fixture and jsdom tests -> renderer behavior inferred
Panda -> browser-owned schema/value reconciliation
```

After:

```text
real Chromium DOM event
  -> @hypster/react Protocol V1 action
  -> Python InteractiveSession.dispatch
  -> complete replacement snapshot + replacement DOM
  -> selected_params == {mode: remote, remote.temperature: 1.25}
```

## Proof

- physical Python-to-React witness: 1 passed
- old Temperature DOM node detached; distinct replacement node rendered `1.25`
- Protocol V2 rendered a visible mismatch and emitted no action
- Hypster full suite: 190 passed, 1 skipped
- React test/typecheck/build: passed
- Panda consumer: 501 Python tests passed; 16 affected frontend tests, build, and lint passed

## Scope

The package remains experimental and private to the repository. This does not publish npm artifacts or promise a stable 1.x protocol.

Closes #101