### PR TITLE
chore: prepare hypster 0.9.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hypster"
-version = "0.8.0"
+version = "0.9.0"
 description = "A flexible configuration system for Python projects"
 authors = [
     {name = "Gilad Rubin", email = "me@giladrubin.com"}

--- a/src/hypster/_version.py
+++ b/src/hypster/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/uv.lock
+++ b/uv.lock
@@ -347,7 +347,7 @@ wheels = [
 
 [[package]]
 name = "hypster"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Outcome

Prepares the reviewed source tree for the public Hypster 0.9.0 release. The release workflow remains source-read-only; this PR is the only version mutation.

## Before / after

Before:

```toml
[project]
version = "0.8.0"
```

```python
__version__ = "0.8.0"
```

After:

```toml
[project]
version = "0.9.0"
```

```python
__version__ = "0.9.0"
```

The root package entry in `uv.lock` changes from `0.8.0` to `0.9.0` in the same commit. The reviewed `## [0.9.0] - 2026-07-12` changelog section is already on `master` from #111.

## Local release-equivalent proof

- exact version parity: `pyproject.toml`, `_version.py`, `uv.lock`, and changelog all identify 0.9.0
- `uv lock --check` and Python 3.12 frozen sync: green
- Ruff format/lint and MyPy: green
- package tests: 204 passed
- strict Twine checks: wheel and sdist passed
- forbidden artifact manifest patterns: absent
- isolated wheel and sdist version imports: green
- built-wheel real Optuna suite: 6 passed
- clean rebuilt artifacts:
  - wheel SHA-256 `2e548f28206c6554546b0b9498892bc215f2e42d7bc9e7de902ca7260c648923`
  - sdist SHA-256 `ae141e44d7cb0749cfae74fd6ce9ccecbc0c6b79041ef0987fc62754d1f206b6`

After merge I will run the exact-SHA dry run first, verify that `master` has not moved, then dispatch publication from that same commit.
