### PR TITLE
fix(interactive): upstream edits keep shape-compatible downstream values (0.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-07-16
+
+### Fixed
+- An interactive `set_value` no longer resets every parameter after the edited path to its schema default. Re-derivation now falls back to the parameter's current value when it is still shape-compatible (options, bounds, kind) before collapsing to the default; exact-context Branch Choice Memory still takes precedence, so per-branch recall is unchanged. Previously, any upstream edit silently discarded seeded or user-entered downstream values — a session seeded with `values=` (for example, profile-provided prompts) lost them to `""`/`[]` on the first unrelated edit.
+
 ## [0.9.0] - 2026-07-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.1] - 2026-07-16
 
 ### Fixed
-- An interactive `set_value` no longer resets every parameter after the edited path to its schema default. Re-derivation now falls back to the parameter's current value when it is still shape-compatible (options, bounds, kind) before collapsing to the default; exact-context Branch Choice Memory still takes precedence, so per-branch recall is unchanged. Previously, any upstream edit silently discarded seeded or user-entered downstream values — a session seeded with `values=` (for example, profile-provided prompts) lost them to `""`/`[]` on the first unrelated edit.
+- An interactive `set_value` no longer resets every parameter after the edited path to its schema default. Re-derivation now falls back to the parameter's current value when it is still shape-compatible (options, bounds, kind, and nullability) before collapsing to the default; exact-context Branch Choice Memory still takes precedence, so revisiting a branch restores its remembered value. Previously, any upstream edit silently discarded seeded or user-entered downstream values — a session seeded with `values=` (for example, profile-provided prompts or an explicit nullable value) lost them to their defaults on the first unrelated edit.
 
 ## [0.9.0] - 2026-07-12
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,7 +177,7 @@ _Avoid_: exploration error, validation error
 - Reachable `values=` entries seed both the initial widget state and the remembered branch-choice state for that interactive session.
 - **Branch Choice Memory** is created only from reachable `values=` entries and subsequent user **Interactive Actions** during the live session.
 - **Branch Choice Memory** is in-memory state scoped to one **Interactive Result**; it is not persisted or shared across fresh interactive sessions.
-- When a parameter becomes reachable again, the interactive controller chooses the most recent compatible value from **Branch Choice Memory**, then the parameter default, then the first available option when the parameter kind supports option fallback.
+- When an **Interactive Action** re-derives a downstream parameter, the interactive controller chooses the most recent compatible value from exact-context **Branch Choice Memory**, then its compatible current **Draft Value**, then the parameter default, then the first available option when the parameter kind supports option fallback.
 - Incompatible remembered values are skipped rather than treated as errors.
 - **Branch Choice Memory** applies to nested parameters by **Parameter Path**.
 - Reset restores the **Interactive Baseline**, clears later branch memory and pending edits, and applies that restored state immediately.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hypster"
-version = "0.9.0"
+version = "0.9.1"
 description = "A flexible configuration system for Python projects"
 authors = [
     {name = "Gilad Rubin", email = "me@giladrubin.com"}

--- a/src/hypster/_version.py
+++ b/src/hypster/_version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/src/hypster/interactive/branch_memory.py
+++ b/src/hypster/interactive/branch_memory.py
@@ -25,7 +25,7 @@ class BranchChoiceMemory:
 
     def latest_compatible(self, parameter: ParameterInfo, context: Mapping[str, Any]) -> tuple[bool, Any]:
         for value in reversed(self._history.get(_memory_key(parameter, context), [])):
-            if _is_compatible(parameter, value):
+            if is_compatible(parameter, value):
                 return True, value
         return False, None
 
@@ -55,7 +55,7 @@ def _stable_json(value: Any) -> str:
     return json.dumps(value, sort_keys=True, default=repr, separators=(",", ":"))
 
 
-def _is_compatible(parameter: ParameterInfo, value: Any) -> bool:
+def is_compatible(parameter: ParameterInfo, value: Any) -> bool:
     if parameter.options is not None:
         return _matches_options(parameter.kind, value, parameter.options)
     if parameter.kind == "bool":

--- a/src/hypster/interactive/branch_memory.py
+++ b/src/hypster/interactive/branch_memory.py
@@ -25,7 +25,7 @@ class BranchChoiceMemory:
 
     def latest_compatible(self, parameter: ParameterInfo, context: Mapping[str, Any]) -> tuple[bool, Any]:
         for value in reversed(self._history.get(_memory_key(parameter, context), [])):
-            if is_compatible(parameter, value):
+            if is_compatible_value(parameter, value):
                 return True, value
         return False, None
 
@@ -55,7 +55,7 @@ def _stable_json(value: Any) -> str:
     return json.dumps(value, sort_keys=True, default=repr, separators=(",", ":"))
 
 
-def is_compatible(parameter: ParameterInfo, value: Any) -> bool:
+def is_compatible_value(parameter: ParameterInfo, value: Any) -> bool:
     if parameter.options is not None:
         return _matches_options(parameter.kind, value, parameter.options)
     if parameter.kind == "bool":

--- a/src/hypster/interactive/session.py
+++ b/src/hypster/interactive/session.py
@@ -12,7 +12,7 @@ from hypster.core import ConfigFunc, UnknownPolicy, instantiate_with_params
 from hypster.explore import ConfigSchema, ParameterInfo, explore
 from hypster.utils import normalize_values
 
-from .branch_memory import BranchChoiceMemory
+from .branch_memory import BranchChoiceMemory, is_compatible
 
 T = TypeVar("T")
 
@@ -182,7 +182,7 @@ class InteractiveSession(Generic[T]):
         self._memory.remember(current_parameter, value, _context_for(current_parameters, prefix_values, path))
 
         try:
-            schema, selected_values = self._build_values(prefix_values)
+            schema, selected_values = self._build_values(prefix_values, carry=dict(self._draft_values))
         except Exception as exc:
             self._draft_values = {**self._draft_values, **prefix_values}
             self._draft_error = InteractiveError(kind="exploration", message=str(exc))
@@ -238,7 +238,9 @@ class InteractiveSession(Generic[T]):
         except Exception as exc:
             self._applied_error = InteractiveError(kind="instantiation", message=str(exc))
 
-    def _build_values(self, seed_values: Dict[str, Any]) -> tuple[ConfigSchema, Dict[str, Any]]:
+    def _build_values(
+        self, seed_values: Dict[str, Any], carry: Optional[Mapping[str, Any]] = None
+    ) -> tuple[ConfigSchema, Dict[str, Any]]:
         values = dict(seed_values)
         while True:
             schema = self._explore(values)
@@ -248,7 +250,16 @@ class InteractiveSession(Generic[T]):
                 return schema, values
 
             found, value = self._memory.latest_compatible(missing, _context_for(parameters, values, missing.path))
-            values[missing.path] = value if found else missing.selected_value
+            if found:
+                values[missing.path] = value
+            elif carry is not None and missing.path in carry and is_compatible(missing, carry[missing.path]):
+                # An upstream edit re-derives everything after the changed
+                # path; a still-compatible current value survives it instead
+                # of collapsing to the schema default. Exact-context branch
+                # memory above stays the stronger signal.
+                values[missing.path] = carry[missing.path]
+            else:
+                values[missing.path] = missing.selected_value
 
     def _explore(self, values: Dict[str, Any]) -> ConfigSchema:
         schema = explore(

--- a/src/hypster/interactive/session.py
+++ b/src/hypster/interactive/session.py
@@ -12,7 +12,7 @@ from hypster.core import ConfigFunc, UnknownPolicy, instantiate_with_params
 from hypster.explore import ConfigSchema, ParameterInfo, explore
 from hypster.utils import normalize_values
 
-from .branch_memory import BranchChoiceMemory, is_compatible
+from .branch_memory import BranchChoiceMemory, is_compatible_value
 
 T = TypeVar("T")
 
@@ -182,7 +182,10 @@ class InteractiveSession(Generic[T]):
         self._memory.remember(current_parameter, value, _context_for(current_parameters, prefix_values, path))
 
         try:
-            schema, selected_values = self._build_values(prefix_values, carry=dict(self._draft_values))
+            schema, selected_values = self._build_values(
+                prefix_values,
+                current_draft_values=dict(self._draft_values),
+            )
         except Exception as exc:
             self._draft_values = {**self._draft_values, **prefix_values}
             self._draft_error = InteractiveError(kind="exploration", message=str(exc))
@@ -239,7 +242,9 @@ class InteractiveSession(Generic[T]):
             self._applied_error = InteractiveError(kind="instantiation", message=str(exc))
 
     def _build_values(
-        self, seed_values: Dict[str, Any], carry: Optional[Mapping[str, Any]] = None
+        self,
+        seed_values: Dict[str, Any],
+        current_draft_values: Optional[Mapping[str, Any]] = None,
     ) -> tuple[ConfigSchema, Dict[str, Any]]:
         values = dict(seed_values)
         while True:
@@ -252,14 +257,40 @@ class InteractiveSession(Generic[T]):
             found, value = self._memory.latest_compatible(missing, _context_for(parameters, values, missing.path))
             if found:
                 values[missing.path] = value
-            elif carry is not None and missing.path in carry and is_compatible(missing, carry[missing.path]):
+            elif (
+                current_draft_values is not None
+                and missing.path in current_draft_values
+                and self._is_compatible_current_value(
+                    missing,
+                    current_draft_values[missing.path],
+                    values,
+                )
+            ):
                 # An upstream edit re-derives everything after the changed
                 # path; a still-compatible current value survives it instead
                 # of collapsing to the schema default. Exact-context branch
                 # memory above stays the stronger signal.
-                values[missing.path] = carry[missing.path]
+                values[missing.path] = current_draft_values[missing.path]
             else:
                 values[missing.path] = missing.selected_value
+
+    def _is_compatible_current_value(
+        self,
+        parameter: ParameterInfo,
+        value: Any,
+        preceding_values: Mapping[str, Any],
+    ) -> bool:
+        if value is not None:
+            return is_compatible_value(parameter, value)
+
+        # Explore Schema does not expose allow_none. Ask the backend whether
+        # this previously valid explicit None remains valid after the upstream
+        # edit instead of duplicating nullability rules in the controller.
+        try:
+            self._explore({**preceding_values, parameter.path: value})
+        except Exception:
+            return False
+        return True
 
     def _explore(self, values: Dict[str, Any]) -> ConfigSchema:
         schema = explore(

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -172,7 +172,9 @@ def test_interact_separates_same_path_values_by_branch_context() -> None:
     result.dispatch({"protocol_version": 1, "type": "set_value", "path": "n", "value": 7})
     result.dispatch({"protocol_version": 1, "type": "set_value", "path": "mode", "value": "b"})
 
-    assert result.params == {"mode": "b", "n": 0}
+    # No memory under the b-context yet, but the current value is still
+    # shape-compatible, so it carries across the upstream edit.
+    assert result.params == {"mode": "b", "n": 7}
 
     result.dispatch({"protocol_version": 1, "type": "set_value", "path": "n", "value": 3})
     result.dispatch({"protocol_version": 1, "type": "set_value", "path": "mode", "value": "a"})
@@ -324,6 +326,35 @@ def test_interact_reset_reports_errors_without_stale_value() -> None:
     assert snapshot["selected_params"] is None
     with pytest.raises(RuntimeError, match="reset failed"):
         result.value
+
+
+def test_interact_upstream_edit_preserves_independent_downstream_values() -> None:
+    """Editing one parameter must not reset unrelated later parameters.
+
+    Regression: a session seeded with non-default values (values=...) lost
+    every parameter after the edited path — text prompts collapsed to "" and
+    rules to [] — because re-derivation only consulted exact-context branch
+    memory before falling back to schema defaults."""
+
+    def config(hp: HP) -> Dict[str, Any]:
+        top_k = hp.int(30, name="top_k", min=1, max=100)
+        system_prompt = hp.text("", name="system_prompt")
+        use_citations = hp.bool(False, name="use_citations")
+        return {"top_k": top_k, "system_prompt": system_prompt, "use_citations": use_citations}
+
+    result = interact(
+        config,
+        values={"system_prompt": "seeded prompt", "use_citations": True},
+    )
+
+    assert result.params == {"top_k": 30, "system_prompt": "seeded prompt", "use_citations": True}
+
+    snapshot = result.dispatch({"protocol_version": 1, "type": "set_value", "path": "top_k", "value": 25})
+
+    assert snapshot["status"] == "applied"
+    assert result.params == {"top_k": 25, "system_prompt": "seeded prompt", "use_citations": True}
+    assert snapshot["draft_values"]["system_prompt"] == "seeded prompt"
+    assert snapshot["selected_params"]["use_citations"] is True
 
 
 def test_interact_branch_memory_rejects_incompatible_multi_value_history() -> None:

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -158,7 +158,7 @@ def test_interact_remembers_latest_compatible_branch_choice() -> None:
     assert result.params == {"provider": "gemini", "model": "pro"}
 
 
-def test_interact_separates_same_path_values_by_branch_context() -> None:
+def test_interact_carries_into_unvisited_branch_then_restores_context_memory() -> None:
     def config(hp: HP) -> Dict[str, Any]:
         mode = hp.select(["a", "b"], name="mode", default="a")
         if mode == "a":
@@ -355,6 +355,20 @@ def test_interact_upstream_edit_preserves_independent_downstream_values() -> Non
     assert result.params == {"top_k": 25, "system_prompt": "seeded prompt", "use_citations": True}
     assert snapshot["draft_values"]["system_prompt"] == "seeded prompt"
     assert snapshot["selected_params"]["use_citations"] is True
+
+
+def test_interact_upstream_edit_preserves_nullable_downstream_value() -> None:
+    def config(hp: HP) -> Dict[str, Any]:
+        top_k = hp.int(30, name="top_k", min=1, max=100)
+        optional_note = hp.text("fallback", name="optional_note", allow_none=True)
+        return {"top_k": top_k, "optional_note": optional_note}
+
+    result = interact(config, values={"optional_note": None})
+
+    snapshot = result.dispatch({"protocol_version": 1, "type": "set_value", "path": "top_k", "value": 25})
+
+    assert snapshot["status"] == "applied"
+    assert snapshot["selected_params"] == {"top_k": 25, "optional_note": None}
 
 
 def test_interact_branch_memory_rejects_incompatible_multi_value_history() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -347,7 +347,7 @@ wheels = [
 
 [[package]]
 name = "hypster"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## The bug

`InteractiveSession._set_value` re-derives every parameter after the edited path. The fallback chain was **exact-context Branch Choice Memory → schema default** — so any unrelated upstream edit silently reset all later parameters to their code defaults. A session seeded with `values=` (e.g. profile-provided prompts) lost them to `""`/`[]` on the first edit.

Found in production use (panda): a generation run launched from a config session answered *"Hi! It looks like your last message was empty"* — one `top_k` edit had wiped the seeded system/user prompts and prompt-addition rules in both `draft_values` and `selected_params`, invisibly (the affected groups were collapsed in the UI).

## The fix

`_build_values` gains a `carry` map (the pre-edit draft values). Fill order for a missing parameter is now:

1. **exact-context branch memory** (unchanged — per-branch recall keeps precedence)
2. **carry value, if still shape-compatible** with the re-explored parameter (options / bounds / kind, via `is_compatible`) ← new
3. schema default

Branch-recall semantics are intact: revisiting a context still restores that branch's remembered value (memory outranks carry), and incompatible values are still rejected (e.g. an out-of-bounds int collapses to the default, a select value absent from the new branch's options falls back).

## Tests

- New: `test_interact_upstream_edit_preserves_independent_downstream_values` — seeded session + unrelated edit keeps seeded text/bool values (red on the old code).
- Updated: one assertion in `test_interact_separates_same_path_values_by_branch_context` — the first flip to an unvisited branch now carries the compatible current value instead of resetting to the default; all subsequent per-branch recall assertions unchanged.
- Full suite: 205 passed.

Also bumps 0.9.0 → 0.9.1 (`pyproject.toml` + `_version.py` in the same change, per AGENTS.md) with a CHANGELOG entry. `branch_memory._is_compatible` is published as `is_compatible` for the session's carry check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved compatible downstream parameter values when editing upstream settings.
  - Prevented seeded or user-entered values from resetting unnecessarily to schema defaults.
  - Improved value retention when switching branch contexts, while honoring exact-context choices.
  - Incompatible values still fall back safely to the appropriate defaults.

- **Release**
  - Updated the package version to 0.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->