### PR TITLE
docs: publish 0.9 migration and harden release recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
         description: "Version to release — must equal the committed version (e.g., 0.8.0)"
         required: true
         type: string
+      expected_sha:
+        description: "Exact 40-character master commit to release — must match the dry run"
+        required: true
+        type: string
       publish_to_pypi:
         description: "Publish to PyPI (false = dry run: build, test, and retain artifacts only)"
         required: true
@@ -46,6 +50,20 @@ jobs:
 
       - uses: actions/checkout@v6.0.2
 
+      - name: Assert exact source commit
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          if ! [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::expected_sha must be a lowercase 40-character commit SHA (got $EXPECTED_SHA)."
+            exit 1
+          fi
+          if [ "$GITHUB_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::Source drift: expected $EXPECTED_SHA but this run resolved master to $GITHUB_SHA."
+            echo "Repeat the dry run for the new commit before publishing."
+            exit 1
+          fi
+
       - name: Validate version format
         env:
           VERSION: ${{ inputs.version }}
@@ -69,14 +87,19 @@ jobs:
             exit 1
           fi
 
-      - name: Assert tag does not already exist (tags are never rewritten)
+      - name: Assert tag is absent or recoverable (tags are never rewritten)
         env:
           VERSION: ${{ inputs.version }}
         run: |
           git fetch --tags --quiet
           if git tag -l | grep -qx "v$VERSION"; then
-            echo "::error::Tag v$VERSION already exists. Released bytes and tags are immutable — bump to a new patch version instead."
-            exit 1
+            TAG_SHA=$(git rev-list -n 1 "v$VERSION")
+            if [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
+              echo "::error::Tag v$VERSION points to $TAG_SHA, not this release commit $GITHUB_SHA."
+              echo "Released tags are immutable — bump to a new patch version instead."
+              exit 1
+            fi
+            echo "Tag v$VERSION already points to this commit; allowing idempotent GitHub-release recovery."
           fi
 
       - name: Assert changelog section exists
@@ -266,19 +289,72 @@ jobs:
             echo "SHA-256 checksums of the published files are attached as SHA256SUMS."
           } >> release_notes.md
 
-      - name: Create tag and GitHub release with artifacts
+      - name: Create or recover tag and GitHub release with immutable artifacts
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
         run: |
+          TAG="v$VERSION"
           DRAFT_FLAG=""
           if [ "${{ inputs.create_draft }}" = "true" ]; then DRAFT_FLAG="--draft"; fi
-          gh release create "v$VERSION" \
-            --target "$GITHUB_SHA" \
-            --title "hypster v$VERSION" \
-            --notes-file release_notes.md \
-            $DRAFT_FLAG \
-            dist/*
+
+          git fetch --tags --quiet
+          if git tag -l | grep -qx "$TAG"; then
+            TAG_SHA=$(git rev-list -n 1 "$TAG")
+            if [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
+              echo "::error::$TAG points to $TAG_SHA, not $GITHUB_SHA; refusing to move it."
+              exit 1
+            fi
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            ACTUAL_DRAFT=$(gh release view "$TAG" --json isDraft --jq .isDraft)
+            if [ "$ACTUAL_DRAFT" != "${{ inputs.create_draft }}" ]; then
+              echo "::error::Existing $TAG draft state is $ACTUAL_DRAFT, expected ${{ inputs.create_draft }}."
+              exit 1
+            fi
+
+            EXPECTED_ASSETS=$(for path in dist/*; do basename "$path"; done | sort)
+            EXISTING_ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name' | sort)
+            while IFS= read -r name; do
+              [ -z "$name" ] && continue
+              if ! echo "$EXPECTED_ASSETS" | grep -Fxq "$name"; then
+                echo "::error::Existing $TAG contains unexpected immutable asset $name."
+                exit 1
+              fi
+            done <<< "$EXISTING_ASSETS"
+
+            for path in dist/*; do
+              name=$(basename "$path")
+              if echo "$EXISTING_ASSETS" | grep -Fxq "$name"; then
+                verify_dir=$(mktemp -d)
+                gh release download "$TAG" --pattern "$name" --dir "$verify_dir"
+                if ! cmp -s "$path" "$verify_dir/$name"; then
+                  echo "::error::Existing $TAG asset $name differs from the verified build; refusing replacement."
+                  exit 1
+                fi
+                rm -rf "$verify_dir"
+                echo "Verified existing immutable asset: $name"
+              else
+                gh release upload "$TAG" "$path"
+                echo "Uploaded missing recovery asset: $name"
+              fi
+            done
+          elif git tag -l | grep -qx "$TAG"; then
+            gh release create "$TAG" \
+              --verify-tag \
+              --title "hypster v$VERSION" \
+              --notes-file release_notes.md \
+              $DRAFT_FLAG \
+              dist/*
+          else
+            gh release create "$TAG" \
+              --target "$GITHUB_SHA" \
+              --title "hypster v$VERSION" \
+              --notes-file release_notes.md \
+              $DRAFT_FLAG \
+              dist/*
+          fi
 
       - name: Summary
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-07-12
+
+### Added
+- `@hypster/react` is now an experimental thin renderer for Python-owned Interactive Snapshots. It accepts a snapshot, emits semantic actions, and leaves validation, reachability, Branch Choice Memory, selected parameters, and apply/reset semantics in Python. The package remains repository-private and is not published to npm.
+- Real installed-wheel host gates now exercise the notebook widget in JupyterLab 4 with Chromium, Notebook 7 with Firefox, and VS Code Desktop with its stable Python and Jupyter extensions. These are currently tested environments for the 0.9 line, not a permanent compatibility guarantee.
+- A physical Python → React → Python browser witness verifies snapshot replacement and fail-closed protocol mismatch behavior.
+
+### Changed
+- **Breaking for custom interactive clients:** snapshots and actions now require `"protocol_version": 1`. Missing or mismatched action versions fail before session state changes; renderers show a visible mismatch and emit no actions for an incompatible snapshot. Protocol V1 detects incompatible peers during 0.x development; it is not a 1.x stability promise.
+- **Breaking for repository consumers of `@hypster/react`:** the browser-side `fetchSchema` configuration model, value reconciliation, rules hooks, and branch memory were removed. Hosts now render `<HypsterRenderer snapshot={...} onAction={...} />`, send each action to Python, and replace the rendered snapshot with Python's response.
+- The release workflow accepts only stable `X.Y.Z` inputs, supports safe recovery after PyPI accepts artifacts, and verifies that PyPI serves the built hashes before creating the immutable tag and GitHub release.
+
+### Fixed
+- `on_unknown="warn"` warnings now point to the user's call site instead of a Hypster internal frame.
+- A missing parameter or nested-config name now raises a friendly `HPCallError` instead of a raw path-joining `TypeError`.
+
+Migration instructions: [0.7 → 0.8](docs/migration/upgrade-0.7-to-0.8.md) and [0.8 → 0.9](docs/migration/upgrade-0.8-to-0.9.md).
+
 ## [0.8.0] - 2026-07-11
 
 ### Fixed

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -55,6 +55,16 @@
 * [Public API](reference/api.md)
 * [Optuna HPO API](reference/optuna-hpo.md)
 * [Error Handling](reference/error-handling.md)
+* [Currently Tested Environments](reference/currently-tested-environments.md)
+
+## Migration
+
+* [Upgrade From 0.7 To 0.8](migration/upgrade-0.7-to-0.8.md)
+* [Upgrade From 0.8 To 0.9](migration/upgrade-0.8-to-0.9.md)
+
+## Contributing
+
+* [Release Hypster](contributing/releasing.md)
 
 ## Integrations
 

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -1,0 +1,105 @@
+# Release Hypster
+
+This guide is for maintainers publishing a stable 0.x release through `.github/workflows/release.yml`. The workflow is source-read-only: version and changelog changes must reach `master` through a release-prep pull request before dispatch.
+
+Published filenames, bytes, and tags are immutable. If a published release is bad, yank it on PyPI and release a new patch; never replace its artifacts or move its tag.
+
+## 1. Land The Release-Prep Pull Request
+
+Update these sources in one reviewed pull request:
+
+- `[project].version` in `pyproject.toml`;
+- `__version__` in `src/hypster/_version.py`;
+- an exact `## [X.Y.Z]` section in `CHANGELOG.md`;
+- `uv.lock` if the version change updates the root package entry.
+
+Before:
+
+```toml
+[project]
+version = "0.8.0"
+```
+
+```python
+__version__ = "0.8.0"
+```
+
+After, for a 0.9.0 release:
+
+```toml
+[project]
+version = "0.9.0"
+```
+
+```python
+__version__ = "0.9.0"
+```
+
+Run the version test and core local checks. The dry run in the next step remains the authoritative artifact gate.
+
+```bash
+uv sync --frozen --extra optuna --dev
+uv run pytest tests/test_version.py
+uv run ruff format --check .
+uv run ruff check .
+uv run mypy src/hypster
+uv run pytest --no-cov -q
+rm -rf dist/ build/
+uv build
+uvx twine check --strict dist/*
+```
+
+Merge the pull request and confirm `master` contains the intended version and changelog section. Do not dispatch a release from a feature branch.
+
+## 2. Run A Dry Run
+
+Dispatch `Release` from `master` with the committed version and `publish_to_pypi=false`. Leave `create_draft=false`; dry runs skip the publication job, so they cannot create a tag or GitHub release regardless of the draft input.
+
+```bash
+gh workflow run release.yml \
+  --ref master \
+  -f version=0.9.0 \
+  -f publish_to_pypi=false \
+  -f create_draft=false
+```
+
+The dry run validates the branch, stable `X.Y.Z` format, both committed version sources, absence of `vX.Y.Z`, and the changelog section. It then runs lint, type checks, tests, build, manifest checks, wheel and sdist smoke tests, a built-wheel Optuna test, strict Twine validation, and checksum generation. The `dist-X.Y.Z` workflow artifact is retained. No bytes are sent to PyPI.
+
+## 3. Publish The Same Commit
+
+After the dry run passes, dispatch the workflow again from the same `master` commit with `publish_to_pypi=true`:
+
+```bash
+gh workflow run release.yml \
+  --ref master \
+  -f version=0.9.0 \
+  -f publish_to_pypi=true \
+  -f create_draft=false
+```
+
+The publication order is fixed:
+
+1. Validate, test, and build.
+2. Publish the wheel and sdist to PyPI through Trusted Publishing with attestations.
+3. Fetch PyPI metadata and verify its SHA-256 hashes match the bytes built by this run.
+4. Create `vX.Y.Z` and the GitHub release, attaching the wheel, sdist, and `SHA256SUMS`.
+
+The tag and GitHub release do not exist until PyPI has accepted and served byte-identical artifacts. Set `create_draft=true` only when you intentionally want the post-PyPI GitHub release hidden for a final editorial check; it does not make PyPI publication a draft.
+
+## 4. Verify The Public Release
+
+Check the workflow, package index, tag target, and attached files:
+
+```bash
+gh run list --workflow release.yml --limit 1
+gh release view v0.9.0
+python -c 'import json, urllib.request; print(json.load(urllib.request.urlopen("https://pypi.org/pypi/hypster/0.9.0/json"))["info"]["version"])'
+```
+
+Confirm the GitHub release contains the wheel, sdist, and `SHA256SUMS`, and that the tag points to the released `master` commit.
+
+## Recover Without Replacing Published Bytes
+
+If PyPI accepts the artifacts but a later job fails, rerun the workflow for the same commit and version. `skip-existing` leaves the PyPI files untouched, and the GitHub release job independently compares their hashes with the run's `SHA256SUMS` before creating the tag.
+
+If the hashes differ, the run fails. Do not overwrite, delete and re-upload, or retag. Investigate, yank the bad release if necessary, increment the patch version in a new release-prep pull request, and publish the fix forward.

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -49,7 +49,12 @@ uv build
 uvx twine check --strict dist/*
 ```
 
-Merge the pull request and confirm `master` contains the intended version and changelog section. Do not dispatch a release from a feature branch.
+Merge the pull request and confirm `master` contains the intended version and changelog section. Record that exact commit; both the dry run and publication must name it. Do not dispatch a release from a feature branch.
+
+```bash
+git fetch origin master
+RELEASE_SHA=$(git rev-parse origin/master)
+```
 
 ## 2. Run A Dry Run
 
@@ -59,11 +64,12 @@ Dispatch `Release` from `master` with the committed version and `publish_to_pypi
 gh workflow run release.yml \
   --ref master \
   -f version=0.9.0 \
+  -f expected_sha="$RELEASE_SHA" \
   -f publish_to_pypi=false \
   -f create_draft=false
 ```
 
-The dry run validates the branch, stable `X.Y.Z` format, both committed version sources, absence of `vX.Y.Z`, and the changelog section. It then runs lint, type checks, tests, build, manifest checks, wheel and sdist smoke tests, a built-wheel Optuna test, strict Twine validation, and checksum generation. The `dist-X.Y.Z` workflow artifact is retained. No bytes are sent to PyPI.
+The dry run validates the branch, exact source commit, stable `X.Y.Z` format, both committed version sources, tag state, and the changelog section. It then runs lint, type checks, tests, build, manifest checks, wheel and sdist smoke tests, a built-wheel Optuna test, strict Twine validation, and checksum generation. The `dist-X.Y.Z` workflow artifact is retained. No bytes are sent to PyPI.
 
 ## 3. Publish The Same Commit
 
@@ -73,9 +79,12 @@ After the dry run passes, dispatch the workflow again from the same `master` com
 gh workflow run release.yml \
   --ref master \
   -f version=0.9.0 \
+  -f expected_sha="$RELEASE_SHA" \
   -f publish_to_pypi=true \
   -f create_draft=false
 ```
+
+`expected_sha` makes a moving `master` safe: if another pull request merges between the two dispatches, the publish run fails before building or uploading anything. Repeat the dry run against the new commit instead of publishing untested source.
 
 The publication order is fixed:
 
@@ -100,6 +109,8 @@ Confirm the GitHub release contains the wheel, sdist, and `SHA256SUMS`, and that
 
 ## Recover Without Replacing Published Bytes
 
-If PyPI accepts the artifacts but a later job fails, rerun the workflow for the same commit and version. `skip-existing` leaves the PyPI files untouched, and the GitHub release job independently compares their hashes with the run's `SHA256SUMS` before creating the tag.
+If PyPI accepts the artifacts but a later job fails, rerun the workflow with the same version and `expected_sha`. `skip-existing` leaves the PyPI files untouched, and the GitHub release job independently compares their hashes with the run's `SHA256SUMS`.
+
+If a failed GitHub-release attempt already created the tag or attached some assets, recovery remains additive and immutable. The workflow accepts the existing tag only when it still points to `expected_sha`, verifies every existing release asset byte-for-byte, and uploads only missing assets. It never moves the tag or replaces an attached file.
 
 If the hashes differ, the run fails. Do not overwrite, delete and re-upload, or retag. Investigate, yank the bad release if necessary, increment the patch version in a new release-prep pull request, and publish the fix forward.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Hypster's core package has no runtime dependencies and supports Python 3.10, 3.11, 3.12, and 3.13.
+Hypster's core package has no runtime dependencies and requires Python 3.10 or newer. The current CI matrix tests Python 3.10, 3.11, 3.12, and 3.13; see [Currently Tested Environments](../reference/currently-tested-environments.md) for the operating-system and notebook-host combinations exercised for the 0.9 line.
 
 ## Install With uv
 
@@ -38,7 +38,7 @@ uv add "hypster[viz]" jupyterlab
 
 ## Install With pip
 
-Check that `python` points at a supported interpreter first:
+Check that `python` points at an interpreter that satisfies the package requirement first:
 
 {% code overflow="wrap" %}
 ```bash
@@ -46,7 +46,7 @@ python --version
 ```
 {% endcode %}
 
-Hypster supports Python 3.10, 3.11, 3.12, and 3.13.
+Hypster requires Python 3.10 or newer. CI currently tests Python 3.10, 3.11, 3.12, and 3.13.
 
 {% code overflow="wrap" %}
 ```bash

--- a/docs/how-to/build-an-interactive-ui.md
+++ b/docs/how-to/build-an-interactive-ui.md
@@ -309,6 +309,8 @@ assert snapshot["status"] == "applied"
 ```
 {% endcode %}
 
-Every action must include `"protocol_version": 1`. Supported actions are `{"protocol_version": 1, "type": "set_value", "path": ..., "value": ...}`, `{"protocol_version": 1, "type": "reset"}`, and `{"protocol_version": 1, "type": "apply"}` (manual mode). A missing or mismatched version raises `ValueError` without changing session state. Setting an unreachable path raises the backend's `Unknown or unreachable parameters` error.
+Every action must include `"protocol_version": 1`. Supported actions are `{"protocol_version": 1, "type": "set_value", "path": ..., "value": ...}`, `{"protocol_version": 1, "type": "reset"}`, and `{"protocol_version": 1, "type": "apply"}` (manual mode). A missing or mismatched version raises `ValueError` without changing session state. The version detects incompatible peers during 0.x development; it is not a stability promise for 1.x. Setting an unreachable path raises the backend's `Unknown or unreachable parameters` error.
+
+Repository consumers that use React can render the same contract with the experimental `@hypster/react` package. It is a thin snapshot/action renderer, remains unpublished to npm, and leaves all configuration semantics in Python. See [Upgrade From 0.8 To 0.9](../migration/upgrade-0.8-to-0.9.md) for the ownership boundary and migration shape.
 
 See also: [Interactive UI From Schema](../examples/interactive-ui.md) for building a custom (non-widget) UI from `explore()` schemas.

--- a/docs/migration/upgrade-0.7-to-0.8.md
+++ b/docs/migration/upgrade-0.7-to-0.8.md
@@ -1,0 +1,84 @@
+# Upgrade From 0.7 To 0.8
+
+Hypster 0.8 removes an accidental integration namespace and renames one schema metadata key. Update those two surfaces before upgrading; ordinary config functions, `explore()`, `instantiate()`, rules, and replayable values keep their 0.7 shapes.
+
+Install the target release and check the version:
+
+```bash
+uv add "hypster==0.8.*"
+uv run python -c "import hypster; print(hypster.__version__)"
+```
+
+## Import HPO APIs From `hypster.hpo`
+
+The removed `hypster.integrations` package used a wildcard export and exposed implementation details as if they were public. Import the HPO API from its owning package.
+
+Before:
+
+```python
+from hypster.integrations import HpoInt, suggest_values
+```
+
+After:
+
+<!-- test: exec -->
+```python
+from hypster.hpo import HpoInt, TrialValueProvider, suggest_values
+
+assert HpoInt(step=2).step == 2
+assert callable(suggest_values)
+assert TrialValueProvider.__name__ == "TrialValueProvider"
+```
+
+You can also import `suggest_values` from `hypster.hpo.optuna`. No compatibility alias remains at `hypster.integrations`.
+
+## Read Schema Definitions From `schema_fields`
+
+Metadata emitted by `hp.schema()` now uses `schema_fields`. The `field_specs` key remains the vocabulary for the conditions accepted by `hp.rules()`; the two concepts are intentionally distinct.
+
+Before:
+
+```python
+fields = parameter["metadata"]["field_specs"]
+```
+
+After:
+
+<!-- test: exec -->
+```python
+from hypster import HP, SchemaField, explore
+
+
+def extraction_config(hp: HP):
+    return hp.schema(
+        default=[SchemaField(key="invoice_number", value_type="text", required=True)],
+        name="fields",
+    )
+
+
+schema = explore(extraction_config, return_schema=True)
+metadata = schema.to_dict()["parameters"][0]["metadata"]
+
+assert metadata["schema_fields"][0]["key"] == "invoice_number"
+assert metadata["schema_fields"][0]["required"] is True
+assert "field_specs" not in metadata
+```
+
+## Check HPO Behavior That Previously Failed
+
+The 0.8 Optuna adapter validates trial suggestions through the same path as explicit values. Integer trials default to a step of `1`; log-scale integer trials enforce Optuna's step rule. Parameter kinds without an Optuna mapping, including `hp.bool`, `hp.text`, and `multi_*`, keep their validated defaults and are omitted from `suggest_values()`'s returned dictionary.
+
+If a search relied on a raw Optuna error or on an unsupported kind appearing in returned suggestions, update the search space explicitly. See [Optuna HPO API](../reference/optuna-hpo.md) for the current mapping and error cases.
+
+## Verify The Upgrade
+
+Run your config tests and search for the two removed 0.7 forms:
+
+```bash
+rg -n "hypster\.integrations|\[\"field_specs\"\]" .
+uv run pytest
+```
+
+An occurrence of `field_specs` can still be correct when it reads `hp.rules()` metadata.
+
+For all user-visible 0.8 changes, see the [changelog](../../CHANGELOG.md).

--- a/docs/migration/upgrade-0.8-to-0.9.md
+++ b/docs/migration/upgrade-0.8-to-0.9.md
@@ -1,0 +1,87 @@
+# Upgrade From 0.8 To 0.9
+
+Hypster 0.9 adds a version check to interactive messages and replaces the repository's React configuration model with an experimental snapshot renderer. Python-only applications that do not dispatch interactive actions can upgrade without changing their config functions.
+
+Install the target release and check the version:
+
+```bash
+uv add "hypster==0.9.*"
+uv run python -c "import hypster; print(hypster.__version__)"
+```
+
+## Add `protocol_version` To Interactive Actions
+
+Custom clients that call `InteractiveResult.dispatch()` must send Protocol V1 on every action. A missing or mismatched version raises `ValueError` before session state changes.
+
+Before:
+
+```python
+snapshot = result.dispatch({"type": "set_value", "path": "count", "value": 4})
+```
+
+After:
+
+<!-- test: exec -->
+```python
+from hypster import HP, interact
+
+
+def config(hp: HP):
+    return {"count": hp.int(1, name="count", min=1, max=5)}
+
+
+result = interact(config)
+snapshot = result.dispatch(
+    {"protocol_version": 1, "type": "set_value", "path": "count", "value": 4}
+)
+
+assert result.value == {"count": 4}
+assert snapshot["protocol_version"] == 1
+assert snapshot["selected_params"] == {"count": 4}
+```
+
+`protocol_version` is mismatch protection: it stops an incompatible renderer and backend from silently corrupting state. Protocol V1 may still change across 0.x releases. It does not freeze this wire shape for a future 1.x release.
+
+## Replace React Configuration Logic With Snapshot Rendering
+
+`@hypster/react` no longer fetches schemas, reconciles values, or keeps branch memory in the browser.
+
+Before:
+
+```tsx
+const config = useConfigSchema({ fetchSchema, kind, values });
+```
+
+After:
+
+```tsx
+import { HypsterRenderer } from "@hypster/react";
+
+<HypsterRenderer
+  snapshot={snapshotFromPython}
+  onAction={async (action) => {
+    const nextSnapshot = await sendActionToPython(action);
+    setSnapshot(nextSnapshot);
+  }}
+/>
+```
+
+The host sends an emitted action to the Python `InteractiveSession`, then replaces the previous snapshot with Python's response. Read `snapshot.selected_params` as the authoritative applied configuration. Python owns validation, reachable branches, draft and applied values, Branch Choice Memory, selected parameters, and apply/reset semantics. React owns presentation state.
+
+The React package is experimental and private to this repository. It is not published to npm, and 0.9 does not promise package or wire compatibility with 1.x. Repository consumers should install it from the workspace and pin the exact commit they test.
+
+## Treat Environment Claims As Current Test Evidence
+
+The 0.9 host matrix records real installed-wheel round trips in JupyterLab, Notebook 7, and VS Code. Those results describe environments tested for this release line; they are not a permanent support or compatibility guarantee.
+
+Check [Currently Tested Environments](../reference/currently-tested-environments.md) for the exact CI pins and proof runs. When you deploy on a different frontend, browser, extension, operating system, or version, run a smoke test that crosses DOM → widget transport → Python → replacement DOM in your environment.
+
+## Verify The Upgrade
+
+Search custom transports for unversioned actions and old React configuration helpers:
+
+```bash
+rg -n 'dispatch\(\{[^}]*"type"|fetchSchema|useConfigSchema|useSchemaField|useRulesField' .
+```
+
+Then run the Python and React suites used by your application. For all user-visible 0.9 changes, see the [changelog](../../CHANGELOG.md).

--- a/docs/reference/currently-tested-environments.md
+++ b/docs/reference/currently-tested-environments.md
@@ -22,7 +22,7 @@ The 0.9 real-host harness builds a wheel, installs it into a clean Python 3.13 k
 | --- | --- | --- |
 | JupyterLab | JupyterLab 4.5.9, anywidget 0.11.0, ipywidgets 8.1.8, jupyterlab-widgets 3.0.16, Playwright 1.61.0 | Playwright Chromium |
 | Notebook 7 | Notebook 7.5.7, JupyterLab 4.5.9, anywidget 0.11.0, ipywidgets 8.1.8, jupyterlab-widgets 3.0.16, Playwright 1.61.0 | Playwright Firefox |
-| VS Code Desktop | Ubuntu 24.04, VS Code 1.128.0, Electron 42.5.0, Chromium 148, Python 3.13.13, Node.js 24.18.0, npm 11.16.0, Python extension 2026.4.0, Jupyter extension 2025.9.1, Notebook Renderers 1.3.0, anywidget 0.11.0 | VS Code's Electron webview |
+| VS Code Desktop | Ubuntu 24.04, VS Code 1.128.0, Electron 42.5.0, Chromium 148.0.7778.271, Python 3.13.13, Node.js 24.18.0, npm 11.16.0, Python extension 2026.4.0, Jupyter extension 2025.9.1, Notebook Renderers 1.3.0, anywidget 0.11.0 | VS Code's Electron webview |
 
 The web-host matrix passed on 12 July 2026 in [Notebook hosts run 29195385284](https://github.com/gilad-rubin/hypster/actions/runs/29195385284). The VS Code matrix passed on the same date in [VS Code host run 29195330706](https://github.com/gilad-rubin/hypster/actions/runs/29195330706). Each run retains setup versions and host evidence as workflow artifacts.
 
@@ -30,7 +30,7 @@ Notebook 7.6.0 with JupyterLab 4.6.1 produced a frontend exception before any Hy
 
 ## Experimental React Renderer Matrix
 
-`@hypster/react` currently runs its type, test, build, and dry-pack checks on Node.js 22 with Python 3.13. Its physical witness uses React DOM 19.2.0 and Playwright Chromium to complete a Python → React → Python round trip. [React package run 29195064948](https://github.com/gilad-rubin/hypster/actions/runs/29195064948) records the 0.9 acceptance proof.
+`@hypster/react` currently runs its type, test, build, and dry-pack checks on Node.js 22 with Python 3.13. Its physical witness uses React and React DOM 19.2.7 with Playwright Chromium to complete a Python → React → Python round trip. [React package run 29195064948](https://github.com/gilad-rubin/hypster/actions/runs/29195064948) records the 0.9 acceptance proof.
 
 The package declares React 18 or newer as a peer dependency, but it remains experimental and unpublished. The acceptance run is current evidence, not a stability promise for npm or 1.x.
 

--- a/docs/reference/currently-tested-environments.md
+++ b/docs/reference/currently-tested-environments.md
@@ -1,0 +1,47 @@
+# Currently Tested Environments
+
+This page records Hypster's current CI evidence. It helps you choose a known test combination; it does not promise permanent compatibility with these environments or exclude other combinations that may work.
+
+## Python Package Matrix
+
+The core suite currently runs on:
+
+| Operating system | Python versions |
+| --- | --- |
+| Ubuntu (`ubuntu-latest`) | 3.10, 3.11, 3.12, 3.13 |
+| macOS (`macos-latest`) | 3.13 |
+| Windows (`windows-latest`) | 3.13 |
+
+The package metadata requires Python 3.10 or newer. The table is the narrower statement: these are the combinations exercised by [the current CI workflow](https://github.com/gilad-rubin/hypster/blob/master/.github/workflows/ci.yml).
+
+## Notebook Widget Matrix
+
+The 0.9 real-host harness builds a wheel, installs it into a clean Python 3.13 kernel, performs real browser actions, and verifies the resulting Python state.
+
+| Host proof | Current pinned environment | Browser |
+| --- | --- | --- |
+| JupyterLab | JupyterLab 4.5.9, anywidget 0.11.0, ipywidgets 8.1.8, jupyterlab-widgets 3.0.16, Playwright 1.61.0 | Playwright Chromium |
+| Notebook 7 | Notebook 7.5.7, JupyterLab 4.5.9, anywidget 0.11.0, ipywidgets 8.1.8, jupyterlab-widgets 3.0.16, Playwright 1.61.0 | Playwright Firefox |
+| VS Code Desktop | Ubuntu 24.04, VS Code 1.128.0, Electron 42.5.0, Chromium 148, Python 3.13.13, Node.js 24.18.0, npm 11.16.0, Python extension 2026.4.0, Jupyter extension 2025.9.1, Notebook Renderers 1.3.0, anywidget 0.11.0 | VS Code's Electron webview |
+
+The web-host matrix passed on 12 July 2026 in [Notebook hosts run 29195385284](https://github.com/gilad-rubin/hypster/actions/runs/29195385284). The VS Code matrix passed on the same date in [VS Code host run 29195330706](https://github.com/gilad-rubin/hypster/actions/runs/29195330706). Each run retains setup versions and host evidence as workflow artifacts.
+
+Notebook 7.6.0 with JupyterLab 4.6.1 produced a frontend exception before any Hypster cell executed. The 0.9 harness therefore pins the newest prior coherent pair it proved green: Notebook 7.5.7 with JupyterLab 4.5.9. This is a recorded test boundary, not a claim that every other patch is incompatible.
+
+## Experimental React Renderer Matrix
+
+`@hypster/react` currently runs its type, test, build, and dry-pack checks on Node.js 22 with Python 3.13. Its physical witness uses React DOM 19.2.0 and Playwright Chromium to complete a Python → React → Python round trip. [React package run 29195064948](https://github.com/gilad-rubin/hypster/actions/runs/29195064948) records the 0.9 acceptance proof.
+
+The package declares React 18 or newer as a peer dependency, but it remains experimental and unpublished. The acceptance run is current evidence, not a stability promise for npm or 1.x.
+
+## Testing Another Environment
+
+For a notebook frontend outside this matrix, install the built wheel with the `viz` extra and verify a branch-sensitive interaction:
+
+1. Render an `interact()` result.
+2. Change a branch control through the real DOM.
+3. Change a dependent control.
+4. Verify `result.params` in a fresh Python cell.
+5. Check the browser console, kernel output, and widget transport for errors.
+
+The repository's [notebook host harness](https://github.com/gilad-rubin/hypster/tree/master/tests/jupyterlab_host) and [VS Code host harness](https://github.com/gilad-rubin/hypster/tree/master/tests/vscode_host) are the executable references.

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -6,6 +6,8 @@ import pytest
 ROOT = Path(__file__).parents[1]
 DOCS = ROOT / "docs"
 SUMMARY = DOCS / "SUMMARY.md"
+RELEASE_GUIDE = DOCS / "contributing" / "releasing.md"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 MIGRATION_PAGES = (
     DOCS / "migration" / "upgrade-0.7-to-0.8.md",
     DOCS / "migration" / "upgrade-0.8-to-0.9.md",
@@ -47,3 +49,14 @@ def test_migration_pages_have_runnable_current_api_examples(page: Path) -> None:
     for index, snippet in enumerate(snippets, start=1):
         namespace = {"__name__": f"docs_example_{page.stem}_{index}"}
         exec(compile(snippet, f"{page}::snippet-{index}", "exec"), namespace)
+
+
+def test_release_guide_tracks_exact_source_and_immutable_recovery_contract() -> None:
+    guide = RELEASE_GUIDE.read_text()
+    workflow = RELEASE_WORKFLOW.read_text()
+
+    assert guide.count('-f expected_sha="$RELEASE_SHA"') == 2
+    assert "expected_sha:" in workflow
+    assert "Source drift:" in workflow
+    assert 'gh release upload "$TAG" "$path"' in workflow
+    assert "--clobber" not in workflow

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,49 @@
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+DOCS = ROOT / "docs"
+SUMMARY = DOCS / "SUMMARY.md"
+MIGRATION_PAGES = (
+    DOCS / "migration" / "upgrade-0.7-to-0.8.md",
+    DOCS / "migration" / "upgrade-0.8-to-0.9.md",
+)
+NEW_VISIBLE_PAGES = (
+    *MIGRATION_PAGES,
+    DOCS / "reference" / "currently-tested-environments.md",
+    DOCS / "contributing" / "releasing.md",
+)
+MARKED_PYTHON = re.compile(r"<!-- test: exec -->\s*```python\n(.*?)\n```", re.DOTALL)
+MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+
+
+def test_issue_89_pages_are_in_gitbook_summary() -> None:
+    summary = SUMMARY.read_text()
+
+    for page in NEW_VISIBLE_PAGES:
+        relative = page.relative_to(DOCS).as_posix()
+        assert f"]({relative})" in summary, f"{relative} is missing from docs/SUMMARY.md"
+
+
+@pytest.mark.parametrize("page", NEW_VISIBLE_PAGES, ids=lambda path: path.name)
+def test_issue_89_pages_have_no_broken_local_links(page: Path) -> None:
+    for target in MARKDOWN_LINK.findall(page.read_text()):
+        if "://" in target or target.startswith(("#", "mailto:")):
+            continue
+        path_text = target.split("#", 1)[0]
+        if not path_text:
+            continue
+        resolved = (page.parent / path_text).resolve()
+        assert resolved.exists(), f"{page.relative_to(ROOT)} links to missing {target}"
+
+
+@pytest.mark.parametrize("page", MIGRATION_PAGES, ids=lambda path: path.name)
+def test_migration_pages_have_runnable_current_api_examples(page: Path) -> None:
+    snippets = MARKED_PYTHON.findall(page.read_text())
+    assert snippets, f"{page.relative_to(ROOT)} has no marked runnable Python examples"
+
+    for index, snippet in enumerate(snippets, start=1):
+        namespace = {"__name__": f"docs_example_{page.stem}_{index}"}
+        exec(compile(snippet, f"{page}::snippet-{index}", "exec"), namespace)


### PR DESCRIPTION
Closes #89.

## Outcome

Publishes the migration, experimental-status, environment-evidence, and maintainer release documentation required to finish the 0.9 milestone.

## Before / after

Before — custom clients sent unversioned actions and the docs did not explain the compatibility boundary:

```python
snapshot = result.dispatch({"type": "set_value", "path": "count", "value": 4})
```

After — the runnable migration guide shows Protocol V1 mismatch protection without promising a 1.x freeze:

```python
snapshot = result.dispatch(
    {"protocol_version": 1, "type": "set_value", "path": "count", "value": 4}
)
```

Before — React/environment/release behavior lived across issues and workflows.

After — GitBook now contains:

- 0.7 → 0.8 and 0.8 → 0.9 migration pages with executable current-API examples;
- `@hypster/react` as an experimental, unpublished, thin snapshot/action renderer;
- exact dated host evidence, explicitly framed as currently tested rather than permanent support;
- the source-read-only dry-run → PyPI/hash verification → immutable GitHub release workflow and recovery rules.

## Proof

- `uv run pytest --no-cov -q` → 203 passed
- `uv run pytest tests/test_docs.py --no-cov -q` → 7 passed
- `uv run ruff format --check .` → 48 files formatted
- `uv run ruff check .` → green
- `uv run mypy src/hypster` → green
- exact host versions cross-checked against workflow pins, lockfiles, and the accepted real-host runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added experimental React rendering support and expanded environment testing coverage.
  - Introduced a protocol version requirement for interactive actions.
  - Added migration guidance for upgrades from versions 0.7 and 0.8.

- **Documentation**
  - Added tested-environment references, release instructions, migration guides, and updated installation guidance.

- **Bug Fixes**
  - Improved warning locations and parameter-missing error reporting.

- **Release Improvements**
  - Strengthened release validation and recovery to prevent tag, source, and artifact mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->